### PR TITLE
Fix infinite loop and reduce the lock contention on Mixer deletion 

### DIFF
--- a/bridge/MixerManager.cpp
+++ b/bridge/MixerManager.cpp
@@ -322,7 +322,7 @@ void MixerManager::engineMessageMixerRemoved(const EngineMessage::Message& messa
 {
     // Aims to delete the mixer out of the locker at it can take some time
     // and we want to reduce the lock contention
-    std::__1::unique_ptr<bridge::Mixer> mixer;
+    std::unique_ptr<bridge::Mixer> mixer;
 
     {
         std::lock_guard<std::mutex> locker(_configurationLock);

--- a/bridge/MixerManager.cpp
+++ b/bridge/MixerManager.cpp
@@ -360,7 +360,7 @@ void MixerManager::engineMessageMixerRemoved(const EngineMessage::Message& messa
     }
 
     mixer.reset();
-    logger::info("EngineMixer removed", "MixerManager", mixer->getLoggableId().c_str());
+    logger::info("EngineMixer removed", "MixerManager");
 }
 
 void MixerManager::engineMessageAllocateAudioBuffer(const EngineMessage::Message& message)

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -697,9 +697,9 @@ TransportImpl::~TransportImpl()
     }
     while (!_rtxPacingQueue.empty())
     {
-        auto& info = _pacingQueue.back();
+        auto& info = _rtxPacingQueue.back();
         info.allocator.free(info.packet);
-        _pacingQueue.pop_back();
+        _rtxPacingQueue.pop_back();
     }
 }
 


### PR DESCRIPTION
Sometimes the smb hangs on Mixer deletion and take the MixerManager lock ownership with it.
It was found a potential infinite loop on Transport destructor.
Also we delete the Mixer outside the MixerManager mutex to reduce lock contention as the `Mixer` deletion is a quite heavy operation