### PR TITLE
RateController

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ set(FILES
         bridge/engine/VideoNackReceiveJob.cpp
         bridge/engine/VideoNackReceiveJob.h
         bridge/engine/Vp8Rewriter.h
+        bridge/engine/SetMaxMediaBitrateJob.h
+        bridge/engine/SetMaxMediaBitrateJob.cpp
         bwe/BandwidthEstimator.cpp
         bwe/BandwidthEstimator.h
         bwe/BandwidthUtils.cpp

--- a/bridge/ApiRequestHandler.cpp
+++ b/bridge/ApiRequestHandler.cpp
@@ -381,6 +381,11 @@ ApiRequestHandler::ApiRequestHandler(bridge::MixerManager& mixerManager, transpo
       _legacyApiRequestHandler(std::make_unique<LegacyApiRequestHandler>(mixerManager, sslDtls))
 #endif
 {
+#if ENABLE_LEGACY_API
+    logger::logAlways("Legacy colibri API enabled", "ApiRequestHandler");
+#else
+    logger::logAlways("Legacy API disabled", "ApiRequestHandler");
+#endif
 }
 
 httpd::Response ApiRequestHandler::onRequest(const httpd::Request& request)

--- a/bridge/ApiRequestHandler.cpp
+++ b/bridge/ApiRequestHandler.cpp
@@ -381,11 +381,6 @@ ApiRequestHandler::ApiRequestHandler(bridge::MixerManager& mixerManager, transpo
       _legacyApiRequestHandler(std::make_unique<LegacyApiRequestHandler>(mixerManager, sslDtls))
 #endif
 {
-#if ENABLE_LEGACY_API
-    logger::logAlways("Legacy colibri API enabled", "ApiRequestHandler");
-#else
-    logger::logAlways("Legacy API disabled", "ApiRequestHandler");
-#endif
 }
 
 httpd::Response ApiRequestHandler::onRequest(const httpd::Request& request)

--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -129,6 +129,7 @@ void Bridge::initialize()
     _rateControllerConfig.ipOverhead = _config.ipOverhead;
     _rateControllerConfig.bandwidthCeilingKbps = _config.rctl.ceiling;
     _rateControllerConfig.bandwidthFloorKbps = _config.rctl.floor;
+    _rateControllerConfig.initialEstimateKbps = _config.rctl.initialEstimate;
 
     _srtpClientFactory = std::make_unique<transport::SrtpClientFactory>(*_sslDtls, *_mainPacketAllocator);
     _bweConfig.sanitize();

--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -126,6 +126,9 @@ void Bridge::initialize()
     }
 
     _rateControllerConfig.enabled = _config.rctl.enable;
+    _rateControllerConfig.ipOverhead = _config.ipOverhead;
+    _rateControllerConfig.bandwidthCeilingKbps = _config.rctl.ceiling;
+    _rateControllerConfig.bandwidthFloorKbps = _config.rctl.floor;
 
     _srtpClientFactory = std::make_unique<transport::SrtpClientFactory>(*_sslDtls, *_mainPacketAllocator);
     _bweConfig.sanitize();

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -3198,13 +3198,13 @@ public:
     SetMaxMediaBitrateJob(transport::RtcTransport& transport,
         uint32_t reporterSsrc,
         uint32_t ssrc,
-        uint32_t bitrate,
+        uint32_t bitrateKbps,
         memory::PacketPoolAllocator& allocator)
         : CountedJob(transport.getJobCounter()),
           _transport(transport),
           _ssrc(ssrc),
           _reporterSsrc(reporterSsrc),
-          _bitrate(bitrate),
+          _bitrate(bitrateKbps),
           _allocator(allocator)
     {
     }
@@ -3218,7 +3218,7 @@ public:
         }
 
         auto& tmmbr = rtp::RtcpTemporaryMaxMediaBitrate::create(packet->get(), _reporterSsrc);
-        tmmbr.addEntry(_ssrc, _bitrate, 34);
+        tmmbr.addEntry(_ssrc, _bitrate * 1000, 34);
         packet->setLength(tmmbr.size());
         _transport.protectAndSend(packet, _allocator);
     }
@@ -3233,7 +3233,7 @@ private:
 
 void EngineMixer::checkVideoBandwidth(const uint64_t timestamp)
 {
-    if (utils::Time::diffGE(_lastVideoBandwidthCheck, timestamp, utils::Time::sec * 5))
+    if (utils::Time::diffGE(_lastVideoBandwidthCheck, timestamp, utils::Time::sec * 3))
     {
         _lastVideoBandwidthCheck = timestamp;
         uint32_t minUplinkEstimate = 10000000;

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -3263,15 +3263,17 @@ void EngineMixer::checkVideoBandwidth(const uint64_t timestamp)
 
         if (presenterSimulcastLevel)
         {
+            const uint32_t slidesLimit = minUplinkEstimate * _config.slides.allocFactor;
+
             logger::debug("limiting bitrate for ssrc %u, at %u",
                 _loggableId.c_str(),
                 presenterSimulcastLevel->_ssrc,
-                static_cast<uint32_t>(minUplinkEstimate * _config.slides.allocFactor));
+                slidesLimit);
 
             presenterStream->_transport.getJobQueue().addJob<SetMaxMediaBitrateJob>(presenterStream->_transport,
                 presenterStream->_localSsrc,
                 presenterSimulcastLevel->_ssrc,
-                static_cast<uint32_t>(minUplinkEstimate * _config.slides.allocFactor),
+                slidesLimit,
                 _sendAllocator);
         }
     }

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -270,6 +270,8 @@ private:
     uint32_t _lastN;
     uint32_t _numMixedAudioStreams;
 
+    uint64_t _lastVideoBandwidthCheck;
+
     void processIncomingRtpPackets(const uint64_t timestamp);
     uint32_t processIncomingVideoRtpPackets(const uint64_t timestamp);
     void processIncomingRtcpPackets(const uint64_t timestamp);
@@ -278,6 +280,7 @@ private:
     void processIncomingTransportFbRtcpPacket(const transport::RtcTransport* transport,
         const rtp::RtcpHeader& rtcpPacket,
         const uint64_t timestamp);
+    void checkVideoBandwidth(const uint64_t timestamp);
 
     void mixSsrcBuffers();
     void processAudioStreams();

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -281,6 +281,7 @@ private:
         const rtp::RtcpHeader& rtcpPacket,
         const uint64_t timestamp);
     void checkVideoBandwidth(const uint64_t timestamp);
+    void runTransportTicks(const uint64_t timestamp);
 
     void mixSsrcBuffers();
     void processAudioStreams();

--- a/bridge/engine/SetMaxMediaBitrateJob.cpp
+++ b/bridge/engine/SetMaxMediaBitrateJob.cpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "SetMaxMediaBitrateJob.h"
+#include "memory/Packet.h"
+#include "rtp/RtcpFeedback.h"
+#include "transport/RtcTransport.h"
+
+namespace bridge
+{
+
+SetMaxMediaBitrateJob::SetMaxMediaBitrateJob(transport::RtcTransport& transport,
+    uint32_t reporterSsrc,
+    uint32_t ssrc,
+    uint32_t bitrateKbps,
+    memory::PacketPoolAllocator& allocator)
+    : CountedJob(transport.getJobCounter()),
+      _transport(transport),
+      _ssrc(ssrc),
+      _reporterSsrc(reporterSsrc),
+      _bitrate(bitrateKbps),
+      _allocator(allocator)
+{
+}
+
+void SetMaxMediaBitrateJob::run() override
+{
+    auto* packet = memory::makePacket(_allocator);
+    if (!packet)
+    {
+        return;
+    }
+
+    auto& tmmbr = rtp::RtcpTemporaryMaxMediaBitrate::create(packet->get(), _reporterSsrc);
+    tmmbr.addEntry(_ssrc, _bitrate * 1000, 34);
+    packet->setLength(tmmbr.size());
+    _transport.protectAndSend(packet, _allocator);
+}
+
+} // namespace bridge

--- a/bridge/engine/SetMaxMediaBitrateJob.cpp
+++ b/bridge/engine/SetMaxMediaBitrateJob.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "SetMaxMediaBitrateJob.h"
 #include "memory/Packet.h"
 #include "rtp/RtcpFeedback.h"
@@ -21,7 +20,7 @@ SetMaxMediaBitrateJob::SetMaxMediaBitrateJob(transport::RtcTransport& transport,
 {
 }
 
-void SetMaxMediaBitrateJob::run() override
+void SetMaxMediaBitrateJob::run()
 {
     auto* packet = memory::makePacket(_allocator);
     if (!packet)

--- a/bridge/engine/SetMaxMediaBitrateJob.h
+++ b/bridge/engine/SetMaxMediaBitrateJob.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "jobmanager/Job.h"
+#include "memory/PacketPoolAllocator.h"
+#include <cstdint>
+
+namespace transport
+{
+class RtcTransport;
+}
+
+namespace bridge
+{
+class SetMaxMediaBitrateJob : public jobmanager::CountedJob
+{
+public:
+    SetMaxMediaBitrateJob(transport::RtcTransport& transport,
+        uint32_t reporterSsrc,
+        uint32_t ssrc,
+        uint32_t bitrateKbps,
+        memory::PacketPoolAllocator& allocator);
+
+    void run() override;
+
+private:
+    transport::RtcTransport& _transport;
+    const uint32_t _ssrc;
+    const uint32_t _reporterSsrc;
+    const uint32_t _bitrate;
+    memory::PacketPoolAllocator& _allocator;
+};
+} // namespace bridge

--- a/bridge/engine/SsrcOutboundContext.h
+++ b/bridge/engine/SsrcOutboundContext.h
@@ -35,6 +35,7 @@ public:
           _timestampOffset(0),
           _lastRewrittenSsrc(ssrc),
           _needsKeyframe(false),
+          _lastKeyFrameSequenceNumber(0),
           _highestSeenExtendedSequenceNumber(0xFFFFFFFF),
           _lastRespondedNackPid(0),
           _lastRespondedNackBlp(0),
@@ -72,6 +73,7 @@ public:
     int64_t _timestampOffset;
     uint32_t _lastRewrittenSsrc;
     bool _needsKeyframe;
+    uint32_t _lastKeyFrameSequenceNumber;
 
     // Used to keep track of offset between inbound and outbound sequence numbers
     uint32_t _highestSeenExtendedSequenceNumber;

--- a/bridge/engine/VideoForwarderReceiveJob.cpp
+++ b/bridge/engine/VideoForwarderReceiveJob.cpp
@@ -196,6 +196,14 @@ void VideoForwarderReceiveJob::run()
         }
     }
 
+    if (rtpHeader->marker && isKeyframe)
+    {
+        logger::debug("end of key frame ssrc %u, seqno %u",
+            "VideoForwarderReceiveJob",
+            _ssrcContext._ssrc,
+            rtpHeader->sequenceNumber.get());
+    }
+
     if (videoDumpFile != nullptr)
     {
         dumpPacket(videoDumpFile, *_packet, std::min(size_t(36), _packet->getLength()));

--- a/bridge/engine/VideoForwarderReceiveJob.cpp
+++ b/bridge/engine/VideoForwarderReceiveJob.cpp
@@ -198,10 +198,14 @@ void VideoForwarderReceiveJob::run()
 
     if (rtpHeader->marker && isKeyframe)
     {
-        logger::debug("end of key frame ssrc %u, seqno %u",
+        logger::debug("end of key frame ssrc %u, seqno %u, pid %u, tid %d, picid %d, tl0picidx %d",
             "VideoForwarderReceiveJob",
             _ssrcContext._ssrc,
-            rtpHeader->sequenceNumber.get());
+            rtpHeader->sequenceNumber.get(),
+            codec::Vp8Header::getPartitionId(payload),
+            codec::Vp8Header::getTid(payload),
+            codec::Vp8Header::getPicId(payload),
+            codec::Vp8Header::getTl0PicIdx(payload));
     }
 
     if (videoDumpFile != nullptr)

--- a/bridge/engine/VideoNackReceiveJob.cpp
+++ b/bridge/engine/VideoNackReceiveJob.cpp
@@ -84,6 +84,15 @@ void VideoNackReceiveJob::run()
 
 void VideoNackReceiveJob::sendIfCached(const uint16_t sequenceNumber)
 {
+    if (static_cast<int16_t>((_ssrcOutboundContext._lastKeyFrameSequenceNumber & 0xFFFFu) - sequenceNumber) > 0)
+    {
+        NACK_LOG("ignoring NACK for pre key frame packet %u, key frame at %u",
+            "VideoNackReceiveJob",
+            sequenceNumber,
+            _ssrcOutboundContext._lastKeyFrameSequenceNumber);
+        return;
+    }
+
     auto scopedRef = memory::RefCountedPacket::ScopedRef(_videoPacketCache.get(sequenceNumber));
     if (!scopedRef._refCountedPacket)
     {

--- a/bridge/engine/VideoNackReceiveJob.cpp
+++ b/bridge/engine/VideoNackReceiveJob.cpp
@@ -118,7 +118,7 @@ void VideoNackReceiveJob::sendIfCached(const uint16_t sequenceNumber)
     memcpy(copyHead, cachedPayload, cachedPacket->getLength() - cachedRtpHeaderLength);
     packet->setLength(cachedPacket->getLength() + sizeof(uint16_t));
 
-    NACK_LOG("Sending cached packet seq %u, feedbackSsrc %u, seq %u",
+    NACK_LOG("Sending cached packet seq %u, feedbackSsrc %x, seq %u",
         "VideoNackReceiveJob",
         sequenceNumber,
         _feedbackSsrc,

--- a/bridge/engine/VideoNackReceiveJob.cpp
+++ b/bridge/engine/VideoNackReceiveJob.cpp
@@ -86,8 +86,9 @@ void VideoNackReceiveJob::sendIfCached(const uint16_t sequenceNumber)
 {
     if (static_cast<int16_t>((_ssrcOutboundContext._lastKeyFrameSequenceNumber & 0xFFFFu) - sequenceNumber) > 0)
     {
-        NACK_LOG("ignoring NACK for pre key frame packet %u, key frame at %u",
+        NACK_LOG("%u ignoring NACK for pre key frame packet %u, key frame at %u",
             "VideoNackReceiveJob",
+            _ssrcOutboundContext._ssrc,
             sequenceNumber,
             _ssrcOutboundContext._lastKeyFrameSequenceNumber);
         return;
@@ -127,7 +128,7 @@ void VideoNackReceiveJob::sendIfCached(const uint16_t sequenceNumber)
     memcpy(copyHead, cachedPayload, cachedPacket->getLength() - cachedRtpHeaderLength);
     packet->setLength(cachedPacket->getLength() + sizeof(uint16_t));
 
-    NACK_LOG("Sending cached packet seq %u, feedbackSsrc %x, seq %u",
+    NACK_LOG("Sending cached packet seq %u, feedbackSsrc %u, seq %u",
         "VideoNackReceiveJob",
         sequenceNumber,
         _feedbackSsrc,

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -51,6 +51,7 @@ RateController::RateController(size_t instanceId, const RateControllerConfig& co
       _minRttNtp(~0u),
       _config(config)
 {
+    _model.bandwidthKbps = config.initialEstimateKbps;
 }
 
 void RateController::onRtpSent(uint64_t timestamp, uint32_t ssrc, uint32_t sequenceNumber, uint16_t size)

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <cmath>
 
-#define RCTL_LOG(fmt, ...) // logger::debug(fmt, ##__VA_ARGS__)
+#define RCTL_LOG(fmt, ...) logger::debug(fmt, ##__VA_ARGS__)
 
 namespace
 {
@@ -25,7 +25,6 @@ uint32_t calculateTargetQueue(double bandwidthKbps, uint32_t minRttNtp, const bw
 } // namespace
 namespace bwe
 {
-// const uint32_t ntp32Second = 0x10000u;
 
 double RateController::BacklogAnalysis::getBitrateKbps() const
 {
@@ -34,7 +33,7 @@ double RateController::BacklogAnalysis::getBitrateKbps() const
         return 0;
     }
 
-    return receivedAfterSR * ntp32Second / (125.0 * delaySinceSR);
+    return static_cast<double>(receivedAfterSR) * ntp32Second / (125.0 * delaySinceSR);
 }
 
 double RateController::BacklogAnalysis::getSendRateKbps() const
@@ -43,7 +42,7 @@ double RateController::BacklogAnalysis::getSendRateKbps() const
     {
         return 0;
     }
-    return receivedAfterSR * utils::Time::ms * 8 / transmitPeriod;
+    return static_cast<double>(receivedAfterSR) * utils::Time::ms * 8 / transmitPeriod;
 }
 
 RateController::RateController(size_t instanceId, const RateControllerConfig& config)

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -11,17 +11,21 @@
 
 #define RCTL_LOG(fmt, ...) // logger::debug(fmt, ##__VA_ARGS__)
 
-namespace bwe
+namespace
 {
 const uint32_t ntp32Second = 0x10000u;
-
-uint32_t calculateTargetQueue(double bandwidthKbps, uint32_t minRttNtp, const RateControllerConfig& config)
+uint32_t calculateTargetQueue(double bandwidthKbps, uint32_t minRttNtp, const bwe::RateControllerConfig& config)
 {
     // 230ms queue at 300kbps then decay to 50ms. Add for min RTT/8 ms to allow for queue on long haul
     const uint32_t targetQueue =
         bandwidthKbps * (50 + 54000 / std::max(200.0, bandwidthKbps) + minRttNtp * 125 / ntp32Second) / 8;
     return math::clamp(targetQueue, 4 * config.mtu, config.maxTargetQueue);
 }
+
+} // namespace
+namespace bwe
+{
+// const uint32_t ntp32Second = 0x10000u;
 
 double RateController::BacklogAnalysis::getBitrateKbps() const
 {

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -117,7 +117,7 @@ public:
 
     uint32_t getPadding(uint64_t timestamp, uint16_t size, uint16_t& paddingSize) const;
     double getTargetRate() const { return (_config.enabled ? _model.bandwidthKbps : 0); }
-    uint32_t getPacingBudget(uint64_t timestamp) const;
+    size_t getPacingBudget(uint64_t timestamp) const;
     void enableRtpProbing() { _canRtxPad = true; }
 
 private:
@@ -144,6 +144,15 @@ private:
             const double ntp32Second = 0x10000u;
             return receivedAfterSR * ntp32Second / (125.0 * delaySinceSR);
         }
+
+        double getSendRateKbps() const
+        {
+            if (transmitPeriod == 0)
+            {
+                return 0;
+            }
+            return receivedAfterSR * utils::Time::ms * 8 / transmitPeriod;
+        }
     };
 
     void markReceivedPacket(uint32_t ssrc, uint32_t sequenceNumber);
@@ -152,7 +161,7 @@ private:
     BacklogAnalysis analyzeBacklog(uint32_t reportNtp, double modelBandwidthKbps) const;
 
     double calculateSendRate(uint64_t timestamp) const;
-    void dumpBacklog(uint32_t seqno, uint32_t ssrc, uint32_t lastSR);
+    void dumpBacklog(uint32_t seqno, uint32_t ssrc);
 
     logger::LoggableId _logId;
     memory::RandomAccessBacklog<PacketMetaData, 512> _backlog;
@@ -163,7 +172,6 @@ private:
         double bandwidthKbps = 200.0;
         uint32_t queue = 0;
         uint32_t targetQueue = 3000;
-        uint32_t networkQueue = 0;
         uint64_t lastTransmission = 0;
 
         void onPacketSent(uint64_t timestamp, uint16_t size)
@@ -181,7 +189,6 @@ private:
         uint64_t start = 0;
         uint64_t interval = utils::Time::sec;
         uint64_t duration = 0;
-        uint32_t initialNetworkQueue = 0;
         uint32_t count = 0;
     } _probe;
 

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -155,6 +155,8 @@ private:
         }
     };
 
+    bool isGood(const BacklogAnalysis& probe) const;
+
     void markReceivedPacket(uint32_t ssrc, uint32_t sequenceNumber);
     uint64_t calculateModelQueueTransmitPeriod();
     RateController::BacklogAnalysis analyzeProbe(const uint32_t probeEndIndex, const double modelBandwidthKbps) const;

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -125,6 +125,7 @@ private:
     {
         uint32_t transmitPeriod = 0;
         uint32_t receivedAfterSR = 0;
+        uint32_t sentAfterSR = 0;
         uint32_t lossCount = 0;
         double lossRatio = 0;
         uint32_t delaySinceSR = 0;
@@ -200,5 +201,10 @@ private:
     uint32_t _minRttNtp;
     const RateControllerConfig& _config;
     uint64_t _lastLossBackoff = 0;
+    struct
+    {
+        uint32_t ntp = 0;
+        uint32_t delaySinceSR = 0;
+    } _lastProbe;
 };
 } // namespace bwe

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -35,10 +35,13 @@ figure out what bandwidth best describes the observation. Typically, a packets t
 - the distance to the receiver
 
 An RR contains information about which packet was last received and the time that has passed since the latest sender
-report (SR). By tracking sent packets, we can use that to calculate the receive rate in that window. We can also
-calculate roughly the number of bytes still in transit. By modelling the network queue according to the bandwidth we
-think it is, we can compare our model to the actual bytes in transit. It is not precise but if the actual queue is much
-lower than expected, the bandwidth is likely higher and the opposite if the actual queue is longer than expected.
+report (SR). By tracking sent packets, we can calculate the receive rate in that window. We can also
+calculate roughly the number of bytes still in transit. By modelling the network queue according to the expected
+bandwidth, we assess if we were utilizing the link fully and the receive rate after the SR can guide us to the link
+bandwidth. The probe receive rate is unreliable in that it can be highe rand lower than the actual through put. Also
+there are multiple streams that send receiver reports at different points in time. The actual number of confirmed
+received packets needs multiple receiver reports to establish. The confidence in the receive rate increases with the
+number of packets confirmed and the time passed since the SR was received.
 
 To get some useful data we need to probe the link by sending excess bandwidth over a short period of time.
 This is done by interleaving the media packets with RTCP padding packets and Video RTX packets with old
@@ -136,24 +139,8 @@ private:
         bool rtpProbe = true;
         const PacketMetaData* senderReportItem = nullptr;
 
-        double getBitrateKbps() const
-        {
-            if (delaySinceSR == 0)
-            {
-                return 0;
-            }
-            const double ntp32Second = 0x10000u;
-            return receivedAfterSR * ntp32Second / (125.0 * delaySinceSR);
-        }
-
-        double getSendRateKbps() const
-        {
-            if (transmitPeriod == 0)
-            {
-                return 0;
-            }
-            return receivedAfterSR * utils::Time::ms * 8 / transmitPeriod;
-        }
+        double getBitrateKbps() const;
+        double getSendRateKbps() const;
     };
 
     bool isGood(const BacklogAnalysis& probe) const;

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -18,10 +18,11 @@ struct RateControllerConfig
     uint32_t ipOverhead = 20 + 14;
     uint32_t mtu = 1480;
     uint32_t maxPaddingSize = 1200;
-    uint32_t bandwidthFloorKbps = 300;
-    uint32_t bandwidthCeilingKbps = 5000;
+    double bandwidthFloorKbps = 300;
+    double bandwidthCeilingKbps = 5000;
     uint64_t minPadPinInterval = 80 * utils::Time::ms;
     uint32_t minPadSize = 50;
+    double rtcpProbeCeiling = 600;
 };
 
 /*
@@ -112,6 +113,7 @@ public:
 
     uint32_t getPadding(uint64_t timestamp, uint16_t size, uint16_t& paddingSize) const;
     double getTargetRate() const { return (_config.enabled ? _model.bandwidthKbps : 0); }
+    uint32_t getPacingBudget(uint64_t timestamp) const;
 
 private:
     void markReceivedPacket(uint32_t ssrc, uint32_t sequenceNumber);
@@ -124,7 +126,8 @@ private:
         uint32_t& receivedAfterSR,
         uint32_t& lossSinceSR,
         uint32_t& networkQueue,
-        bool& probing);
+        bool& probing,
+        bool& rtpProbe);
 
     double calculateSendRate(uint64_t timestamp) const;
 

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -24,6 +24,7 @@ struct RateControllerConfig
     uint32_t minPadSize = 50;
     double rtcpProbeCeiling = 600;
     uint32_t maxTargetQueue = 128000;
+    uint32_t initialEstimateKbps = 1200;
 };
 
 /*

--- a/codec/Vp8Header.h
+++ b/codec/Vp8Header.h
@@ -34,6 +34,11 @@ constexpr uint8_t getK(const uint8_t* payload)
     return (payload[1] >> 0x4) & 0x1;
 }
 
+constexpr uint8_t getN(const uint8_t* payload)
+{
+    return (payload[0] >> 5) & 0x1;
+}
+
 constexpr size_t getPayloadDescriptorSize(const uint8_t* payload, const size_t payloadSize)
 {
     if (payloadSize == 0)

--- a/config/Config.h
+++ b/config/Config.h
@@ -65,6 +65,7 @@ public:
     CFG_PROP(bool, enable, false);
     CFG_PROP(uint32_t, floor, 300);
     CFG_PROP(uint32_t, ceiling, 9000);
+    CFG_PROP(uint32_t, initialEstimate, 1200);
     CFG_GROUP_END(rctl)
 
     CFG_GROUP()

--- a/config/Config.h
+++ b/config/Config.h
@@ -74,32 +74,31 @@ public:
 
     CFG_GROUP()
     CFG_PROP(uint32_t, minBitrate, 700);
-    CFG_PROP(double, allocFactor, 1.5);
+    CFG_PROP(double, allocFactor, 1.0);
     CFG_GROUP_END(slides)
 
-    struct RtcpConfig
-    {
-        uint32_t mtu = 1440;
-        struct SenderReports
-        {
-            uint64_t interval = utils::Time::ms * 600;
-            uint64_t resubmitInterval = utils::Time::sec * 7;
-        } senderReport;
-        struct ReceiveReports
-        {
-            uint64_t delayAfterSR = utils::Time::ms * 400;
-            uint64_t idleInterval = utils::Time::sec * 6;
-        } receiveReport;
-    } rtcp; // can be made configurable later
+    CFG_GROUP()
+    CFG_PROP(uint32_t, mtu, 1440);
 
-    struct RecordingRtcpConfig
-    {
-        uint32_t mtu = 1440;
-        uint64_t reportInterval = utils::Time::ms * 2500;
-    } recordingRtcp; // can be made configurable later
+    CFG_GROUP()
+    CFG_PROP(uint64_t, interval, utils::Time::ms * 600);
+    CFG_PROP(uint64_t, resubmitInterval, utils::Time::sec * 7);
+    CFG_GROUP_END(senderReport)
 
-    uint32_t mtu = 1480;
-    uint32_t ipOverhead = 20 + 14;
+    CFG_GROUP()
+    CFG_PROP(uint64_t, delayAfterSR, utils::Time::ms * 400);
+    CFG_PROP(uint64_t, idleInterval, utils::Time::sec * 6);
+    CFG_GROUP_END(receiveReport)
+
+    CFG_GROUP_END(rtcp) // can be made configurable later
+
+    CFG_GROUP()
+    CFG_PROP(uint32_t, mtu, 1440);
+    CFG_PROP(uint64_t, reportInterval, utils::Time::ms * 2500);
+    CFG_GROUP_END(recordingRtcp)
+
+    CFG_PROP(uint32_t, mtu, 1480);
+    CFG_PROP(uint32_t, ipOverhead, 20 + 14);
 };
 
 } // namespace config

--- a/config/Config.h
+++ b/config/Config.h
@@ -73,7 +73,7 @@ public:
     CFG_GROUP_END(recording)
 
     CFG_GROUP()
-    CFG_PROP(uint32_t, minBitrate, 700);
+    CFG_PROP(uint32_t, minBitrate, 900);
     CFG_PROP(double, allocFactor, 1.0);
     CFG_GROUP_END(slides)
 

--- a/config/Config.h
+++ b/config/Config.h
@@ -64,13 +64,18 @@ public:
     CFG_GROUP() // rate control
     CFG_PROP(bool, enable, false);
     CFG_PROP(uint32_t, floor, 300);
-    CFG_PROP(uint32_t, ceiling, 5000);
+    CFG_PROP(uint32_t, ceiling, 9000);
     CFG_GROUP_END(rctl)
 
     CFG_GROUP()
     CFG_PROP(uint16_t, singlePort, 10500);
     CFG_PROP(uint32_t, sharedPorts, 1);
     CFG_GROUP_END(recording)
+
+    CFG_GROUP()
+    CFG_PROP(uint32_t, minBitrate, 700);
+    CFG_PROP(double, allocFactor, 1.5);
+    CFG_GROUP_END(slides)
 
     struct RtcpConfig
     {
@@ -94,6 +99,7 @@ public:
     } recordingRtcp; // can be made configurable later
 
     uint32_t mtu = 1480;
+    uint32_t ipOverhead = 20 + 14;
 };
 
 } // namespace config

--- a/logger/Logger.cpp
+++ b/logger/Logger.cpp
@@ -62,7 +62,7 @@ void logStack(const void* stack, int frames, const char* logGroup)
         std::memcpy(item.message, stack, byteCount);
         std::memset(item.message + byteCount, 0, sizeof(void*));
         std::strcpy(item.message + byteCount + sizeof(void*), logGroup);
-        _logThread->post(std::move(item));
+        _logThread->immediate(std::move(item));
     }
 }
 

--- a/math/helpers.h
+++ b/math/helpers.h
@@ -7,4 +7,27 @@ T clamp(const T& value, const T& minValue, const T& maxValue)
 {
     return std::min(std::max(value, minValue), maxValue);
 }
+
+template <uint8_t mantissaBits, uint8_t exponentBits>
+bool extractMantissaExponent(uint64_t value, uint32_t& mantissa, uint32_t& exponent)
+{
+    static_assert(mantissaBits <= 32, "mantissa too large");
+    static_assert(exponentBits < 16, "exponent too large");
+
+    exponent = 0;
+    const uint64_t maxMantissa = (uint64_t(1) << mantissaBits) - 1;
+    const uint32_t maxExponent = (1u << exponentBits) - 1;
+    while (value & ~maxMantissa)
+    {
+        ++exponent;
+        value >>= 1;
+    }
+
+    if (exponent > maxExponent)
+    {
+        return false;
+    }
+    mantissa = static_cast<uint32_t>(value);
+    return true;
+}
 } // namespace math

--- a/math/helpers.h
+++ b/math/helpers.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace math
+{
+template <typename T>
+T clamp(const T& value, const T& minValue, const T& maxValue)
+{
+    return std::min(std::max(value, minValue), maxValue);
+}
+} // namespace math

--- a/memory/PoolAllocator.h
+++ b/memory/PoolAllocator.h
@@ -76,10 +76,10 @@ public:
         munmap(_elements, _size);
     }
 
-    PoolAllocator(const PoolAllocator&) = default;
-    PoolAllocator& operator=(const PoolAllocator&) = default;
-    PoolAllocator(PoolAllocator&&) = default;
-    PoolAllocator& operator=(PoolAllocator&&) = default;
+    PoolAllocator(const PoolAllocator&) = delete;
+    PoolAllocator& operator=(const PoolAllocator&) = delete;
+    PoolAllocator(PoolAllocator&&) = delete;
+    PoolAllocator& operator=(PoolAllocator&&) = delete;
     const std::string& getName() const { return _name; }
 
     size_t size() const { return _count.load(std::memory_order_relaxed); }

--- a/memory/RandomAccessBacklog.h
+++ b/memory/RandomAccessBacklog.h
@@ -59,6 +59,7 @@ public:
     size_t size() const { return _count; }
     bool empty() const { return _count == 0; }
     bool full() const { return _count >= N; }
+    size_t capacity() const { return N; }
 
     const_iterator cbegin() const { return const_iterator(*this, 0); }
     iterator begin() { return iterator(*this, 0); }

--- a/memory/RandomAccessBacklog.h
+++ b/memory/RandomAccessBacklog.h
@@ -58,6 +58,7 @@ public:
 
     size_t size() const { return _count; }
     bool empty() const { return _count == 0; }
+    bool full() const { return _count >= N; }
 
     const_iterator cbegin() const { return const_iterator(*this, 0); }
     iterator begin() { return iterator(*this, 0); }
@@ -104,6 +105,15 @@ public:
             reinterpret_cast<T*>(&_data[(_head + i) % N])->~T();
         }
         _count = 0;
+    }
+
+    void pop_back()
+    {
+        if (_count > 0)
+        {
+            reinterpret_cast<T*>(&_data[(_head + _count - 1) % N])->~T();
+            --_count;
+        }
     }
 
 private:

--- a/rtp/RtcpFeedback.cpp
+++ b/rtp/RtcpFeedback.cpp
@@ -9,6 +9,28 @@ size_t getFeedbackControlInfoSize(const rtp::RtcpFeedback* rtcpFeedback)
     return rtcpFeedback->_header.size() - sizeof(rtp::RtcpFeedback);
 }
 
+template <uint8_t mantissaBits, uint8_t exponentBits>
+bool extractMantissaExponent(uint64_t value, uint32_t& mantissa, uint32_t& exponent)
+{
+    static_assert(mantissaBits <= 32, "mantissa too large");
+    static_assert(exponentBits < 16, "exponent too large");
+
+    exponent = 0;
+    const uint64_t maxMantissa = (uint64_t(1) << mantissaBits) - 1;
+    const uint32_t maxExponent = (1u << exponentBits) - 1;
+    while (value & ~maxMantissa)
+    {
+        ++exponent;
+        value >>= 1;
+    }
+
+    if (exponent > maxExponent)
+    {
+        return false;
+    }
+    mantissa = static_cast<uint32_t>(value);
+    return true;
+}
 } // namespace
 
 namespace rtp
@@ -50,25 +72,22 @@ void getFeedbackControlInfo(const RtcpFeedback* rtcpFeedback,
     outBlp = static_cast<uint16_t>(feedbackControlInfo[2]) << 8 | static_cast<uint16_t>(feedbackControlInfo[3]);
 }
 
-uint64_t RtcpRembFeedback::getBitRate() const
+uint64_t RtcpRembFeedback::getBitrate() const
 {
     uint32_t exponent = _bitrate[0] >> 2;
     uint64_t mantissa = (uint32_t(_bitrate[0]) & 0x3u) << 16 | uint32_t(_bitrate[1]) << 8 | _bitrate[2];
     return mantissa << exponent;
 }
 
-void RtcpRembFeedback::setBitRate(uint64_t bps)
+void RtcpRembFeedback::setBitrate(uint64_t bps)
 {
-    uint8_t exponent = 0;
-    const uint64_t maxMantissa = (1 << 18) - 1;
-    while (bps & ~maxMantissa)
-    {
-        ++exponent;
-        bps >>= 1;
-    }
-    _bitrate[0] = (exponent << 2) | (bps >> 16);
-    _bitrate[1] = (bps >> 8) & 0xFFu;
-    _bitrate[2] = bps & 0xFF;
+    uint32_t exponent = 0;
+    uint32_t mantissa = 0;
+    extractMantissaExponent<18, 6>(bps, mantissa, exponent);
+
+    _bitrate[0] = (exponent << 2) | (mantissa >> 16);
+    _bitrate[1] = (mantissa >> 8) & 0xFFu;
+    _bitrate[2] = mantissa & 0xFF;
 }
 
 RtcpRembFeedback::RtcpRembFeedback() : reporterSsrc(0), mediaSsrc(0), ssrcCount(0)
@@ -107,6 +126,71 @@ bool isRemb(const void* p)
         return std::memcmp(remb.uniqueId, "REMB", 4) == 0;
     }
     return false;
+}
+
+RtcpTemporaryMaxMediaBitrate::RtcpTemporaryMaxMediaBitrate() : reporterSsrc(0), _mediaSsrc(0)
+{
+    header.length = 2;
+    header.packetType = RtcpPacketType::RTPTRANSPORT_FB;
+    header.fmtCount = TransportLayerFeedbackType::TemporaryMaxMediaBitrate;
+}
+
+RtcpTemporaryMaxMediaBitrate& RtcpTemporaryMaxMediaBitrate::create(void* area, uint32_t reporterSsrc)
+{
+    auto& tmmbr = *new (area) RtcpTemporaryMaxMediaBitrate();
+    tmmbr.reporterSsrc = reporterSsrc;
+    return tmmbr;
+}
+
+uint64_t RtcpTemporaryMaxMediaBitrate::Entry::getBitrate() const
+{
+    uint32_t value = _data;
+    const uint32_t exponent = value >> 26;
+    const uint64_t mantissa = (value >> 9) & 0x1FFFFu;
+    return mantissa << exponent;
+}
+
+void RtcpTemporaryMaxMediaBitrate::Entry::setBitrate(uint64_t bps)
+{
+    uint32_t exponent = 0; // 6 bit
+    uint32_t mantissa = 0;
+    extractMantissaExponent<17, 6>(bps, mantissa, exponent);
+    uint32_t overhead = _data.get() & 0x1FFu; // 9 bit
+
+    _data = (exponent << 26) | (mantissa << 9) | overhead;
+}
+
+uint32_t RtcpTemporaryMaxMediaBitrate::Entry::getPacketOverhead() const
+{
+    return _data.get() & 0x1FFu;
+}
+
+void RtcpTemporaryMaxMediaBitrate::Entry::setPacketOverhead(uint32_t overhead)
+{
+    uint32_t value = _data;
+    _data = (value & ~0x1FFu) | (overhead & 0x1FFu);
+}
+
+RtcpTemporaryMaxMediaBitrate::Entry& RtcpTemporaryMaxMediaBitrate::getEntry(size_t index)
+{
+    return _entry[index];
+}
+
+const RtcpTemporaryMaxMediaBitrate::Entry& RtcpTemporaryMaxMediaBitrate::getEntry(size_t index) const
+{
+    return _entry[index];
+}
+
+RtcpTemporaryMaxMediaBitrate::Entry& RtcpTemporaryMaxMediaBitrate::addEntry(uint32_t ssrc,
+    uint32_t bps,
+    uint32_t packetOverhead)
+{
+    auto& entry = _entry[getCount()];
+    header.length += 2;
+    entry.ssrc = ssrc;
+    entry.setBitrate(bps);
+    entry.setPacketOverhead(packetOverhead);
+    return entry;
 }
 
 } // namespace rtp

--- a/rtp/RtcpFeedback.cpp
+++ b/rtp/RtcpFeedback.cpp
@@ -144,7 +144,7 @@ RtcpTemporaryMaxMediaBitrate& RtcpTemporaryMaxMediaBitrate::create(void* area, u
 
 uint64_t RtcpTemporaryMaxMediaBitrate::Entry::getBitrate() const
 {
-    uint32_t value = _data;
+    const uint32_t value = _data;
     const uint32_t exponent = value >> 26;
     const uint64_t mantissa = (value >> 9) & 0x1FFFFu;
     return mantissa << exponent;
@@ -155,7 +155,7 @@ void RtcpTemporaryMaxMediaBitrate::Entry::setBitrate(uint64_t bps)
     uint32_t exponent = 0; // 6 bit
     uint32_t mantissa = 0;
     extractMantissaExponent<17, 6>(bps, mantissa, exponent);
-    uint32_t overhead = _data.get() & 0x1FFu; // 9 bit
+    const uint32_t overhead = _data.get() & 0x1FFu; // 9 bit
 
     _data = (exponent << 26) | (mantissa << 9) | overhead;
 }
@@ -167,7 +167,7 @@ uint32_t RtcpTemporaryMaxMediaBitrate::Entry::getPacketOverhead() const
 
 void RtcpTemporaryMaxMediaBitrate::Entry::setPacketOverhead(uint32_t overhead)
 {
-    uint32_t value = _data;
+    const uint32_t value = _data;
     _data = (value & ~0x1FFu) | (overhead & 0x1FFu);
 }
 

--- a/rtp/RtcpFeedback.h
+++ b/rtp/RtcpFeedback.h
@@ -24,7 +24,8 @@ enum PayloadSpecificFeedbackType
 
 enum TransportLayerFeedbackType
 {
-    PacketNack = 1
+    PacketNack = 1,
+    TemporaryMaxMediaBitrate = 3
 };
 
 RtcpFeedback* createPLI(void* buffer, const uint32_t fromSsrc, const uint32_t aboutSsrc);
@@ -39,11 +40,10 @@ void getFeedbackControlInfo(const RtcpFeedback* rtcpFeedback,
 struct RtcpRembFeedback
 {
     RtcpRembFeedback();
-    uint64_t getBitRate() const;
-    void setBitRate(uint64_t bps);
+    uint64_t getBitrate() const;
+    void setBitrate(uint64_t bps);
     static RtcpRembFeedback& create(void* area, uint32_t reporterSsrc);
     void addSsrc(uint32_t ssrc);
-    uint32_t size() const;
 
     RtcpHeader header;
     nwuint32_t reporterSsrc;
@@ -58,4 +58,38 @@ public:
 };
 
 bool isRemb(const void* header);
+
+struct RtcpTemporaryMaxMediaBitrate
+{
+    struct Entry
+    {
+        uint64_t getBitrate() const;
+        void setBitrate(uint64_t bps);
+        uint32_t getPacketOverhead() const;
+        void setPacketOverhead(uint32_t overhead);
+
+        nwuint32_t ssrc;
+
+    private:
+        nwuint32_t _data;
+    };
+
+    RtcpTemporaryMaxMediaBitrate();
+
+    static RtcpTemporaryMaxMediaBitrate& create(void* area, uint32_t reporterSsrc);
+
+    uint32_t size() const { return header.size(); }
+    uint32_t getCount() const { return (header.length - 2) / 2; }
+    Entry& getEntry(size_t index);
+    const Entry& getEntry(size_t index) const;
+    Entry& addEntry(uint32_t ssrc, uint32_t bps, uint32_t packetOverhead);
+
+    RtcpHeader header;
+    nwuint32_t reporterSsrc;
+
+private:
+    nwuint32_t _mediaSsrc;
+    Entry _entry[];
+};
+
 } // namespace rtp

--- a/test/bridge/DummyRtcTransport.h
+++ b/test/bridge/DummyRtcTransport.h
@@ -49,6 +49,7 @@ public:
     bool isIceEnabled() const override { return true; }
     bool isDtlsEnabled() const override { return true; }
     void connect() override {}
+    void runTick(uint64_t timestamp) override {}
     jobmanager::JobQueue& getJobQueue() override { return _jobQueue; }
     uint32_t getSenderLossCount() const override { return 0; }
     uint32_t getUplinkEstimateKbps() const override { return 0; }

--- a/test/bwe/EstimatorReRun.cpp
+++ b/test/bwe/EstimatorReRun.cpp
@@ -149,7 +149,7 @@ uint32_t identifyAudioSsrc(logger::PacketLogReader& reader)
 }
 } // namespace
 
-TEST(BweReRun, fromTrace)
+TEST(BweReRun, DISABLED_fromTrace)
 {
     bwe::Config config;
     config.congestion.cap.ratio = 0.5;
@@ -274,7 +274,7 @@ class BweRerunLimit : public testing::TestWithParam<uint32_t>
 {
 };
 
-TEST_P(BweRerunLimit, limitedLink)
+TEST_P(BweRerunLimit, DISABLED_limitedLink)
 {
     bwe::Config config;
     /*
@@ -335,7 +335,7 @@ TEST_P(BweRerunLimit, limitedLink)
             "Transport-277",
             "Transport-317"};*/
 
-    std::array<std::string, 56> trace = {"Transport-5"};
+    std::array<std::string, 56> trace = {"Transport-5", "Transport-20", "Transport-17"};
     memory::PacketPoolAllocator allocator(8092, "rerun");
     fakenet::NetworkLink link(GetParam(), 1950 * 1024, 3000);
     link.setLossRate(0);

--- a/test/bwe/RateControllerTest.cpp
+++ b/test/bwe/RateControllerTest.cpp
@@ -48,7 +48,7 @@ TEST_P(RateControllerTestLongRtt, longRtt)
         video->setBandwidth(100);
     }
 
-    call.run(utils::Time::sec * 9, capacityKbps * 1.05);
+    call.run(utils::Time::sec * 16, capacityKbps * 1.05);
 
     EXPECT_GE(rateControl.getTargetRate(), std::min(1000.0, capacityKbps * 0.60));
     if (video)
@@ -80,7 +80,7 @@ TEST_P(RateControllerTestShortRtt, shortRtt)
 {
     uint32_t capacityKbps = GetParam();
     bwe::RateControllerConfig rcConfig;
-    rcConfig.initialEstimateKbps = 200;
+    rcConfig.initialEstimateKbps = 300;
     bwe::RateController rateControl(1, rcConfig);
     auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
     uplink->setStaticDelay(0);

--- a/test/bwe/RateControllerTest.cpp
+++ b/test/bwe/RateControllerTest.cpp
@@ -31,6 +31,7 @@ TEST_P(RateControllerTestLongRtt, longRtt)
 {
     uint32_t capacityKbps = GetParam();
     bwe::RateControllerConfig rcConfig;
+    rcConfig.initialEstimateKbps = 300;
     bwe::RateController rateControl(1, rcConfig);
     auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
     uplink->setStaticDelay(90);
@@ -79,6 +80,7 @@ TEST_P(RateControllerTestShortRtt, shortRtt)
 {
     uint32_t capacityKbps = GetParam();
     bwe::RateControllerConfig rcConfig;
+    rcConfig.initialEstimateKbps = 200;
     bwe::RateController rateControl(1, rcConfig);
     auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
     uplink->setStaticDelay(0);

--- a/test/bwe/RcCall.cpp
+++ b/test/bwe/RcCall.cpp
@@ -90,10 +90,7 @@ void RcCall::sendRtpPadding(uint32_t count, uint32_t ssrc, uint16_t paddingSize)
             reinterpret_cast<uint16_t*>(padRtpHeader->getPayload())[0] =
                 hton<uint16_t>(_mixVideoSendState.getSentSequenceNumber() - 10000);
 
-            _bwe.onRtpPaddingSent(_timeCursor,
-                padRtpHeader->ssrc,
-                padRtpHeader->sequenceNumber,
-                padPacket->getLength());
+            _bwe.onRtpSent(_timeCursor, padRtpHeader->ssrc, padRtpHeader->sequenceNumber, padPacket->getLength());
 
             _mixVideoSendState.onRtpSent(_timeCursor, *padPacket);
             push(_upLink, padPacket);
@@ -291,7 +288,8 @@ void RcCall::processReceiverReports()
                     _bwe.onReportBlockReceived(block.ssrc,
                         block.extendedSeqNoReceived,
                         block.loss.getCumulativeLoss(),
-                        block.lastSR);
+                        block.lastSR,
+                        block.delaySinceLastSR);
                 }
                 if (rttNtp != ~0u)
                 {

--- a/test/rtp/RtcpFeedbackTest.cpp
+++ b/test/rtp/RtcpFeedbackTest.cpp
@@ -54,9 +54,22 @@ TEST(RtcpFeedbackTest, Remb)
     EXPECT_EQ(remb.ssrcFeedback[0], 45);
     EXPECT_EQ(remb.ssrcCount, 1);
     const uint64_t bps = uint64_t(955) * 8 * 1000000;
-    EXPECT_EQ(remb.getBitRate(), 0);
-    remb.setBitRate(bps);
-    EXPECT_NEAR(remb.getBitRate(), bps, 10000);
+    EXPECT_EQ(remb.getBitrate(), 0);
+    remb.setBitrate(bps);
+    EXPECT_NEAR(remb.getBitrate(), bps, 10000);
     EXPECT_EQ(remb.header.length.get(), 4 + 1); // only one ssrc added
     EXPECT_EQ(remb.header.size(), sizeof(remb) + 4);
+}
+
+TEST(RtcpFeedbackTest, Tmmbr)
+{
+    uint8_t data[512];
+
+    auto& tmmbr = rtp::RtcpTemporaryMaxMediaBitrate::create(data, 111);
+    tmmbr.addEntry(211, 600000, 34);
+    auto& entry = tmmbr.getEntry(0);
+    EXPECT_EQ(tmmbr.reporterSsrc, 111);
+    EXPECT_EQ(entry.ssrc, 211);
+    EXPECT_EQ(entry.getBitrate(), 600000);
+    EXPECT_EQ(entry.getPacketOverhead(), 34);
 }

--- a/transport/RtcTransport.h
+++ b/transport/RtcTransport.h
@@ -84,6 +84,8 @@ public:
     virtual void getReportSummary(std::unordered_map<uint32_t, ReportSummary>& outReportSummary) const = 0;
 
     virtual void setRtxProbeSource(uint32_t ssrc, uint32_t* sequenceCounter) = 0;
+
+    virtual void runTick(uint64_t timestamp) = 0;
 };
 
 std::shared_ptr<RtcTransport> createTransport(jobmanager::JobManager& jobmanager,

--- a/transport/RtpSenderState.h
+++ b/transport/RtpSenderState.h
@@ -89,6 +89,7 @@ private:
     uint64_t _rtpSendTime;
     uint64_t _senderReportSendTime;
     uint32_t _senderReportNtp;
+    uint32_t _lossSinceSenderReport;
 
     const config::Config& _config;
     uint64_t _scheduledSenderReport;

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1395,6 +1395,7 @@ void TransportImpl::sendPadding(uint64_t timestamp, uint32_t ssrc, uint32_t rtpT
             budget -= std::min(budget, packetInfo.packet->getLength() + _config.ipOverhead);
             pacingQueue->pop_back();
             protectAndSendRtp(timestamp, packetInfo.packet, packetInfo.allocator);
+            pacingQueue = _rtxPacingQueue.empty() ? &_pacingQueue : &_rtxPacingQueue;
         }
 
         auto paddingCount = _rateController.getPadding(timestamp, nextPacketSize, padding);
@@ -1424,7 +1425,6 @@ void TransportImpl::sendPadding(uint64_t timestamp, uint32_t ssrc, uint32_t rtpT
 
                 // fake a really old packet
                 reinterpret_cast<uint16_t*>(padRtpHeader->getPayload())[0] = hton<uint16_t>(23033);
-
                 protectAndSendRtp(timestamp, padPacket, _mainAllocator);
             }
             else

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -2263,6 +2263,7 @@ void TransportImpl::onSctpChunkDropped(sctp::SctpAssociation* session, size_t si
     logger::error("Sctp chunk dropped due to overload or unknown type", _loggableId.c_str());
 }
 
+// ns
 uint64_t TransportImpl::getRtt() const
 {
     return (static_cast<uint64_t>(_rttNtp) * utils::Time::sec) >> 16;

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -282,7 +282,8 @@ private:
         const SocketAddress& target,
         Endpoint* endpoint,
         memory::PacketPoolAllocator& allocator);
-    void sendPadding(uint64_t timestamp, uint32_t ssrc, uint32_t rtpTimestamp, uint16_t nextPacketSize);
+    void sendPadding(uint64_t timestamp);
+    void sendRtcpPadding(uint64_t timestamp, uint32_t ssrc, uint16_t nextPacketSize);
 
     void processRtcpReport(const rtp::RtcpHeader& packet,
         uint64_t timestamp,

--- a/utils/StdExtensions.h
+++ b/utils/StdExtensions.h
@@ -11,6 +11,17 @@ constexpr std::size_t size(const T (&array)[N])
 }
 #endif
 
+template <typename T>
+T max(const T& a, const T& b, const T& c)
+{
+    return std::max(a, std::max(b, c));
+}
+
+template <typename T>
+T max(const T& a, const T& b, const T& c, const T& d)
+{
+    return std::max(a, std::max(b, std::max(c, d)));
+}
 } // namespace std
 
 namespace utils


### PR DESCRIPTION
Measures uplink using RTCP receiver reports and probing from sender side.
Video is paced according to estimate. If we do not do that, the burst from the sender will cause packet drop on the downlink at the receiver. Pacing prevents NACK on video that cause unnecessary additional load on the limited link. 
A positive effect of this is that if link is overloaded by video, the audio will still pass through as it is not paced. For example, video and screen share may be delayed and broken but audio will likely be intelligable. 

A limit is imposed on slides video stream according to estiamte but with a configurable min bandwidth. This means that we can set a minimum quality to allow users in meetings to have at least that level even if someone in the meeting does not have enough bandwidth. The person with insufficient bandwidth will have poor video but good audio. Video will be delayed and it will take time before a new slide can be seen but he can still participate in the meeting. 