### PR TITLE
Reduce mem usage in packet pools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(FILES
         memory/List.h
         memory/Packet.h
         memory/PacketPoolAllocator.h
+        memory/AudioPacketPoolAllocator.h
         memory/PoolAllocator.h
         memory/PriorityQueue.h
         memory/RefCountedPacket.h

--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -59,6 +59,7 @@ Bridge::Bridge(const config::Config& config)
       _network(transport::createRtcePoll()),
       _mainPacketAllocator(std::make_unique<memory::PacketPoolAllocator>(16 * 1024, "main")),
       _sendPacketAllocator(std::make_unique<memory::PacketPoolAllocator>(64 * 1024, "send")),
+      _audioPacketAllocator(std::make_unique<memory::AudioPacketPoolAllocator>(4 * 1024, "audio")),
       _engine(std::make_unique<bridge::Engine>())
 {
 }
@@ -156,7 +157,8 @@ void Bridge::initialize()
         *_engine,
         _config,
         *_mainPacketAllocator,
-        *_sendPacketAllocator);
+        *_sendPacketAllocator,
+        *_audioPacketAllocator);
 
     _requestHandler = std::make_unique<bridge::ApiRequestHandler>(*_mixerManager, *_sslDtls);
 

--- a/bridge/Bridge.h
+++ b/bridge/Bridge.h
@@ -2,6 +2,7 @@
 #include "bwe/BandwidthEstimator.h"
 #include "bwe/RateController.h"
 #include "config/Config.h"
+#include "memory/AudioPacketPoolAllocator.h"
 #include "memory/PacketPoolAllocator.h"
 #include "transport/RtcePoll.h"
 #include "transport/dtls/SslDtls.h"
@@ -64,6 +65,7 @@ private:
     const std::unique_ptr<transport::RtcePoll> _network;
     const std::unique_ptr<memory::PacketPoolAllocator> _mainPacketAllocator;
     const std::unique_ptr<memory::PacketPoolAllocator> _sendPacketAllocator;
+    const std::unique_ptr<memory::AudioPacketPoolAllocator> _audioPacketAllocator;
     std::unique_ptr<transport::TransportFactory> _transportFactory;
     const std::unique_ptr<bridge::Engine> _engine;
     std::unique_ptr<bridge::MixerManager> _mixerManager;

--- a/bridge/MixerManager.cpp
+++ b/bridge/MixerManager.cpp
@@ -20,7 +20,7 @@ namespace
 const auto intervalNs = 10000000UL;
 const uint32_t maxLastN = 16;
 
-}
+} // namespace
 
 namespace bridge
 {
@@ -32,7 +32,8 @@ MixerManager::MixerManager(utils::IdGenerator& idGenerator,
     Engine& engine,
     const config::Config& config,
     memory::PacketPoolAllocator& mainAllocator,
-    memory::PacketPoolAllocator& sendAllocator)
+    memory::PacketPoolAllocator& sendAllocator,
+    memory::AudioPacketPoolAllocator& audioAllocator)
     : _idGenerator(idGenerator),
       _ssrcGenerator(ssrcGenerator),
       _jobManager(jobManager),
@@ -42,7 +43,8 @@ MixerManager::MixerManager(utils::IdGenerator& idGenerator,
       _threadRunning(true),
       _engineMessages(16384),
       _mainAllocator(mainAllocator),
-      _sendAllocator(sendAllocator)
+      _sendAllocator(sendAllocator),
+      _audioAllocator(audioAllocator)
 {
     _engine.setMessageListener(this);
 
@@ -98,6 +100,7 @@ Mixer* MixerManager::create(uint32_t lastN)
             localVideoSsrc,
             _config,
             _sendAllocator,
+            _audioAllocator,
             audioSsrcs,
             videoSsrcs,
             lastN));

--- a/bridge/MixerManager.h
+++ b/bridge/MixerManager.h
@@ -50,7 +50,8 @@ public:
         bridge::Engine& engine,
         const config::Config& config,
         memory::PacketPoolAllocator& mainAllocator,
-        memory::PacketPoolAllocator& sendAllocator);
+        memory::PacketPoolAllocator& sendAllocator,
+        memory::AudioPacketPoolAllocator& audioAllocator);
 
     ~MixerManager();
 
@@ -99,6 +100,7 @@ private:
     Stats::SystemStatsCollector _systemStatCollector;
     memory::PacketPoolAllocator& _mainAllocator;
     memory::PacketPoolAllocator& _sendAllocator;
+    memory::AudioPacketPoolAllocator& _audioAllocator;
 
     void engineMessageMixerRemoved(const EngineMessage::Message& message);
     void engineMessageAllocateAudioBuffer(const EngineMessage::Message& message);

--- a/bridge/engine/AudioForwarderReceiveJob.h
+++ b/bridge/engine/AudioForwarderReceiveJob.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "jobmanager/Job.h"
+#include "memory/AudioPacketPoolAllocator.h"
 #include "memory/PacketPoolAllocator.h"
 #include <memory>
 
@@ -32,6 +33,7 @@ class AudioForwarderReceiveJob : public jobmanager::CountedJob
 public:
     AudioForwarderReceiveJob(memory::Packet* packet,
         memory::PacketPoolAllocator& allocator,
+        memory::AudioPacketPoolAllocator& audioPacketAllocator,
         transport::RtcTransport* sender,
         EngineMixer& engineMixer,
         SsrcInboundContext& ssrcContext,
@@ -50,6 +52,7 @@ private:
 
     memory::Packet* _packet;
     memory::PacketPoolAllocator& _allocator;
+    memory::AudioPacketPoolAllocator& _audioPacketAllocator;
     EngineMixer& _engineMixer;
     transport::RtcTransport* _sender;
     SsrcInboundContext& _ssrcContext;

--- a/bridge/engine/EncodeJob.h
+++ b/bridge/engine/EncodeJob.h
@@ -2,6 +2,7 @@
 
 #include "concurrency/MpmcHashmap.h"
 #include "jobmanager/Job.h"
+#include "memory/AudioPacketPoolAllocator.h"
 #include "memory/PacketPoolAllocator.h"
 #include <atomic>
 #include <cstdint>
@@ -25,7 +26,8 @@ class SsrcOutboundContext;
 class EncodeJob : public jobmanager::CountedJob
 {
 public:
-    EncodeJob(memory::Packet* packet,
+    EncodeJob(memory::AudioPacket* packet,
+        memory::AudioPacketPoolAllocator& allocator,
         SsrcOutboundContext& outboundContext,
         transport::Transport& transport,
         const uint64_t rtpTimestamp,
@@ -36,9 +38,8 @@ public:
     void run() override;
 
 private:
-    void doSend(memory::Packet* packet);
-
-    memory::Packet* _packet;
+    memory::AudioPacket* _packet;
+    memory::AudioPacketPoolAllocator& _audioPacketPoolAllocator;
     SsrcOutboundContext& _outboundContext;
     transport::Transport& _transport;
     uint64_t _rtpTimestamp;

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -145,6 +145,7 @@ EngineMixer::EngineMixer(const std::string& id,
     const uint32_t localVideoSsrc,
     const config::Config& config,
     memory::PacketPoolAllocator& sendAllocator,
+    memory::AudioPacketPoolAllocator& audioAllocator,
     const std::vector<uint32_t>& audioSsrcs,
     const std::vector<SimulcastLevel>& videoSsrcs,
     const uint32_t lastN)
@@ -165,6 +166,7 @@ EngineMixer::EngineMixer(const std::string& id,
       _localVideoSsrc(localVideoSsrc),
       _rtpTimestampSource(1000),
       _sendAllocator(sendAllocator),
+      _audioAllocator(audioAllocator),
       _noIncomingPacketsIntervalMs(0),
       _maxNoIncomingPacketsIntervalMs(inactivityTimeoutMs),
       _noTicks(0),
@@ -758,12 +760,13 @@ void EngineMixer::clear()
 
 void EngineMixer::flush()
 {
-    IncomingPacketInfo packetInfo;
-    while (_incomingMixerAudioRtp.pop(packetInfo))
+    IncomingAudioPacketInfo audioPacketInfo;
+    while (_incomingMixerAudioRtp.pop(audioPacketInfo))
     {
-        packetInfo.release();
+        audioPacketInfo.release();
     }
 
+    IncomingPacketInfo packetInfo;
     while (_incomingForwarderAudioRtp.pop(packetInfo))
     {
         packetInfo.release();
@@ -1543,6 +1546,7 @@ void EngineMixer::onRtpPacketReceived(transport::RtcTransport* sender,
         if (_engineAudioStreams.size() == 0 ||
             !sender->getJobQueue().addJob<bridge::AudioForwarderReceiveJob>(packet,
                 receiveAllocator,
+                _audioAllocator,
                 sender,
                 *this,
                 *ssrcContext,
@@ -1600,13 +1604,17 @@ void EngineMixer::onForwarderVideoRtpPacketDecrypted(transport::RtcTransport* se
 }
 
 void EngineMixer::onMixerAudioRtpPacketDecoded(transport::RtcTransport* sender,
-    memory::Packet* packet,
-    memory::PacketPoolAllocator& receiveAllocator)
+    memory::AudioPacket* packet,
+    memory::AudioPacketPoolAllocator& receiveAllocator)
 {
     assert(packet);
-    const IncomingPacketInfo packetInfo = {packet, &receiveAllocator, sender};
-    if (!enqueuePacket(packetInfo, _incomingMixerAudioRtp))
+    const IncomingAudioPacketInfo packetInfo = {packet, &receiveAllocator, sender};
+    packetInfo.lockOwner();
+    auto result = _incomingMixerAudioRtp.push(packetInfo);
+    assert(result);
+    if (!result)
     {
+        packetInfo.release();
         logger::error("Failed to push incoming mixer audio packet onto queue", getLoggableId().c_str());
     }
 }
@@ -1967,9 +1975,9 @@ void EngineMixer::processIncomingRtpPackets(const uint64_t timestamp)
     numRtpPackets += processIncomingVideoRtpPackets(timestamp);
     bool overrunLogSpamGuard = false;
 
-    for (IncomingPacketInfo packetInfo; _incomingMixerAudioRtp.pop(packetInfo);)
+    for (IncomingAudioPacketInfo packetInfo; _incomingMixerAudioRtp.pop(packetInfo);)
     {
-        utils::ReleaseGuard<IncomingPacketInfo> autoRelease(packetInfo);
+        utils::ReleaseGuard<IncomingAudioPacketInfo> autoRelease(packetInfo);
         ++numRtpPackets;
 
         const auto rtpHeader = rtp::RtpHeader::fromPacket(*packetInfo._packet);
@@ -2417,18 +2425,18 @@ inline void EngineMixer::processAudioStreams()
             continue;
         }
 
-        auto rtpPacket = memory::makePacket(_sendAllocator);
-        if (!rtpPacket)
+        auto audioPacket = memory::makePacket(_audioAllocator);
+        if (!audioPacket)
         {
             return;
         }
 
-        auto rtpHeader = rtp::RtpHeader::create(rtpPacket->get(), memory::Packet::size);
+        auto rtpHeader = rtp::RtpHeader::create(audioPacket->get(), memory::Packet::size);
         rtpHeader->ssrc = audioStream->_localSsrc;
 
         auto payloadStart = rtpHeader->getPayload();
         const auto headerLength = rtpHeader->headerLength();
-        rtpPacket->setLength(headerLength + samplesPerIteration * bytesPerSample);
+        audioPacket->setLength(headerLength + samplesPerIteration * bytesPerSample);
         memcpy(payloadStart, _mixedData, samplesPerIteration * bytesPerSample);
 
         if (isContributingToMix && audioBuffer)
@@ -2441,13 +2449,14 @@ inline void EngineMixer::processAudioStreams()
 
         auto* ssrcContext = obtainOutboundSsrcContext(*audioStream, audioStream->_localSsrc);
         if (!ssrcContext ||
-            !audioStream->_transport.getJobQueue().addJob<EncodeJob>(rtpPacket,
+            !audioStream->_transport.getJobQueue().addJob<EncodeJob>(audioPacket,
+                _audioAllocator,
                 *ssrcContext,
                 audioStream->_transport,
                 _rtpTimestampSource,
                 audioStream->_audioLevelExtensionId))
         {
-            _sendAllocator.free(rtpPacket);
+            _audioAllocator.free(audioPacket);
         }
     }
 }

--- a/codec/AudioLevel.cpp
+++ b/codec/AudioLevel.cpp
@@ -1,5 +1,5 @@
 #include "AudioLevel.h"
-#include "memory/Packet.h"
+#include "memory/AudioPacketPoolAllocator.h"
 #include "rtp/RtpHeader.h"
 #include <cmath>
 #include <inttypes.h>
@@ -23,7 +23,7 @@ int computeAudioLevel(const int16_t* payload, int count)
     return -std::max(-127, static_cast<int>(20 * std::log10(rms)));
 }
 
-void addAudioLevelRtpExtension(int extensionId, memory::Packet& packet)
+void addAudioLevelRtpExtension(int extensionId, memory::AudioPacket& packet)
 {
     const auto rtpHeader = rtp::RtpHeader::fromPacket(packet);
     if (!rtpHeader)

--- a/codec/AudioLevel.h
+++ b/codec/AudioLevel.h
@@ -2,10 +2,10 @@
 
 namespace memory
 {
-class Packet;
+class AudioPacket;
 }
 
 namespace codec
 {
-void addAudioLevelRtpExtension(int extensionId, memory::Packet& packet);
+void addAudioLevelRtpExtension(int extensionId, memory::AudioPacket& packet);
 }

--- a/memory/AudioPacketPoolAllocator.h
+++ b/memory/AudioPacketPoolAllocator.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "logger/Logger.h"
+#include "memory/Packet.h"
+#include "memory/PoolAllocator.h"
+
+namespace memory
+{
+
+class AudioPacket : public FixedPacket<5800>
+{
+};
+
+using AudioPacketPoolAllocator = PoolAllocator<sizeof(AudioPacket)>;
+
+inline AudioPacket* makePacket(AudioPacketPoolAllocator& allocator)
+{
+    auto pointer = allocator.allocate();
+    assert(pointer);
+    if (!pointer)
+    {
+        logger::error("Unable to allocate packet, no space left in pool %s",
+            "AudioPacketPoolAllocator",
+            allocator.getName().c_str());
+        return nullptr;
+    }
+
+    return new (pointer) memory::AudioPacket();
+}
+
+inline AudioPacket* makePacket(AudioPacketPoolAllocator& allocator, const void* data, size_t length)
+{
+    assert(length <= memory::AudioPacket::size);
+    if (length > memory::AudioPacket::size)
+    {
+        return nullptr;
+    }
+
+    auto packet = makePacket(allocator);
+    if (!packet)
+    {
+        return packet;
+    }
+
+    std::memcpy(packet->get(), data, length);
+    packet->setLength(length);
+    return packet;
+}
+
+inline AudioPacket* makePacket(AudioPacketPoolAllocator& allocator, const Packet& packet)
+{
+    return makePacket(allocator, packet.get(), packet.getLength());
+}
+
+} // namespace memory

--- a/memory/Packet.h
+++ b/memory/Packet.h
@@ -7,13 +7,14 @@
 namespace memory
 {
 
-class Packet
+template <size_t PacketSize>
+class FixedPacket
 {
 public:
-    Packet() : _length(0) { _data[0] = 0; }
+    FixedPacket() : _length(0) { _data[0] = 0; }
 
-    static const size_t size = 4096; // TODO, this is not enough for 48kHz 16bit 30ms packets, nor for 2-channel 48kHz.
-                                     // Allocator should have multiple packet sizes
+    static const size_t size = PacketSize;
+    static_assert(PacketSize % 8 == 0, "packet size must be 8B aligned");
 
     unsigned char* get() { return _data; }
     const unsigned char* get() const { return _data; }
@@ -26,7 +27,7 @@ public:
 
     size_t getLength() const { return _length; }
 
-    void copyTo(Packet& dst)
+    void copyTo(FixedPacket<PacketSize>& dst)
     {
         std::memcpy(dst.get(), get(), getLength());
         dst.setLength(getLength());
@@ -44,6 +45,10 @@ public:
 private:
     unsigned char _data[size];
     size_t _length;
+};
+
+class Packet : public FixedPacket<1504>
+{
 };
 
 } // namespace memory

--- a/rtp/RtpHeader.h
+++ b/rtp/RtpHeader.h
@@ -72,8 +72,16 @@ struct RtpHeader
 
     static RtpHeader* fromPtr(void* p, size_t len);
     inline static const RtpHeader* fromPtr(const void* p, size_t len) { return fromPtr(const_cast<void*>(p), len); }
-    inline static RtpHeader* fromPacket(memory::Packet& p) { return fromPtr(p.get(), p.getLength()); }
-    inline static const RtpHeader* fromPacket(const memory::Packet& p) { return fromPtr(p.get(), p.getLength()); }
+    template <typename PacketType>
+    inline static RtpHeader* fromPacket(PacketType& p)
+    {
+        return fromPtr(p.get(), p.getLength());
+    }
+    template <typename PacketType>
+    inline static const RtpHeader* fromPacket(const PacketType& p)
+    {
+        return fromPtr(p.get(), p.getLength());
+    }
     static RtpHeader* create(void* p, size_t len);
     size_t headerLength() const;
     uint8_t* getPayload() { return reinterpret_cast<uint8_t*>(this) + headerLength(); }

--- a/test/sctp/SctpEndpoint.cpp
+++ b/test/sctp/SctpEndpoint.cpp
@@ -115,6 +115,12 @@ bool SctpEndpoint::sendSctpPacket(const void* data, size_t length)
         return false;
     }
 
+    if (length > memory::Packet::size)
+    {
+        logger::error("sctp packet %zu exceeds MTU %zu", _loggableId.c_str(), length, memory::Packet::size);
+        return false;
+    }
+
     auto* packet = memory::makePacket(_allocator, data, length);
     if (packet && _sendQueue.push(packet, _timeSource))
     {

--- a/test/sctp/SctpTransferTests.cpp
+++ b/test/sctp/SctpTransferTests.cpp
@@ -188,7 +188,7 @@ TEST_F(SctpTransferTestFixture, mtuDiscovery)
     SctpEndpoint B(5001, _config, _timestamp, 250);
 
     establishConnection(A, B);
-    const size_t MTUA = 2000 + A._sendQueue.IPOVERHEAD;
+    const size_t MTUA = 1250 + A._sendQueue.IPOVERHEAD;
     B._sendQueue.setMTU(MTUA);
     B._session->startMtuProbing(_timestamp);
     for (int i = 0; i < 100; ++i)
@@ -201,7 +201,7 @@ TEST_F(SctpTransferTestFixture, mtuDiscovery)
         B.process();
     }
 
-    EXPECT_EQ(B._session->getScptMTU(), 1792);
+    EXPECT_EQ(B._session->getScptMTU(), 1152);
 }
 
 // checks that full cwnd does not prevent data flow

--- a/test/transport/SrtpTest.cpp
+++ b/test/transport/SrtpTest.cpp
@@ -31,7 +31,7 @@ struct FakeSrtpEndpoint : public transport::SslWriteBioListener
         }
     }
 
-    int32_t sendDtls(const char* buffer, int32_t length) override
+    int32_t sendDtls(const char* buffer, uint32_t length) override
     {
         if (transport::isDtlsPacket(buffer))
         {

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -99,20 +99,25 @@ private:
     Endpoint& _endpoint;
 };
 
-struct IceSettings
+struct IceCredentials
 {
-    static const size_t maxCandidateCount = 28;
-
-    // max is actually 256 but usually less
     char ufrag[64];
     char password[128];
+};
+static_assert(sizeof(IceCredentials) < memory::Packet::size, "IceCredentials does not fit into a Packet");
+
+struct IceCandidates
+{
+    static const size_t maxCandidateCount = 10;
     size_t candidateCount = 0;
     ice::IceCandidate candidates[maxCandidateCount];
 };
-static_assert(sizeof(IceSettings) < sizeof(memory::Packet) - sizeof(size_t), "IceSettings does not fit into a Packet");
+static_assert(sizeof(IceCandidates) < memory::Packet::size, "IceCandidates does not fit into a Packet");
 
 class IceSetRemoteJob : public jobmanager::CountedJob
 {
+    static const size_t maxCandidatePackets = 4;
+
 public:
     IceSetRemoteJob(TransportImpl& transport,
         const std::pair<std::string, std::string>& credentials,
@@ -120,31 +125,73 @@ public:
         memory::PacketPoolAllocator& allocator)
         : CountedJob(transport.getJobCounter()),
           _transport(transport),
-          _allocator(allocator)
+          _allocator(allocator),
+          _iceCredentials(nullptr),
+          _iceCandidates{0}
     {
-        _iceSettings = memory::makePacket(allocator);
-        if (!_iceSettings)
+        _iceCredentials = memory::makePacket(allocator);
+        if (!_iceCredentials)
         {
             logger::error("failed to allocate packet", "setRemoteIce");
             return;
         }
-        auto& iceSettings = *reinterpret_cast<IceSettings*>(_iceSettings->get());
+        auto& iceSettings = *reinterpret_cast<IceCredentials*>(_iceCredentials->get());
         utils::strncpy(iceSettings.ufrag, credentials.first.c_str(), sizeof(iceSettings.ufrag));
         utils::strncpy(iceSettings.password, credentials.second.c_str(), sizeof(iceSettings.password));
 
-        for (size_t i = 0; i < IceSettings::maxCandidateCount && i < candidates.size(); ++i)
+        memory::Packet* icePacket = nullptr;
+        for (size_t i = 0; i < candidates.size() && i < maxCandidatePackets * IceCandidates::maxCandidateCount; ++i)
         {
-            iceSettings.candidates[i] = candidates[i];
-            iceSettings.candidateCount = i + 1;
+            if (i % IceCandidates::maxCandidateCount == 0)
+            {
+                icePacket = memory::makePacket(allocator);
+                if (!icePacket)
+                {
+                    logger::error("failed to allocate packet", "setRemoteIce");
+                    return;
+                }
+                _iceCandidates[i / maxCandidatePackets] = icePacket;
+                auto& iceCandidates = *reinterpret_cast<IceCandidates*>(icePacket->get());
+                iceCandidates.candidateCount = 0;
+            }
+            auto& iceCandidates = *reinterpret_cast<IceCandidates*>(icePacket->get());
+            iceCandidates.candidates[i % IceCandidates::maxCandidateCount] = candidates[i];
+            iceCandidates.candidateCount++;
         }
     }
 
-    void run() override { _transport.doSetRemoteIce(_iceSettings, _allocator); }
+    void run() override
+    {
+        if (!_iceCredentials)
+        {
+            return;
+        }
+
+        _transport.doSetRemoteIce(_iceCredentials, _iceCandidates);
+    }
+
+    ~IceSetRemoteJob()
+    {
+        if (_iceCredentials)
+        {
+            _allocator.free(_iceCredentials);
+        }
+
+        for (size_t i = 0; i < maxCandidatePackets; ++i)
+        {
+            if (!_iceCandidates[i])
+            {
+                break;
+            }
+            _allocator.free(_iceCandidates[i]);
+        }
+    }
 
 private:
     TransportImpl& _transport;
     memory::PacketPoolAllocator& _allocator;
-    memory::Packet* _iceSettings;
+    memory::Packet* _iceCredentials;
+    memory::Packet* _iceCandidates[maxCandidatePackets + 1];
 };
 
 struct DtlsCredentials
@@ -1932,17 +1979,24 @@ void TransportImpl::setRemoteIce(const std::pair<std::string, std::string>& cred
     }
 }
 
-void TransportImpl::doSetRemoteIce(memory::Packet* packet, memory::PacketPoolAllocator& allocator)
+void TransportImpl::doSetRemoteIce(const memory::Packet* credentialPacket,
+    const memory::Packet* const* candidatePackets)
 {
-    if (_rtpIceSession && packet)
+    if (!_rtpIceSession)
     {
-        const auto& iceSettings = *reinterpret_cast<IceSettings*>(packet->get());
-        _rtpIceSession->setRemoteCredentials(
-            std::pair<std::string, std::string>(iceSettings.ufrag, iceSettings.password));
+        return;
+    }
 
-        for (size_t i = 0; i < iceSettings.candidateCount && i < _config.ice.maxCandidateCount; ++i)
+    auto& credentials = *reinterpret_cast<const IceCredentials*>(credentialPacket->get());
+    _rtpIceSession->setRemoteCredentials(std::pair<std::string, std::string>(credentials.ufrag, credentials.password));
+
+    uint32_t candidateCount = 0;
+    for (const memory::Packet* const* packetCursor = candidatePackets; *packetCursor; packetCursor++)
+    {
+        auto& iceCandidates = *reinterpret_cast<const IceCandidates*>((*packetCursor)->get());
+        for (size_t i = 0; i < iceCandidates.candidateCount && candidateCount++ < _config.ice.maxCandidateCount; ++i)
         {
-            const ice::IceCandidate& candidate = iceSettings.candidates[i];
+            const ice::IceCandidate& candidate = iceCandidates.candidates[i];
             if (candidate.component == ice::IceComponent::RTP && !candidate.empty())
             {
                 if (candidate.transportType == ice::TransportType::UDP)
@@ -1965,7 +2019,6 @@ void TransportImpl::doSetRemoteIce(memory::Packet* packet, memory::PacketPoolAll
             }
         }
     }
-    allocator.free(packet);
 }
 
 void TransportImpl::setRemoteDtlsFingerprint(const std::string& fingerprintType,
@@ -2149,7 +2202,7 @@ void TransportImpl::onDtlsStateChange(SrtpClient*, const SrtpClient::State state
     }
 }
 
-int32_t TransportImpl::sendDtls(const char* buffer, const int32_t length)
+int32_t TransportImpl::sendDtls(const char* buffer, const uint32_t length)
 {
     assert(length >= 0);
     if (!buffer || length <= 0)
@@ -2165,6 +2218,12 @@ int32_t TransportImpl::sendDtls(const char* buffer, const int32_t length)
     if (buffer[0] != DTLSContentType::applicationData)
     {
         logger::debug("sending DTLS protocol message, %d", _loggableId.c_str(), length);
+    }
+
+    if (length > memory::Packet::size || length > _config.mtu)
+    {
+        logger::error("DTLS message %d exceeds MTU %u", _loggableId.c_str(), length, _config.mtu.get());
+        return 0;
     }
 
     auto packet = memory::makePacket(_mainAllocator, buffer, length);

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -177,7 +177,7 @@ public: // Transport
 
 public: // SslWriteBioListener
     // Called from Transport serial thread
-    int32_t sendDtls(const char* buffer, int32_t length) override;
+    int32_t sendDtls(const char* buffer, uint32_t length) override;
     void onDtlsStateChange(SrtpClient* srtpClient, SrtpClient::State state) override;
 
 public:
@@ -289,7 +289,7 @@ private:
         uint64_t timestamp,
         std::__1::chrono::system_clock::time_point wallClock);
 
-    void doSetRemoteIce(memory::Packet* packet, memory::PacketPoolAllocator& allocator);
+    void doSetRemoteIce(const memory::Packet* credentials, const memory::Packet* const* candidatePackets);
     void doSetRemoteDtls(const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool dtlsClientSide);

--- a/transport/dtls/SslDtls.cpp
+++ b/transport/dtls/SslDtls.cpp
@@ -140,9 +140,9 @@ int32_t writeBioFree(BIO* bio)
 int32_t writeBioWrite(BIO* bio, const char* buffer, int32_t length)
 {
     auto writeBioListener = reinterpret_cast<transport::SslWriteBioListener*>(BIO_get_data(bio));
-    if (writeBioListener)
+    if (writeBioListener && length > 0)
     {
-        return writeBioListener->sendDtls(buffer, length);
+        return writeBioListener->sendDtls(buffer, static_cast<uint32_t>(length));
     }
     return 0;
 }

--- a/transport/dtls/SslWriteBioListener.h
+++ b/transport/dtls/SslWriteBioListener.h
@@ -11,7 +11,7 @@ class SslWriteBioListener
 public:
     virtual ~SslWriteBioListener() = default;
 
-    virtual int32_t sendDtls(const char* buffer, int32_t length) = 0;
+    virtual int32_t sendDtls(const char* buffer, uint32_t length) = 0;
 };
 
 } // namespace transport

--- a/transport/ice/IceCandidate.h
+++ b/transport/ice/IceCandidate.h
@@ -21,6 +21,7 @@ enum class TcpType
     PASSIVE,
     SO
 };
+
 class IceCandidate
 {
 public:


### PR DESCRIPTION
Reduced packet size in packet pools cuts memory usage in half. the packet caches are more numerous and saves most.
Audio specific pool is declared to handle PCM16 packets.