### PR TITLE
Remove JobQueue from EngineRecordingStream and use transport jobQueue instead

### DIFF
--- a/bridge/Mixer.cpp
+++ b/bridge/Mixer.cpp
@@ -1705,7 +1705,7 @@ bool Mixer::addOrUpdateRecording(const std::string& conferenceId,
             streamEntry =
                 _recordingStreams
                     .emplace(conferenceId,
-                        std::make_unique<RecordingStream>(conferenceId, std::make_unique<std::atomic_uint32_t>(0)))
+                        std::make_unique<RecordingStream>(conferenceId))
                     .first;
         }
 
@@ -1736,8 +1736,6 @@ bool Mixer::addOrUpdateRecording(const std::string& conferenceId,
                     isAudioEnabled,
                     isVideoEnabled,
                     isScreenSharingEnabled,
-                    _engineMixer.getJobManager(),
-                    *stream->_jobsCounter,
                     *recEventPacketCache));
             _recordingEventPacketCache.emplace(stream->_endpointIdHash, std::move(recEventPacketCache));
 
@@ -1999,7 +1997,7 @@ void Mixer::engineRecordingStreamRemoved(EngineRecordingStream* engineStream)
                           "deletion anyway.",
                 _loggableId.c_str(),
                 stream->_id.c_str(),
-                stream->_jobsCounter->load());
+                transportEntry.second->getJobCounter().load());
         }
     }
 

--- a/bridge/RecordingStream.h
+++ b/bridge/RecordingStream.h
@@ -13,10 +13,9 @@ namespace bridge
 
 struct RecordingStream
 {
-    RecordingStream(const std::string& id, std::unique_ptr<std::atomic_uint32_t> jobsCounter)
+    RecordingStream(const std::string& id)
         : _id(id),
           _endpointIdHash(std::hash<std::string>{}(id)),
-          _jobsCounter(std::move(jobsCounter)),
           _audioActiveRecCount(0),
           _videoActiveRecCount(0),
           _screenSharingActiveRecCount(0),
@@ -28,7 +27,6 @@ struct RecordingStream
     size_t _endpointIdHash;
     std::unordered_map<size_t, std::unique_ptr<transport::RecordingTransport>> _transports;
     std::unordered_map<size_t, std::unique_ptr<bridge::UnackedPacketsTracker>> _recEventUnackedPacketsTracker;
-    std::unique_ptr<std::atomic_uint32_t> _jobsCounter;
 
     uint16_t _audioActiveRecCount;
     uint16_t _videoActiveRecCount;

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -648,8 +648,7 @@ void EngineMixer::recordingStart(EngineRecordingStream* stream, const RecordingD
                           .setUserId(desc->_ownerId)
                           .build();
 
-        stream->_jobQueue.addJob<RecordingSendEventJob>(stream->_jobsCounter,
-            packet,
+        transportEntry.second.getJobQueue().addJob<RecordingSendEventJob>(packet,
             _sendAllocator,
             transportEntry.second,
             stream->_recordingEventsOutboundContext._packetCache,
@@ -682,8 +681,7 @@ void EngineMixer::recordingStop(EngineRecordingStream* stream, const RecordingDe
                           .setUserId(desc->_ownerId)
                           .build();
 
-        stream->_jobQueue.addJob<RecordingSendEventJob>(stream->_jobsCounter,
-            packet,
+        transportEntry.second.getJobQueue().addJob<RecordingSendEventJob>(packet,
             _sendAllocator,
             transportEntry.second,
             stream->_recordingEventsOutboundContext._packetCache,
@@ -1499,7 +1497,7 @@ void EngineMixer::onRecControlReceived(transport::RecordingTransport* sender,
             return;
         }
 
-        stream->_jobQueue.addJob<RecordingEventAckReceiveJob>(packet,
+        sender->getJobQueue().addJob<RecordingEventAckReceiveJob>(packet,
             receiveAllocator,
             sender,
             unackedPacketsTrackerItr->second);
@@ -1514,7 +1512,7 @@ void EngineMixer::onRecControlReceived(transport::RecordingTransport* sender,
             return;
         }
 
-        stream->_jobQueue.addJob<RecordingRtpNackReceiveJob>(packet, receiveAllocator, sender, *ssrcContext);
+        sender->getJobQueue().addJob<RecordingRtpNackReceiveJob>(packet, receiveAllocator, sender, *ssrcContext);
     }
 }
 
@@ -1956,7 +1954,7 @@ void EngineMixer::processIncomingRtpPackets(const uint64_t timestamp)
                 auto packet = memory::makePacket(_sendAllocator, *packetInfo._packet);
 
                 ssrcOutboundContext->onRtpSent(timestamp);
-                if (!recordingStream->_jobQueue.addJob<RecordingAudioForwarderSendJob>(*ssrcOutboundContext,
+                if (!transportEntry.second.getJobQueue().addJob<RecordingAudioForwarderSendJob>(*ssrcOutboundContext,
                         packet,
                         transportEntry.second,
                         packetInfo._extendedSequenceNumber))
@@ -2771,8 +2769,7 @@ void EngineMixer::sendDominantSpeakerToRecordingStream(EngineRecordingStream& re
                           .setDominantSpeakerEndpoint(dominantSpeakerEndpoint)
                           .build();
 
-        recordingStream._jobQueue.addJob<RecordingSendEventJob>(recordingStream._jobsCounter,
-            packet,
+        transportEntry.second.getJobQueue().addJob<RecordingSendEventJob>(packet,
             _sendAllocator,
             transportEntry.second,
             recordingStream._recordingEventsOutboundContext._packetCache,
@@ -2953,8 +2950,7 @@ void EngineMixer::sendRecordingAudioStream(EngineRecordingStream& targetStream,
             }
         }
 
-        targetStream._jobQueue.addJob<RecordingSendEventJob>(targetStream._jobsCounter,
-            packet,
+        transportEntry.second.getJobQueue().addJob<RecordingSendEventJob>(packet,
             _sendAllocator,
             transportEntry.second,
             targetStream._recordingEventsOutboundContext._packetCache,
@@ -3081,8 +3077,7 @@ void EngineMixer::sendRecordingSimulcast(EngineRecordingStream& targetStream,
             }
         }
 
-        targetStream._jobQueue.addJob<RecordingSendEventJob>(targetStream._jobsCounter,
-            packet,
+        transportEntry.second.getJobQueue().addJob<RecordingSendEventJob>(packet,
             _sendAllocator,
             transportEntry.second,
             targetStream._recordingEventsOutboundContext._packetCache,

--- a/bridge/engine/EngineRecordingStream.h
+++ b/bridge/engine/EngineRecordingStream.h
@@ -16,8 +16,6 @@ struct EngineRecordingStream
         bool isAudioEnabled,
         bool isVideoEnabled,
         bool isScreenSharingEnabled,
-        jobmanager::JobManager& jobManager,
-        std::atomic_uint32_t& jobsCounter,
         PacketCache& recordingEventPacketCache)
         : _id(id),
           _endpointIdHash(endpointIdHash),
@@ -28,8 +26,6 @@ struct EngineRecordingStream
           _isReady(false),
           _ssrcOutboundContexts(1024),
           _recordingEventsOutboundContext(recordingEventPacketCache),
-          _jobQueue(jobManager),
-          _jobsCounter(jobsCounter),
           _recEventUnackedPacketsTracker(2)
     {
     }
@@ -44,9 +40,6 @@ struct EngineRecordingStream
 
     concurrency::MpmcHashmap32<uint32_t, SsrcOutboundContext> _ssrcOutboundContexts;
     RecordingOutboundContext _recordingEventsOutboundContext;
-
-    jobmanager::JobQueue _jobQueue;
-    std::atomic_uint32_t& _jobsCounter;
 
     // missing packet trackers per transport peer
     concurrency::MpmcHashmap32<size_t, UnackedPacketsTracker&> _recEventUnackedPacketsTracker;

--- a/bridge/engine/RecordingSendEventJob.cpp
+++ b/bridge/engine/RecordingSendEventJob.cpp
@@ -5,13 +5,12 @@
 namespace bridge
 {
 
-RecordingSendEventJob::RecordingSendEventJob(std::atomic_uint32_t& ownerJobsCounter,
-    memory::Packet* packet,
+RecordingSendEventJob::RecordingSendEventJob(memory::Packet* packet,
     memory::PacketPoolAllocator& allocator,
     transport::RecordingTransport& transport,
     PacketCache& recEventPacketCache,
     UnackedPacketsTracker& unackedPacketsTracker)
-    : CountedJob(ownerJobsCounter),
+    : CountedJob(transport.getJobCounter()),
       _packet(packet),
       _allocator(allocator),
       _transport(transport),

--- a/bridge/engine/RecordingSendEventJob.h
+++ b/bridge/engine/RecordingSendEventJob.h
@@ -21,8 +21,7 @@ class SsrcInboundContext;
 class RecordingSendEventJob : public jobmanager::CountedJob
 {
 public:
-    RecordingSendEventJob(std::atomic_uint32_t& ownerJobsCounter,
-        memory::Packet* packet,
+    RecordingSendEventJob(memory::Packet* packet,
         memory::PacketPoolAllocator& allocator,
         transport::RecordingTransport& transport,
         PacketCache& recEventPacketCache,

--- a/transport/RecordingTransport.h
+++ b/transport/RecordingTransport.h
@@ -67,7 +67,6 @@ private:
         uint64_t reportInterval;
     };
 
-    void doProtectAndSend(memory::Packet* packet, memory::PacketPoolAllocator& sendAllocator);
     uint32_t getRolloverCounter(uint32_t ssrc, uint16_t sequenceNumber);
 
     void sendRtcpSenderReport(memory::PacketPoolAllocator& sendAllocator, uint64_t timestamp);


### PR DESCRIPTION
**Details**
Sometimes the E2E test to Cloud Recording  fails. This is because sometimes SMB does not send the StopRecordingEvent. FWD waits for this event to end the recording until report to CS the recordings that are running and CS force FWD to end the recording because the conference is no longer available. This will create a bigger recording than what is expected.

SMB didn't send the StopRecordingEvent sometimes because `RecordingEngineStream` has it own `JobQueue` to run jobs before handover the packet to `RecordingTransport` and enqueue other job on `RecordingTransport`'s `JobQueue`.
This cause sometimes the `RecordingTransport` to shutdown before the `StopRecordingEvent` has been enqueue in `RecordingTransport`'s `JobQueue`, then that packet is not sent.
To fix the problem we have removed the `JobQueue` of `RecordingEngineStream` as it only increase complexity in the moment of removing `RecordingEngineStream` and create extra context switching. Now we are using directly `JobQueue` of `RecordingTransport` when we need to create a Job in EngineMixer and that will ensure all jobs in the queue are executed before shutdown `RecordingTransport`