### PR TITLE
OlofkRctlLog

### DIFF
--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -130,6 +130,7 @@ void Bridge::initialize()
     _rateControllerConfig.bandwidthCeilingKbps = _config.rctl.ceiling;
     _rateControllerConfig.bandwidthFloorKbps = _config.rctl.floor;
     _rateControllerConfig.initialEstimateKbps = _config.rctl.initialEstimate;
+    _rateControllerConfig.debugLog = _config.rctl.debugLog;
 
     _srtpClientFactory = std::make_unique<transport::SrtpClientFactory>(*_sslDtls, *_mainPacketAllocator);
     _bweConfig.sanitize();

--- a/bwe/NetworkQueue.h
+++ b/bwe/NetworkQueue.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "utils/Time.h"
+#include <algorithm>
+#include <cstdint>
+
+namespace bwe
+{
+class NetworkQueue
+{
+public:
+    NetworkQueue() : _queue(0), _lastTransmission(0), _bandwidthKbps(200) {}
+
+    void setBandwidth(uint32_t kbps) { _bandwidthKbps = kbps; }
+    uint32_t getBandwidth() const { return _bandwidthKbps; }
+    void onPacketSent(uint64_t timestamp, uint16_t size)
+    {
+        _queue -= std::min(_queue,
+            static_cast<uint32_t>(
+                utils::Time::diff(_lastTransmission, timestamp) * _bandwidthKbps / (8 * utils::Time::ms)));
+
+        _queue += size;
+        _lastTransmission = timestamp;
+    }
+
+    uint32_t size() const { return _queue; }
+    void drain(uint64_t timestamp) { onPacketSent(timestamp, 0); }
+    void clear() { _queue = 0; }
+    uint32_t predictQueueAt(uint64_t timestamp) const
+    {
+        return _queue -
+            std::min(_queue,
+                static_cast<uint32_t>(
+                    utils::Time::diff(_lastTransmission, timestamp) * _bandwidthKbps / (8 * utils::Time::ms)));
+    }
+
+    void setSize(uint32_t bytes) { _queue = bytes; }
+
+private:
+    uint32_t _queue;
+    uint64_t _lastTransmission;
+    uint32_t _bandwidthKbps;
+};
+} // namespace bwe

--- a/bwe/NetworkQueue.h
+++ b/bwe/NetworkQueue.h
@@ -5,6 +5,9 @@
 
 namespace bwe
 {
+
+/** Models a network FIFO queue that drains at a specific bit rate.
+ */
 class NetworkQueue
 {
 public:
@@ -12,6 +15,7 @@ public:
 
     void setBandwidth(uint32_t kbps) { _bandwidthKbps = kbps; }
     uint32_t getBandwidth() const { return _bandwidthKbps; }
+
     void onPacketSent(uint64_t timestamp, uint16_t size)
     {
         _queue -= std::min(_queue,
@@ -22,9 +26,11 @@ public:
         _lastTransmission = timestamp;
     }
 
-    uint32_t size() const { return _queue; }
     void drain(uint64_t timestamp) { onPacketSent(timestamp, 0); }
     void clear() { _queue = 0; }
+    void setSize(uint32_t bytes) { _queue = bytes; }
+
+    uint32_t size() const { return _queue; }
     uint32_t predictQueueAt(uint64_t timestamp) const
     {
         return _queue -
@@ -32,8 +38,6 @@ public:
                 static_cast<uint32_t>(
                     utils::Time::diff(_lastTransmission, timestamp) * _bandwidthKbps / (8 * utils::Time::ms)));
     }
-
-    void setSize(uint32_t bytes) { _queue = bytes; }
 
 private:
     uint32_t _queue;

--- a/bwe/NetworkQueue.h
+++ b/bwe/NetworkQueue.h
@@ -12,6 +12,7 @@ class NetworkQueue
 {
 public:
     NetworkQueue() : _queue(0), _lastTransmission(0), _bandwidthKbps(200) {}
+    explicit NetworkQueue(uint32_t kbps) : _queue(0), _lastTransmission(0), _bandwidthKbps(kbps) {}
 
     void setBandwidth(uint32_t kbps) { _bandwidthKbps = kbps; }
     uint32_t getBandwidth() const { return _bandwidthKbps; }

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -648,7 +648,7 @@ size_t RateController::getPacingBudget(uint64_t timestamp) const
     {
         currentTargetQ += _config.mtu;
         currentTargetQ +=
-            static_cast<uint32_t>(_model.targetQueue * 2 * (timestamp - _probe.start) / _config.probeDuration);
+            static_cast<uint32_t>(_model.targetQueue * 3 * (timestamp - _probe.start) / _config.probeDuration);
     }
 
     return currentTargetQ - std::min(currentTargetQ, currentQueue);

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -55,6 +55,7 @@ RateController::RateController(size_t instanceId, const RateControllerConfig& co
       _config(config)
 {
     _model.bandwidthKbps = config.initialEstimateKbps;
+    _model.targetQueue = calculateTargetQueue(_model.bandwidthKbps, 1, config);
 }
 
 void RateController::onRtpSent(uint64_t timestamp, uint32_t ssrc, uint32_t sequenceNumber, uint16_t size)
@@ -147,7 +148,7 @@ void RateController::onReportBlockReceived(uint32_t ssrc,
     {
         if (item.ssrc == ssrc && item.type == PacketMetaData::RTP)
         {
-            if (item.sequenceNumber == receivedSequenceNumber)
+            if (item.sequenceNumber == receivedSequenceNumber && !item.received)
             {
                 item.received = true;
                 item.lossCount = lossCount;

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -9,7 +9,11 @@
 #include <algorithm>
 #include <cmath>
 
-#define RCTL_LOG(fmt, ...) // logger::debug(fmt, ##__VA_ARGS__)
+#define RCTL_LOG(fmt, ...)                                                                                             \
+    if (_config.debugLog)                                                                                              \
+    {                                                                                                                  \
+        logger::debug(fmt, ##__VA_ARGS__);                                                                             \
+    }
 
 namespace
 {

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -647,7 +647,7 @@ uint32_t RateController::getPadding(const uint64_t timestamp, const uint16_t siz
         if (_canRtxPad &&
             (_rtxSendTime == 0 || utils::Time::diffGE(_rtxSendTime, timestamp, _config.minPadPinInterval)))
         {
-            paddingSize = rtp::MIN_RTP_HEADER_SIZE + 4; // tiny packet to keep flow on padding ssrc
+            paddingSize = rtp::MIN_RTP_HEADER_SIZE + 8; // tiny packet to keep flow on padding ssrc
             return 1;
         }
         return 0;

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -701,7 +701,7 @@ double RateController::getTargetRate() const
         return 0;
     }
 
-    return _model.queue.getBandwidth() * (1.0 - _drainMargin);
+    return _model.queue.getBandwidth();
 }
 
 } // namespace bwe

--- a/bwe/RateController.cpp
+++ b/bwe/RateController.cpp
@@ -217,7 +217,7 @@ bool isProbe(const T& backlog, double bandwidthKbps, uint32_t trainEnd, uint32_t
 
         if (i == trainEnd)
         {
-            return queueSize > 100;
+            return queueSize >= queueLimit;
         }
     }
 

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "bwe/NetworkQueue.h"
 #include "logger/Logger.h"
 #include "memory/RandomAccessBacklog.h"
 #include "utils/Optional.h"
@@ -18,15 +19,15 @@ struct RateControllerConfig
     uint32_t ipOverhead = 20 + 14;
     uint32_t mtu = 1480;
     uint32_t maxPaddingSize = 1200;
-    double bandwidthFloorKbps = 300;
-    double bandwidthCeilingKbps = 9000;
+    uint32_t bandwidthFloorKbps = 300;
+    uint32_t bandwidthCeilingKbps = 9000;
     uint64_t minPadPinInterval = 80 * utils::Time::ms;
     uint32_t minPadSize = 50;
-    double rtcpProbeCeiling = 600;
+    uint32_t rtcpProbeCeiling = 600;
     uint32_t maxTargetQueue = 128000;
     uint32_t initialEstimateKbps = 1200;
     bool debugLog = false;
-    uint64_t probeDuration = 700 * utils::Time::ms;
+    uint64_t probeDuration = 500 * utils::Time::ms;
     uint64_t probeRampup = 300 * utils::Time::ms;
 };
 
@@ -143,8 +144,8 @@ private:
         bool rtpProbe = true;
         const PacketMetaData* senderReportItem = nullptr;
 
-        double getBitrateKbps() const;
-        double getSendRateKbps() const;
+        uint32_t getBitrateKbps() const;
+        uint32_t getSendRateKbps() const;
 
         bool empty() const { return !senderReportItem; }
     };
@@ -165,12 +166,8 @@ private:
 
     struct Model
     {
-        double bandwidthKbps = 200.0;
-        uint32_t queue = 0;
+        NetworkQueue queue;
         uint32_t targetQueue = 3000;
-        uint64_t lastTransmission = 0;
-
-        void onPacketSent(uint64_t timestamp, uint16_t size);
     } _model;
 
     double _drainMargin = 0;

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -58,15 +58,6 @@ class RateController
 {
     struct PacketMetaData
     {
-        uint64_t transmissionTime = 0;
-        uint32_t ssrc = 0;
-        uint32_t size = 0;
-        uint32_t reportNtp = 0;
-        uint32_t queueSize = 0;
-        uint32_t sequenceNumber = 0;
-        uint32_t lossCount = 0;
-        uint32_t delaySinceSR = 0;
-        bool received = false;
         enum Type : uint16_t
         {
             SR = 0,
@@ -74,13 +65,24 @@ class RateController
             RTP,
             RTCP_PADDING,
             SCTP
-        } type = RTP;
+        };
+
+        uint64_t transmissionTime = 0;
+        uint32_t ssrc = 0;
+        uint32_t size = 0;
+        uint32_t reportNtp = 0;
+        uint32_t queueSize = 0;
+        uint32_t lossCount = 0;
+        uint32_t delaySinceSR = 0;
+        uint16_t sequenceNumber = 0;
+        Type type = RTP;
+        bool received = false;
 
         PacketMetaData() = default;
         ~PacketMetaData() = default;
         PacketMetaData(uint64_t timestamp,
             uint32_t streamSsrc,
-            uint32_t packetSequenceNumber,
+            uint16_t packetSequenceNumber,
             uint32_t packetSize,
             Type packetType)
             : transmissionTime(timestamp),
@@ -88,11 +90,11 @@ class RateController
               size(packetSize),
               reportNtp(0),
               queueSize(0),
-              sequenceNumber(packetSequenceNumber),
               lossCount(0),
               delaySinceSR(0),
-              received(false),
-              type(packetType)
+              sequenceNumber(packetSequenceNumber),
+              type(packetType),
+              received(false)
         {
         }
     };
@@ -110,7 +112,7 @@ class RateController
 public:
     explicit RateController(size_t instanceId, const RateControllerConfig& config);
 
-    void onRtpSent(uint64_t timestamp, uint32_t ssrc, uint32_t sequenceNumber, uint16_t size);
+    void onRtpSent(uint64_t timestamp, uint32_t ssrc, uint16_t sequenceNumber, uint16_t size);
     void onSenderReportSent(uint64_t timestamp, uint32_t ssrc, uint32_t reportNtp, uint16_t size);
     void onReportBlockReceived(uint32_t ssrc,
         uint32_t receivedSequenceNumber,
@@ -139,6 +141,8 @@ private:
         uint32_t packetsSent = 0;
         uint32_t packetsReceived = 0;
         uint32_t networkQueue = ~0u;
+        uint32_t probeBacklogDepth = 0;
+        uint32_t probeBacklogLength = 0;
         bool probing = false;
         bool rtpProbe = true;
         const PacketMetaData* senderReportItem = nullptr;
@@ -148,6 +152,9 @@ private:
 
         bool empty() const { return !senderReportItem; }
     };
+
+    bool hasRecentlyBackedOffDueToLoss(uint64_t timestamp);
+
     BacklogAnalysis bestReport(const BacklogAnalysis& probe1,
         const BacklogAnalysis& probe2,
         const uint32_t modelBandwidth) const;
@@ -156,13 +163,13 @@ private:
     void markReceivedPacket(uint32_t ssrc, uint32_t sequenceNumber);
     uint64_t calculateModelQueueTransmitPeriod();
     RateController::BacklogAnalysis analyzeProbe(const uint32_t probeEndIndex, const double modelBandwidthKbps) const;
-    BacklogAnalysis analyzeBacklog(uint32_t reportNtp, double modelBandwidthKbps) const;
+    BacklogAnalysis analyzeBacklog(uint32_t reportNtp, double modelBandwidthKbps);
 
     double calculateSendRate(uint64_t timestamp) const;
     void dumpBacklog(uint32_t seqno, uint32_t ssrc);
 
     logger::LoggableId _logId;
-    memory::RandomAccessBacklog<PacketMetaData, 512> _backlog;
+    memory::RandomAccessBacklog<PacketMetaData, 2048> _backlog;
     memory::RandomAccessBacklog<ReceiveBlockSample, 32> _receiveBlocks;
 
     struct Model
@@ -173,10 +180,15 @@ private:
 
     struct Probe
     {
+        constexpr static uint64_t INITIAL_INTERVAL = utils::Time::sec;
+        constexpr static uint64_t MAX_INTERVAL = utils::Time::sec * 4;
+
         uint64_t start = 0;
-        uint64_t interval = utils::Time::sec;
+        uint64_t lastGoodProbe = 0;
+        uint64_t interval = INITIAL_INTERVAL;
         uint64_t duration = 0;
         uint32_t count = 0;
+        uint32_t countOnLastIntervalReduction = 0;
         uint32_t targetQueue = 0;
 
         bool isProbing(uint64_t timestamp) const
@@ -193,6 +205,33 @@ private:
     uint64_t _lastLossBackoff = 0;
     struct
     {
+        uint32_t logTimes = 0;
+        uint32_t backlogAnalysisCount = 0;
+        uint32_t probeAnalysisCount = 0;
+        uint32_t isNotProbingCount = 0;
+        uint32_t insufficientDelayCount = 0;
+        uint32_t insufficientConfirmationsCount = 0;
+        uint32_t srNotFoundCount = 0;
+        uint32_t srSeqnoNotFoundCount = 0;
+        uint32_t noCandidatesFound = 0;
+
+        void resetCounters()
+        {
+            logTimes = 0;
+            backlogAnalysisCount = 0;
+            probeAnalysisCount = 0;
+            isNotProbingCount = 0;
+            insufficientDelayCount = 0;
+            insufficientConfirmationsCount = 0;
+            srNotFoundCount = 0;
+            srSeqnoNotFoundCount = 0;
+            noCandidatesFound = 0;
+        }
+
+    } _probeMetrics;
+
+    struct
+    {
         uint32_t ntp = 0;
         uint32_t delaySinceSR = 0;
         uint32_t packetsReceived = 0;
@@ -200,4 +239,5 @@ private:
         bool empty() const { return ntp == 0 && packetsReceived == 0; }
     } _lastProbe;
 };
+
 } // namespace bwe

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -25,6 +25,7 @@ struct RateControllerConfig
     double rtcpProbeCeiling = 600;
     uint32_t maxTargetQueue = 128000;
     uint32_t initialEstimateKbps = 1200;
+    bool debugLog = false;
 };
 
 /*

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -27,8 +27,7 @@ struct RateControllerConfig
     uint32_t maxTargetQueue = 128000;
     uint32_t initialEstimateKbps = 1200;
     bool debugLog = false;
-    uint64_t probeDuration = 500 * utils::Time::ms;
-    uint64_t probeRampup = 300 * utils::Time::ms;
+    uint64_t probeDuration = 700 * utils::Time::ms;
 };
 
 /*

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -121,7 +121,7 @@ public:
     void onSctpSent(uint64_t timestamp, uint16_t size);
 
     uint32_t getPadding(uint64_t timestamp, uint16_t size, uint16_t& paddingSize) const;
-    double getTargetRate() const { return (_config.enabled ? _model.bandwidthKbps : 0); }
+    double getTargetRate() const;
     size_t getPacingBudget(uint64_t timestamp) const;
     void enableRtpProbing() { _canRtxPad = true; }
 
@@ -166,15 +166,10 @@ private:
         uint32_t targetQueue = 3000;
         uint64_t lastTransmission = 0;
 
-        void onPacketSent(uint64_t timestamp, uint16_t size)
-        {
-            queue -= std::min(queue,
-                static_cast<uint32_t>(
-                    utils::Time::diff(lastTransmission, timestamp) * bandwidthKbps / (8 * utils::Time::ms)));
-            queue += size;
-            lastTransmission = timestamp;
-        }
+        void onPacketSent(uint64_t timestamp, uint16_t size);
     } _model;
+
+    double _drainMargin = 0;
 
     struct Probe
     {

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -148,8 +148,10 @@ private:
 
         bool empty() const { return !senderReportItem; }
     };
-    BacklogAnalysis bestReport(const BacklogAnalysis& probe1, const BacklogAnalysis& probe2) const;
-    bool isGood(const BacklogAnalysis& probe) const;
+    BacklogAnalysis bestReport(const BacklogAnalysis& probe1,
+        const BacklogAnalysis& probe2,
+        const uint32_t modelBandwidth) const;
+    bool isGood(const BacklogAnalysis& probe, const uint32_t modelBandwidthKbps) const;
 
     void markReceivedPacket(uint32_t ssrc, uint32_t sequenceNumber);
     uint64_t calculateModelQueueTransmitPeriod();

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -179,6 +179,7 @@ private:
         uint64_t interval = utils::Time::sec;
         uint64_t duration = 0;
         uint32_t count = 0;
+        uint32_t augmentedQueue = 0;
 
         bool isProbing(uint64_t timestamp) const
         {

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -171,8 +171,6 @@ private:
         uint32_t targetQueue = 3000;
     } _model;
 
-    double _drainMargin = 0;
-
     struct Probe
     {
         uint64_t start = 0;

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -179,7 +179,7 @@ private:
         uint64_t interval = utils::Time::sec;
         uint64_t duration = 0;
         uint32_t count = 0;
-        uint32_t augmentedQueue = 0;
+        uint32_t targetQueue = 0;
 
         bool isProbing(uint64_t timestamp) const
         {
@@ -198,6 +198,8 @@ private:
         uint32_t ntp = 0;
         uint32_t delaySinceSR = 0;
         uint32_t packetsReceived = 0;
+
+        bool empty() const { return ntp == 0 && packetsReceived == 0; }
     } _lastProbe;
 };
 } // namespace bwe

--- a/bwe/RateController.h
+++ b/bwe/RateController.h
@@ -27,7 +27,7 @@ struct RateControllerConfig
     uint32_t initialEstimateKbps = 1200;
     bool debugLog = false;
     uint64_t probeDuration = 700 * utils::Time::ms;
-    uint64_t probeRampup = 500 * utils::Time::ms;
+    uint64_t probeRampup = 300 * utils::Time::ms;
 };
 
 /*

--- a/config/Config.h
+++ b/config/Config.h
@@ -66,6 +66,7 @@ public:
     CFG_PROP(uint32_t, floor, 300);
     CFG_PROP(uint32_t, ceiling, 9000);
     CFG_PROP(uint32_t, initialEstimate, 1200);
+    CFG_PROP(bool, debugLog, false);
     CFG_GROUP_END(rctl)
 
     CFG_GROUP()

--- a/test/bwe/RateControllerTest.cpp
+++ b/test/bwe/RateControllerTest.cpp
@@ -32,6 +32,7 @@ TEST_P(RateControllerTestLongRtt, longRtt)
     uint32_t capacityKbps = GetParam();
     bwe::RateControllerConfig rcConfig;
     rcConfig.initialEstimateKbps = 300;
+    rcConfig.debugLog = true;
     bwe::RateController rateControl(1, rcConfig);
     auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
     uplink->setStaticDelay(90);
@@ -81,6 +82,7 @@ TEST_P(RateControllerTestShortRtt, shortRtt)
     uint32_t capacityKbps = GetParam();
     bwe::RateControllerConfig rcConfig;
     rcConfig.initialEstimateKbps = 300;
+    rcConfig.debugLog = true;
     bwe::RateController rateControl(1, rcConfig);
     auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
     uplink->setStaticDelay(0);

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1408,6 +1408,8 @@ void TransportImpl::sendPadding(uint64_t timestamp)
             padRtpHeader->payloadType = rtxPayloadType;
             padRtpHeader->timestamp = 1293887;
             padRtpHeader->sequenceNumber = (*_rtxProbeSequenceCounter)++ & 0xFFFF;
+            padRtpHeader->padding = 1;
+            padPacket->get()[padPacket->getLength() - 1] = 0x01;
             if (_absSendTimeExtensionId.isSet())
             {
                 padRtpHeader->extension = 1;


### PR DESCRIPTION
* RC probes spread in time to avoid all packets being sent before 2nd SR.
* Probe applied on current target queue in case target queue is already consumed by pending data from streams.
