### PR TITLE
Choose a recording endpoint with same ip family than FWD

### DIFF
--- a/bridge/Mixer.cpp
+++ b/bridge/Mixer.cpp
@@ -1829,15 +1829,25 @@ void Mixer::addRecordingTransportsToRecordingStream(RecordingStream* recordingSt
                 channel._aesKey,
                 channel._aesSalt);
 
-            EngineCommand::Command command{EngineCommand::Type::StartRecordingTransport};
-            command._command.startRecordingTransport._mixer = &_engineMixer;
-            command._command.startRecordingTransport._transport = transport.get();
+            if (transport)
+            {
+                EngineCommand::Command command{EngineCommand::Type::StartRecordingTransport};
+                command._command.startRecordingTransport._mixer = &_engineMixer;
+                command._command.startRecordingTransport._transport = transport.get();
 
-            recordingStream->_transports.emplace(endpointIdHash, std::move(transport));
-            recordingStream->_recEventUnackedPacketsTracker.emplace(endpointIdHash,
-                std::make_unique<UnackedPacketsTracker>("RecEventUnackedPacketsTracker", 50));
+                recordingStream->_transports.emplace(endpointIdHash, std::move(transport));
+                recordingStream->_recEventUnackedPacketsTracker.emplace(endpointIdHash,
+                    std::make_unique<UnackedPacketsTracker>("RecEventUnackedPacketsTracker", 50));
 
-            _engine.pushCommand(command);
+                _engine.pushCommand(command);
+            }
+            else
+            {
+                logger::error("Creation of recording transport has failed for channel %s:%u",
+                    _loggableId.c_str(),
+                    channel._host.c_str(),
+                    channel._port);
+            }
         }
     }
 }

--- a/transport/RecordingTransport.cpp
+++ b/transport/RecordingTransport.cpp
@@ -102,6 +102,7 @@ RecordingTransport::RecordingTransport(jobmanager::JobManager& jobManager,
     logger::info("Recording client: %s", _loggableId.c_str(), _peerPort.toString().c_str());
 
     assert(_recordingEndpoint->isGood());
+    assert(recordingEndpoint->getLocalPort().getFamily() == remotePeer.getFamily());
 
     _recordingEndpoint->registerRecordingListener(_peerPort, this);
     ++_jobCounter;
@@ -110,6 +111,14 @@ RecordingTransport::RecordingTransport(jobmanager::JobManager& jobManager,
     _ivGenerator = std::make_unique<crypto::AesGcmIvGenerator>(salt, 12);
 
     _isInitialized = true;
+
+    if (recordingEndpoint->getLocalPort().getFamily() != remotePeer.getFamily())
+    {
+        logger::error("ip family mismatch. local ip family: %d, remote ip family: %d",
+            _loggableId.c_str(),
+            recordingEndpoint->getLocalPort().getFamily(),
+            remotePeer.getFamily());
+    }
 }
 
 bool RecordingTransport::start()

--- a/transport/TransportFactory.cpp
+++ b/transport/TransportFactory.cpp
@@ -374,11 +374,11 @@ public:
         if (!_sharedRecordingEndpoints.empty())
         {
             const uint32_t initialIndex = _sharedRecordingEndpointListIndex.fetch_add(1) % _sharedRecordingEndpoints.size();
-            uint32_t listIdex = initialIndex;
+            uint32_t listIndex = initialIndex;
             do {
-                for (size_t endpointIndex = 0; endpointIndex < _sharedRecordingEndpoints[listIdex].size(); ++endpointIndex)
+                for (size_t endpointIndex = 0; endpointIndex < _sharedRecordingEndpoints[listIndex].size(); ++endpointIndex)
                 {
-                    auto* endpoint = _sharedRecordingEndpoints[listIdex][endpointIndex];
+                    auto* endpoint = _sharedRecordingEndpoints[listIndex][endpointIndex];
                     if (endpoint->getLocalPort().getFamily() == peer.getFamily())
                     {
                         return createRecordingTransport(_jobManager,
@@ -392,9 +392,9 @@ public:
                     }
                 }
 
-                listIdex = (initialIndex + 1) % _sharedRecordingEndpoints.size();
+                listIndex = (listIndex + 1) % _sharedRecordingEndpoints.size();
 
-            } while(listIdex != initialIndex);
+            } while(listIndex != initialIndex);
         }
 
         logger::error("No shared recording endpoints configured", "TransportFactory");

--- a/transport/TransportFactory.cpp
+++ b/transport/TransportFactory.cpp
@@ -40,7 +40,6 @@ public:
           _mainAllocator(mainAllocator),
           _callbackRefCount(0),
           _sharedRecordingEndpointListIndex(0),
-          _nextRecordingEndpointIndex(0),
           _good(true)
     {
 #ifdef __APPLE__
@@ -374,25 +373,32 @@ public:
     {
         if (!_sharedRecordingEndpoints.empty())
         {
-            const uint32_t index = _sharedRecordingEndpointListIndex.fetch_add(1) % _sharedRecordingEndpoints.size();
-            if (_nextRecordingEndpointIndex >= _sharedEndpoints.size())
-            {
-                _nextRecordingEndpointIndex = 0;
-            }
-            return createRecordingTransport(_jobManager,
-                _config,
-                _sharedRecordingEndpoints[index][_nextRecordingEndpointIndex++],
-                endpointHashId,
-                streamHashId,
-                peer,
-                aesKey,
-                salt);
+            const uint32_t initialIndex = _sharedRecordingEndpointListIndex.fetch_add(1) % _sharedRecordingEndpoints.size();
+            uint32_t listIdex = initialIndex;
+            do {
+                for (size_t endpointIndex = 0; endpointIndex < _sharedRecordingEndpoints[listIdex].size(); ++endpointIndex)
+                {
+                    auto* endpoint = _sharedRecordingEndpoints[listIdex][endpointIndex];
+                    if (endpoint->getLocalPort().getFamily() == peer.getFamily())
+                    {
+                        return createRecordingTransport(_jobManager,
+                            _config,
+                            endpoint,
+                            endpointHashId,
+                            streamHashId,
+                            peer,
+                            aesKey,
+                            salt);
+                    }
+                }
+
+                listIdex = (initialIndex + 1) % _sharedRecordingEndpoints.size();
+
+            } while(listIdex != initialIndex);
         }
-        else
-        {
-            logger::error("No shared recording endpoints configured", "TransportFactory");
-            return nullptr;
-        }
+
+        logger::error("No shared recording endpoints configured", "TransportFactory");
+        return nullptr;
     }
 
     bool isGood() const override { return _good; }
@@ -457,7 +463,6 @@ private:
 
     std::vector<std::vector<RecordingEndpoint*>> _sharedRecordingEndpoints;
     std::atomic_uint32_t _sharedRecordingEndpointListIndex;
-    std::atomic_uint32_t _nextRecordingEndpointIndex;
     bool _good;
 };
 

--- a/transport/sctp/SctpAssociationImpl.cpp
+++ b/transport/sctp/SctpAssociationImpl.cpp
@@ -8,7 +8,16 @@
 #include "utils/Time.h"
 #include <set>
 
-#define SCTP_LOG(fmt, ...) // logger::debug(fmt, ##__VA_ARGS__)
+#define SCTP_LOG_ENABLE 0
+
+#if SCTP_LOG_ENABLE
+    #define SCTP_LOG(fmt, ...) logger::debug(fmt, ##__VA_ARGS__)
+#else
+    // silence compiler warnings
+    #define SCTP_LOG(fmt, logId, ...) (void)logId;
+#endif
+
+
 namespace
 {
 utils::MersienneRandom<uint32_t> g_randomGenerator;


### PR DESCRIPTION
smb can open an ipv4 and an ipv6 interface for recording and we were just round robin to choose one interface without care about FWD ip family. This cause empty records since smb couldn't send packets to FWD when the ip family mismatch