### PR TITLE
Olofk/sendtime

### DIFF
--- a/api/Parser.cpp
+++ b/api/Parser.cpp
@@ -312,8 +312,11 @@ EndpointDescription parsePatchEndpoint(const nlohmann::json& data, const std::st
         {
             for (const auto& rtpHdrExtJson : audioJson["rtp-hdrexts"])
             {
-                audioChannel._rtpHeaderExtensions.emplace_back(rtpHdrExtJson["id"].get<uint32_t>(),
-                    rtpHdrExtJson["uri"].get<std::string>());
+                const auto id = rtpHdrExtJson["id"].get<uint32_t>();
+                if (id > 0 && id < 15)
+                {
+                    audioChannel._rtpHeaderExtensions.emplace_back(id, rtpHdrExtJson["uri"].get<std::string>());
+                }
             }
         }
 
@@ -343,8 +346,11 @@ EndpointDescription parsePatchEndpoint(const nlohmann::json& data, const std::st
 
         for (const auto& rtpHdrExtJson : videoJson["rtp-hdrexts"])
         {
-            videoChannel._rtpHeaderExtensions.emplace_back(rtpHdrExtJson["id"].get<uint32_t>(),
-                rtpHdrExtJson["uri"].get<std::string>());
+            const auto id = rtpHdrExtJson["id"].get<uint32_t>();
+            if (id > 0 && id < 15)
+            {
+                videoChannel._rtpHeaderExtensions.emplace_back(id, rtpHdrExtJson["uri"].get<std::string>());
+            }
         }
 
         for (const auto& ssrcGroupJson : videoJson["ssrc-groups"])

--- a/bridge/ApiRequestHandler.cpp
+++ b/bridge/ApiRequestHandler.cpp
@@ -1092,12 +1092,12 @@ void ApiRequestHandler::configureAudioEndpoint(const api::EndpointDescription& e
         remoteSsrc.set(audio._ssrcs.front());
     }
 
-    utils::Optional<int32_t> audioLevelExtensionId;
+    utils::Optional<uint8_t> audioLevelExtensionId;
     for (const auto& rtpHeaderExtension : audio._rtpHeaderExtensions)
     {
         if (rtpHeaderExtension.second.compare("urn:ietf:params:rtp-hdrext:ssrc-audio-level") == 0)
         {
-            audioLevelExtensionId.set(utils::checkedCast<int32_t>(rtpHeaderExtension.first));
+            audioLevelExtensionId.set(utils::checkedCast<uint8_t>(rtpHeaderExtension.first));
         }
     }
 

--- a/bridge/AudioStream.h
+++ b/bridge/AudioStream.h
@@ -24,7 +24,7 @@ struct AudioStream
           _localSsrc(localSsrc),
           _transport(transport),
           _audioLevelExtensionId(-1),
-          _absSendTimeExtensionId(-1),
+          _absSendTimeExtensionId(0),
           _audioMixed(audioMixed),
           _rtpMap(),
           _markedForDeletion(false),
@@ -41,7 +41,7 @@ struct AudioStream
 
     std::shared_ptr<transport::RtcTransport> _transport;
     int32_t _audioLevelExtensionId;
-    int32_t _absSendTimeExtensionId;
+    uint8_t _absSendTimeExtensionId;
     bool _audioMixed;
 
     bridge::RtpMap _rtpMap;

--- a/bridge/LegacyApiRequestHandler.cpp
+++ b/bridge/LegacyApiRequestHandler.cpp
@@ -1126,7 +1126,7 @@ bool LegacyApiRequestHandler::configureChannel(const std::string& contentName,
                 remoteSsrc.set(channel._sources.front());
             }
 
-            utils::Optional<int32_t> audioLevelExtensionId;
+            utils::Optional<uint8_t> audioLevelExtensionId;
             for (const auto& rtpHeaderExtension : channel._rtpHeaderHdrExts)
             {
                 if (rtpHeaderExtension._uri.compare("urn:ietf:params:rtp-hdrext:ssrc-audio-level") == 0)

--- a/bridge/Mixer.cpp
+++ b/bridge/Mixer.cpp
@@ -952,7 +952,7 @@ Mixer::Stats Mixer::getStats()
 bool Mixer::configureAudioStream(const std::string& endpointId,
     const RtpMap& rtpMap,
     const utils::Optional<uint32_t>& remoteSsrc,
-    const utils::Optional<int32_t>& audioLevelExtensionId,
+    const utils::Optional<uint8_t>& audioLevelExtensionId,
     const utils::Optional<uint8_t>& absSendTimeExtensionId)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
@@ -1092,9 +1092,10 @@ bool Mixer::configureVideoStream(const std::string& endpointId,
     {
         videoStream->_secondarySimulcastStream = secondarySimulcastStream;
     }
-    videoStream->_absSendTimeExtensionId = absSendTimeExtensionId;
+
     if (absSendTimeExtensionId.isSet())
     {
+        videoStream->_absSendTimeExtensionId = absSendTimeExtensionId.get();
         videoStream->_transport->setAbsSendTimeExtensionId(absSendTimeExtensionId.get());
     }
 

--- a/bridge/Mixer.h
+++ b/bridge/Mixer.h
@@ -117,7 +117,7 @@ public:
     bool configureAudioStream(const std::string& endpointId,
         const RtpMap& rtpMap,
         const utils::Optional<uint32_t>& remoteSsrc,
-        const utils::Optional<int32_t>& audioLevelExtensionId,
+        const utils::Optional<uint8_t>& audioLevelExtensionId,
         const utils::Optional<uint8_t>& absSendTimeExtensionId);
 
     bool reconfigureAudioStream(const std::string& endpointId, const utils::Optional<uint32_t>& remoteSsrc);

--- a/bridge/VideoStream.h
+++ b/bridge/VideoStream.h
@@ -25,6 +25,7 @@ struct VideoStream
           _localSsrc(localSsrc),
           _simulcastStream{0},
           _transport(transport),
+          _absSendTimeExtensionId(0),
           _markedForDeletion(false),
           _ssrcRewrite(ssrcRewrite),
           _isConfigured(false)
@@ -41,7 +42,7 @@ struct VideoStream
 
     bridge::RtpMap _rtpMap;
     bridge::RtpMap _feedbackRtpMap;
-    utils::Optional<uint8_t> _absSendTimeExtensionId;
+    uint8_t _absSendTimeExtensionId;
 
     SsrcWhitelist _ssrcWhitelist;
 

--- a/bridge/engine/AudioForwarderReceiveJob.cpp
+++ b/bridge/engine/AudioForwarderReceiveJob.cpp
@@ -151,7 +151,7 @@ void AudioForwarderReceiveJob::run()
 
         for (const auto& rtpHeaderExtension : rtpHeaderExtensions->extensions())
         {
-            if (rtpHeaderExtension.id != _ssrcContext._audioLevelExtensionId)
+            if (rtpHeaderExtension.getId() != _ssrcContext._audioLevelExtensionId)
             {
                 continue;
             }

--- a/bridge/engine/EncodeJob.cpp
+++ b/bridge/engine/EncodeJob.cpp
@@ -13,9 +13,9 @@ EncodeJob::EncodeJob(memory::AudioPacket* packet,
     memory::AudioPacketPoolAllocator& allocator,
     SsrcOutboundContext& outboundContext,
     transport::Transport& transport,
-    const uint64_t rtpTimestamp,
-    const int32_t audioLevelExtensionId,
-    int32_t absSendTimeExtensionId)
+    uint64_t rtpTimestamp,
+    uint8_t audioLevelExtensionId,
+    uint8_t absSendTimeExtensionId)
     : jobmanager::CountedJob(transport.getJobCounter()),
       _packet(packet),
       _audioPacketPoolAllocator(allocator),
@@ -24,7 +24,6 @@ EncodeJob::EncodeJob(memory::AudioPacket* packet,
       _rtpTimestamp(rtpTimestamp),
       _audioLevelExtensionId(audioLevelExtensionId),
       _absSendTimeExtensionId(absSendTimeExtensionId)
-
 {
     assert(packet);
     assert(packet->getLength() > 0);
@@ -68,16 +67,12 @@ void EncodeJob::run()
         auto cursor = extensionHead.extensions().begin();
         if (_absSendTimeExtensionId)
         {
-            rtp::GeneralExtension1Byteheader absSendTime;
-            absSendTime.id = 3;
-            absSendTime.setDataLength(3);
+            rtp::GeneralExtension1Byteheader absSendTime(_absSendTimeExtensionId, 3);
             extensionHead.addExtension(cursor, absSendTime);
         }
-        if (_audioLevelExtensionId > 0)
+        if (_audioLevelExtensionId)
         {
-            rtp::GeneralExtension1Byteheader audioLevel;
-            audioLevel.setDataLength(1);
-            audioLevel.id = 1;
+            rtp::GeneralExtension1Byteheader audioLevel(_audioLevelExtensionId, 1);
             audioLevel.data[0] = codec::computeAudioLevel(*_packet);
             extensionHead.addExtension(cursor, audioLevel);
         }

--- a/bridge/engine/EncodeJob.cpp
+++ b/bridge/engine/EncodeJob.cpp
@@ -61,7 +61,7 @@ void EncodeJob::run()
             return;
         }
 
-        auto opusHeader = rtp::RtpHeader::create(opusPacket->get(), memory::Packet::size);
+        auto opusHeader = rtp::RtpHeader::create(*opusPacket);
 
         rtp::RtpHeaderExtension extensionHead(opusHeader->getExtensionHeader());
         auto cursor = extensionHead.extensions().begin();

--- a/bridge/engine/EncodeJob.h
+++ b/bridge/engine/EncodeJob.h
@@ -21,8 +21,8 @@ public:
         SsrcOutboundContext& outboundContext,
         transport::Transport& transport,
         uint64_t rtpTimestamp,
-        int32_t audioLevelExtensionId,
-        int32_t absSendTimeExtensionId);
+        uint8_t audioLevelExtensionId,
+        uint8_t absSendTimeExtensionId);
 
     virtual ~EncodeJob();
 
@@ -34,8 +34,8 @@ private:
     SsrcOutboundContext& _outboundContext;
     transport::Transport& _transport;
     uint64_t _rtpTimestamp;
-    int32_t _audioLevelExtensionId;
-    int32_t _absSendTimeExtensionId;
+    uint8_t _audioLevelExtensionId;
+    uint8_t _absSendTimeExtensionId;
 };
 
 } // namespace bridge

--- a/bridge/engine/EngineAudioStream.h
+++ b/bridge/engine/EngineAudioStream.h
@@ -19,8 +19,8 @@ struct EngineAudioStream
         const uint32_t localSsrc,
         const utils::Optional<uint32_t>& remoteSsrc,
         transport::RtcTransport& transport,
-        const int32_t audioLevelExtensionId,
-        const int32_t absSendTimeExtensionId,
+        const uint8_t audioLevelExtensionId,
+        const uint8_t absSendTimeExtensionId,
         const bool audioMixed,
         const bridge::RtpMap& rtpMap,
         bool ssrcRewrite)
@@ -45,8 +45,8 @@ struct EngineAudioStream
     concurrency::MpmcHashmap32<uint32_t, SsrcOutboundContext> _ssrcOutboundContexts;
 
     transport::RtcTransport& _transport;
-    int32_t _audioLevelExtensionId;
-    int32_t _absSendTimeExtensionId;
+    uint8_t _audioLevelExtensionId;
+    uint8_t _absSendTimeExtensionId;
     bool _audioMixed;
 
     bridge::RtpMap _rtpMap;

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -2429,7 +2429,7 @@ inline void EngineMixer::processAudioStreams()
             return;
         }
 
-        auto rtpHeader = rtp::RtpHeader::create(audioPacket->get(), memory::Packet::size);
+        auto rtpHeader = rtp::RtpHeader::create(*audioPacket);
         rtpHeader->ssrc = audioStream->_localSsrc;
 
         auto payloadStart = rtpHeader->getPayload();

--- a/bridge/engine/EngineVideoStream.h
+++ b/bridge/engine/EngineVideoStream.h
@@ -29,7 +29,7 @@ struct EngineVideoStream
         transport::RtcTransport& transport,
         const bridge::RtpMap& rtpMap,
         const bridge::RtpMap& feedbackRtpMap,
-        const utils::Optional<uint8_t>& absSendTimeExtensionId,
+        const uint8_t absSendTimeExtensionId,
         const SsrcWhitelist& ssrcWhitelist,
         const bool ssrcRewrite,
         const std::vector<SimulcastLevel>& videoPinSsrcs)
@@ -87,7 +87,7 @@ struct EngineVideoStream
     bridge::RtpMap _rtpMap;
     bridge::RtpMap _feedbackRtpMap;
 
-    utils::Optional<uint8_t> _absSendTimeExtensionId;
+    uint8_t _absSendTimeExtensionId;
 
     SsrcWhitelist _ssrcWhitelist;
     bool _ssrcRewrite;

--- a/legacyapi/Parser.cpp
+++ b/legacyapi/Parser.cpp
@@ -275,7 +275,10 @@ Conference parse(const nlohmann::json& data)
                             Channel::RtpHdrExt rtpHdrExt;
                             rtpHdrExt._id = rtpHdrExtJson["id"].get<uint32_t>();
                             rtpHdrExt._uri = rtpHdrExtJson["uri"].get<std::string>();
-                            channel._rtpHeaderHdrExts.emplace_back(std::move(rtpHdrExt));
+                            if (rtpHdrExt._id > 0 && rtpHdrExt._id < 15)
+                            {
+                                channel._rtpHeaderHdrExts.emplace_back(std::move(rtpHdrExt));
+                            }
                         }
                     }
 

--- a/memory/Packet.h
+++ b/memory/Packet.h
@@ -42,6 +42,8 @@ public:
         }
     }
 
+    void clear() { std::memset(_data, 0, size); }
+
 private:
     unsigned char _data[size];
     size_t _length;

--- a/rtp/RtpHeader.cpp
+++ b/rtp/RtpHeader.cpp
@@ -50,15 +50,6 @@ RtpHeader* RtpHeader::fromPtr(void* p, const size_t len)
     return header;
 }
 
-RtpHeader* RtpHeader::create(void* p, const size_t len)
-{
-    assert(len >= MIN_RTP_HEADER_SIZE);
-    auto header = reinterpret_cast<RtpHeader*>(p);
-    std::memset(header, 0, MIN_RTP_HEADER_SIZE);
-    header->version = 2;
-    return header;
-}
-
 size_t RtpHeader::headerLength() const
 {
     const size_t baseHeaderLength = MIN_RTP_HEADER_SIZE + csrcCount * sizeof(u_int32_t);

--- a/rtp/RtpHeader.cpp
+++ b/rtp/RtpHeader.cpp
@@ -139,12 +139,22 @@ const uint8_t* findExtensionsEnd(const uint8_t* data, const uint8_t* dataEnd)
 
 utils::TlvCollectionConst<GeneralExtension1Byteheader> RtpHeaderExtension::extensions() const
 {
+    if (profile.get() != GENERAL1)
+    {
+        return utils::TlvCollectionConst<GeneralExtension1Byteheader>(data, data);
+    }
+
     return utils::TlvCollectionConst<GeneralExtension1Byteheader>(data,
         findExtensionsEnd(data, data + length * sizeof(uint32_t)));
 }
 
 utils::TlvCollection<GeneralExtension1Byteheader> RtpHeaderExtension::extensions()
 {
+    if (profile.get() != GENERAL1)
+    {
+        return utils::TlvCollection<GeneralExtension1Byteheader>(data, data);
+    }
+
     return utils::TlvCollection<GeneralExtension1Byteheader>(data,
         const_cast<uint8_t*>(findExtensionsEnd(data, data + length * sizeof(uint32_t))));
 }

--- a/rtp/RtpHeader.cpp
+++ b/rtp/RtpHeader.cpp
@@ -153,11 +153,7 @@ utils::TlvCollection<GeneralExtension1Byteheader> RtpHeaderExtension::extensions
 bool RtpHeaderExtension::isValid() const
 {
     auto extEnd = findExtensionsEnd(data, data + length * sizeof(uint32_t));
-    if (extEnd == data + length * sizeof(uint32_t))
-    {
-        return true;
-    }
-    else if ((*extEnd & 0xF0) == 0xF0)
+    if (extEnd == data + length * sizeof(uint32_t) || (*extEnd & 0xF0) == 0xF0)
     {
         return true;
     }

--- a/rtp/RtpHeader.h
+++ b/rtp/RtpHeader.h
@@ -7,15 +7,28 @@
 namespace rtp
 {
 
-struct GeneralExtension1Byteheader
+/**
+ * Id of 15 means end of list and and iteration can be aborted
+ */
+class GeneralExtension1Byteheader
 {
-    uint8_t len : 4;
-    uint8_t id : 4;
+    uint8_t _length : 4;
+    uint8_t _id : 4;
 
+public:
     uint8_t data[20];
 
-    GeneralExtension1Byteheader() : len(0), id(0), data{0} { data[0] = 0; }
-    void setDataLength(int length);
+    GeneralExtension1Byteheader(uint8_t extensionId, uint8_t dataLength)
+        : _length(std::max(uint8_t(1), dataLength) - 1),
+          _id(extensionId),
+          data{0}
+    {
+        data[0] = 0;
+    }
+
+    uint8_t getId() const { return _id; }
+    void setDataLength(uint8_t length);
+    uint8_t getDataLength() const;
 
     size_t size() const;
 };
@@ -36,20 +49,15 @@ struct RtpHeaderExtension
     RtpHeaderExtension() : profile(GENERAL1), length(0) { data[0] = 0; }
     explicit RtpHeaderExtension(const RtpHeaderExtension* extensions);
 
-    utils::TlvCollectionConst<GeneralExtension1Byteheader> extensions() const
-    {
-        return utils::TlvCollectionConst<GeneralExtension1Byteheader>(data, data + length * sizeof(uint32_t));
-    }
-
-    utils::TlvCollection<GeneralExtension1Byteheader> extensions()
-    {
-        return utils::TlvCollection<GeneralExtension1Byteheader>(data, data + length * sizeof(uint32_t));
-    }
+    utils::TlvCollectionConst<GeneralExtension1Byteheader> extensions() const;
+    utils::TlvCollection<GeneralExtension1Byteheader> extensions();
 
     size_t size() const { return minSize() + length * sizeof(uint32_t); }
     constexpr static size_t minSize() { return 2 * sizeof(uint16_t); }
     void addExtension(iterator1& cursor, GeneralExtension1Byteheader& extension);
     bool empty() const { return length.get() == 0; }
+
+    bool isValid() const;
 
 private:
     uint8_t data[512];

--- a/rtp/RtpHeader.h
+++ b/rtp/RtpHeader.h
@@ -81,17 +81,29 @@ struct RtpHeader
 
     static RtpHeader* fromPtr(void* p, size_t len);
     inline static const RtpHeader* fromPtr(const void* p, size_t len) { return fromPtr(const_cast<void*>(p), len); }
+
     template <typename PacketType>
     inline static RtpHeader* fromPacket(PacketType& p)
     {
         return fromPtr(p.get(), p.getLength());
     }
+
     template <typename PacketType>
     inline static const RtpHeader* fromPacket(const PacketType& p)
     {
         return fromPtr(p.get(), p.getLength());
     }
-    static RtpHeader* create(void* p, size_t len);
+
+    template <typename PacketType>
+    inline static RtpHeader* create(PacketType& p)
+    {
+        static_assert(PacketType::size >= MIN_RTP_HEADER_SIZE, "Packet too small for RTP header");
+        auto header = reinterpret_cast<RtpHeader*>(p.get());
+        std::memset(header, 0, MIN_RTP_HEADER_SIZE);
+        header->version = 2;
+        return header;
+    }
+
     size_t headerLength() const;
     uint8_t* getPayload() { return reinterpret_cast<uint8_t*>(this) + headerLength(); }
     const uint8_t* getPayload() const { return const_cast<RtpHeader*>(this)->getPayload(); }

--- a/test/bridge/ActiveMediaListTest.cpp
+++ b/test/bridge/ActiveMediaListTest.cpp
@@ -130,7 +130,7 @@ protected:
             *_transport,
             bridge::RtpMap(),
             bridge::RtpMap(),
-            utils::Optional<uint8_t>(),
+            0,
             bridge::SsrcWhitelist({false, 0, {0, 0}}),
             true,
             _videoPinSsrcs);

--- a/test/bridge/Vp8RewriterTest.cpp
+++ b/test/bridge/Vp8RewriterTest.cpp
@@ -45,7 +45,7 @@ TEST_F(Vp8RewriterTest, rewrite)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     rtpHeader->ssrc = 1;
     rtpHeader->sequenceNumber = 1;
     rtpHeader->timestamp = 1;
@@ -96,7 +96,7 @@ TEST_F(Vp8RewriterTest, rewriteRtx)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size - sizeof(uint16_t));
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->getLength());
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     rtpHeader->ssrc = 1;
     rtpHeader->sequenceNumber = 1;
     rtpHeader->timestamp = 1;
@@ -139,7 +139,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveWhenSsrcIsUnchanged)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -210,7 +210,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveWhenSsrcIsChanged)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -282,7 +282,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveWhenSsrcIsChangedSequenceNumberLow
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -354,7 +354,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveIfLastPacketBeforeSwitchIsReordere
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -422,7 +422,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveWhenSsrcIsUnchangedAndSequenceRoll
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -497,7 +497,7 @@ TEST_F(Vp8RewriterTest, countersAreConsecutiveIfLastPacketBeforeSwitchIsReordere
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -579,7 +579,7 @@ TEST_F(Vp8RewriterTest, longGapInSequenceNumbersSameSsrc)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());
@@ -627,7 +627,7 @@ TEST_F(Vp8RewriterTest, longGapInSequenceNumbersNewSsrc)
     auto packet = memory::makePacket(*_allocator);
     packet->setLength(packet->size);
 
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), packet->size);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     auto payload = rtpHeader->getPayload();
     std::array<uint8_t, 6> vp8PayloadDescriptor = {0x90, 0xe0, 0xab, 0xb9, 0xd3, 0x60};
     memcpy(payload, vp8PayloadDescriptor.data(), vp8PayloadDescriptor.size());

--- a/test/bwe/EstimatorTestEasy.cpp
+++ b/test/bwe/EstimatorTestEasy.cpp
@@ -35,7 +35,7 @@ TEST(BweTest, absTimestamp)
 TEST(BweTest, absTimestampExt)
 {
     memory::Packet packet;
-    auto header = rtp::RtpHeader::create(packet.get(), packet.size);
+    auto header = rtp::RtpHeader::create(packet);
     rtp::RtpHeaderExtension ext;
     rtp::GeneralExtension1Byteheader timeExt(4, 3);
     auto cursor = ext.extensions().begin();

--- a/test/bwe/EstimatorTestEasy.cpp
+++ b/test/bwe/EstimatorTestEasy.cpp
@@ -37,9 +37,7 @@ TEST(BweTest, absTimestampExt)
     memory::Packet packet;
     auto header = rtp::RtpHeader::create(packet.get(), packet.size);
     rtp::RtpHeaderExtension ext;
-    rtp::GeneralExtension1Byteheader timeExt;
-    timeExt.id = 4;
-    timeExt.len = 3;
+    rtp::GeneralExtension1Byteheader timeExt(4, 3);
     auto cursor = ext.extensions().begin();
     ext.addExtension(cursor, timeExt);
     header->setExtensions(ext);

--- a/test/bwe/FakeAudioSource.cpp
+++ b/test/bwe/FakeAudioSource.cpp
@@ -42,9 +42,7 @@ memory::Packet* FakeAudioSource::getPacket(uint64_t timestamp)
             _rtpTimestamp += 960;
 
             rtp::RtpHeaderExtension extensionHead(rtpHeader->getExtensionHeader());
-            rtp::GeneralExtension1Byteheader absSendTime;
-            absSendTime.id = 3;
-            absSendTime.setDataLength(3);
+            rtp::GeneralExtension1Byteheader absSendTime(3, 3);
             auto cursor = extensionHead.extensions().begin();
             extensionHead.addExtension(cursor, absSendTime);
             rtpHeader->setExtensions(extensionHead);

--- a/test/bwe/FakeAudioSource.cpp
+++ b/test/bwe/FakeAudioSource.cpp
@@ -41,7 +41,7 @@ memory::Packet* FakeAudioSource::getPacket(uint64_t timestamp)
             rtpHeader->timestamp = _rtpTimestamp;
             _rtpTimestamp += 960;
 
-            rtp::RtpHeaderExtension extensionHead(rtpHeader->getExtensionHeader());
+            rtp::RtpHeaderExtension extensionHead;
             rtp::GeneralExtension1Byteheader absSendTime(3, 3);
             auto cursor = extensionHead.extensions().begin();
             extensionHead.addExtension(cursor, absSendTime);

--- a/test/bwe/FakeAudioSource.cpp
+++ b/test/bwe/FakeAudioSource.cpp
@@ -34,7 +34,7 @@ memory::Packet* FakeAudioSource::getPacket(uint64_t timestamp)
         auto* packet = memory::makePacket(_allocator);
         if (packet)
         {
-            auto rtpHeader = rtp::RtpHeader::create(packet->get(), 100);
+            auto rtpHeader = rtp::RtpHeader::create(*packet);
             rtpHeader->payloadType = _payloadType;
             rtpHeader->sequenceNumber = _sequenceCounter++;
             rtpHeader->ssrc = _ssrc;

--- a/test/bwe/FakeVideoSource.cpp
+++ b/test/bwe/FakeVideoSource.cpp
@@ -56,7 +56,7 @@ memory::Packet* FakeVideoSource::getPacket(uint64_t timestamp)
             rtpHeader->sequenceNumber = _sequenceCounter++;
             rtpHeader->timestamp = _rtpTimestamp;
 
-            rtp::RtpHeaderExtension extensionHead(rtpHeader->getExtensionHeader());
+            rtp::RtpHeaderExtension extensionHead;
             rtp::GeneralExtension1Byteheader absSendTime(3, 3);
             auto cursor = extensionHead.extensions().begin();
             extensionHead.addExtension(cursor, absSendTime);

--- a/test/bwe/FakeVideoSource.cpp
+++ b/test/bwe/FakeVideoSource.cpp
@@ -57,9 +57,7 @@ memory::Packet* FakeVideoSource::getPacket(uint64_t timestamp)
             rtpHeader->timestamp = _rtpTimestamp;
 
             rtp::RtpHeaderExtension extensionHead(rtpHeader->getExtensionHeader());
-            rtp::GeneralExtension1Byteheader absSendTime;
-            absSendTime.id = 3;
-            absSendTime.setDataLength(3);
+            rtp::GeneralExtension1Byteheader absSendTime(3, 3);
             auto cursor = extensionHead.extensions().begin();
             extensionHead.addExtension(cursor, absSendTime);
             rtpHeader->setExtensions(extensionHead);

--- a/test/bwe/FakeVideoSource.cpp
+++ b/test/bwe/FakeVideoSource.cpp
@@ -50,7 +50,7 @@ memory::Packet* FakeVideoSource::getPacket(uint64_t timestamp)
         if (packet)
         {
             packet->setLength(packetSize);
-            auto rtpHeader = rtp::RtpHeader::create(packet->get(), 300);
+            auto rtpHeader = rtp::RtpHeader::create(*packet);
             rtpHeader->ssrc = _ssrc;
             rtpHeader->payloadType = 111;
             rtpHeader->sequenceNumber = _sequenceCounter++;

--- a/test/bwe/RcCall.cpp
+++ b/test/bwe/RcCall.cpp
@@ -78,12 +78,9 @@ void RcCall::sendRtpPadding(uint32_t count, uint32_t ssrc, uint16_t paddingSize)
         {
             std::memset(padPacket->get(), 0, memory::Packet::size);
             padPacket->setLength(paddingSize);
-            auto padRtpHeader = rtp::RtpHeader::create(padPacket->get(), memory::Packet::size);
+            auto padRtpHeader = rtp::RtpHeader::create(*padPacket);
             padRtpHeader->ssrc = ssrc;
             padRtpHeader->payloadType = 96;
-            padRtpHeader->padding = 0;
-            padRtpHeader->marker = 0;
-            padRtpHeader->timestamp = 0;
             padRtpHeader->sequenceNumber = (_mixVideoSendState.getSentSequenceNumber() + 1) & 0xFFFF;
             // fake a really old packet
             reinterpret_cast<uint16_t*>(padRtpHeader->getPayload())[0] =

--- a/test/bwe/RcCall.cpp
+++ b/test/bwe/RcCall.cpp
@@ -76,9 +76,9 @@ void RcCall::sendRtpPadding(uint32_t count, uint32_t ssrc, uint16_t paddingSize)
         auto padPacket = memory::makePacket(_allocator);
         if (padPacket)
         {
-            std::memset(padPacket->get(), 0, memory::Packet::size);
-            padPacket->setLength(paddingSize);
+            padPacket->clear();
             auto padRtpHeader = rtp::RtpHeader::create(*padPacket);
+            padPacket->setLength(paddingSize);
             padRtpHeader->ssrc = ssrc;
             padRtpHeader->payloadType = 96;
             padRtpHeader->sequenceNumber = (_mixVideoSendState.getSentSequenceNumber() + 1) & 0xFFFF;

--- a/test/integration/SampleDataUtils.cpp
+++ b/test/integration/SampleDataUtils.cpp
@@ -166,8 +166,7 @@ struct OpusBuilder : SampleDataUtils::RtpStreamBuilder
             memory::Packet& packet = batch[0];
             memset(packet.get(), 0, memory::Packet::size);
 
-            auto rtpHeader = rtp::RtpHeader::create(packet.get(), packet.size);
-            rtpHeader->version = 2;
+            auto rtpHeader = rtp::RtpHeader::create(packet);
             rtpHeader->payloadType = codec::Opus::payloadType;
             rtpHeader->sequenceNumber = _sequenceNumber;
             rtpHeader->ssrc = _ssrc;

--- a/test/integration/SampleDataUtils.cpp
+++ b/test/integration/SampleDataUtils.cpp
@@ -322,7 +322,7 @@ int audioLevelFromPacket(const memory::Packet& packet)
     auto extensions = rtpHeader->getExtensionHeader()->extensions();
     for (auto extension : extensions)
     {
-        if (extension.id == 1)
+        if (extension.getId() == 1)
         {
             return extension.data[0];
         }

--- a/test/integration/SampleDataUtils.cpp
+++ b/test/integration/SampleDataUtils.cpp
@@ -235,8 +235,7 @@ SampleDataUtils::AudioData SampleDataUtils::decodeOpusRtpStream(const std::vecto
     for (const auto& packet : packets)
     {
         const bool isRtp = rtp::isRtpPacket(packet);
-        const bool isRtcp = rtp::isRtcpPacket(packet);
-        assert(isRtp || isRtcp);
+        assert(isRtp || rtp::isRtcpPacket(packet));
         if (!isRtp)
         {
             continue;

--- a/test/integration/emulator/AudioSource.cpp
+++ b/test/integration/emulator/AudioSource.cpp
@@ -34,7 +34,7 @@ memory::Packet* AudioSource::getPacket(uint64_t timestamp)
     _nextRelease += utils::Time::ms * 20;
 
     auto* packet = memory::makePacket(_allocator);
-    auto rtpHeader = rtp::RtpHeader::create(packet->get(), 100);
+    auto rtpHeader = rtp::RtpHeader::create(*packet);
     rtpHeader->payloadType = 111;
     rtpHeader->sequenceNumber = _sequenceCounter++;
     rtpHeader->ssrc = _ssrc;

--- a/test/integration/emulator/AudioSource.cpp
+++ b/test/integration/emulator/AudioSource.cpp
@@ -54,14 +54,10 @@ memory::Packet* AudioSource::getPacket(uint64_t timestamp)
     rtp::RtpHeaderExtension extensionHead;
     auto cursor = extensionHead.extensions().begin();
 
-    rtp::GeneralExtension1Byteheader absSendTime;
-    absSendTime.id = 3;
-    absSendTime.setDataLength(3);
+    rtp::GeneralExtension1Byteheader absSendTime(3, 3);
     extensionHead.addExtension(cursor, absSendTime);
 
-    rtp::GeneralExtension1Byteheader audioLevel;
-    audioLevel.setDataLength(1);
-    audioLevel.id = 1;
+    rtp::GeneralExtension1Byteheader audioLevel(1, 1);
     audioLevel.data[0] = codec::computeAudioLevel(audio, samplesPerPacket);
     extensionHead.addExtension(cursor, audioLevel);
     rtpHeader->setExtensions(extensionHead);

--- a/test/integration/emulator/AudioSource.cpp
+++ b/test/integration/emulator/AudioSource.cpp
@@ -34,6 +34,12 @@ memory::Packet* AudioSource::getPacket(uint64_t timestamp)
     _nextRelease += utils::Time::ms * 20;
 
     auto* packet = memory::makePacket(_allocator);
+    assert(packet);
+    if (!packet)
+    {
+        return nullptr;
+    }
+
     auto rtpHeader = rtp::RtpHeader::create(*packet);
     rtpHeader->payloadType = 111;
     rtpHeader->sequenceNumber = _sequenceCounter++;

--- a/test/rtp/SendTimeTest.cpp
+++ b/test/rtp/SendTimeTest.cpp
@@ -1,4 +1,4 @@
-
+#include "rtp/RtpHeader.h"
 #include "rtp/SendTimeDial.h"
 #include "utils/Time.h"
 #include <cstdint>
@@ -63,4 +63,125 @@ TEST(RtpSendTimeTest, corner)
 
     sendTimestamp = converter.toAbsoluteTime(512 * 2, utils::Time::ms * 51);
     EXPECT_EQ(sendTimestamp, uint64_t(0));
+}
+
+namespace rtp
+{
+uint32_t nsToSecondsFp6_18(uint64_t timestampNs);
+}
+
+TEST(RtpSendTimeTest, multipleExtensions)
+{
+    const uint8_t absSendTimeId = 3;
+    const uint8_t audioLevelId = 1;
+
+    memory::Packet packet;
+    auto rtpHeader = rtp::RtpHeader::create(packet.get(), 100);
+    rtpHeader->extension = 1;
+    std::memset(rtpHeader->getPayload(), 0xCD, 200);
+
+    rtp::RtpHeaderExtension header;
+    auto cursor = header.extensions().begin();
+    EXPECT_EQ(header.size(), 4);
+
+    rtp::GeneralExtension1Byteheader audioLevel(audioLevelId, 1);
+    audioLevel.data[0] = 122;
+    header.addExtension(cursor, audioLevel);
+    EXPECT_EQ(header.size(), 8);
+
+    rtp::GeneralExtension1Byteheader absSendTime(absSendTimeId, 3);
+    absSendTime.data[0] = 1;
+    absSendTime.data[1] = 2;
+    absSendTime.data[2] = 3;
+    header.addExtension(cursor, absSendTime);
+    EXPECT_EQ(header.size(), 12);
+
+    rtpHeader->setExtensions(header);
+    EXPECT_EQ(rtpHeader->headerLength(), rtp::MIN_RTP_HEADER_SIZE + header.size());
+    EXPECT_NE(rtpHeader->getExtensionHeader(), nullptr);
+    EXPECT_TRUE(rtpHeader->getExtensionHeader()->isValid());
+    packet.setLength(rtpHeader->headerLength());
+
+    auto it = rtpHeader->getExtensionHeader()->extensions().begin();
+    EXPECT_EQ(it->getId(), audioLevelId);
+    EXPECT_EQ(it->getDataLength(), 1);
+
+    ++it;
+    EXPECT_EQ(it->getId(), absSendTimeId);
+    EXPECT_EQ(it->getDataLength(), 3);
+    EXPECT_EQ(it->data[0], 1);
+    EXPECT_EQ(it->data[1], 2);
+    EXPECT_EQ(it->data[2], 3);
+
+    rtp::setTransmissionTimestamp(&packet, absSendTimeId, 0x102030);
+    it = rtpHeader->getExtensionHeader()->extensions().begin();
+    EXPECT_EQ(it->getId(), audioLevelId);
+    EXPECT_EQ(it->data[0], 122);
+    EXPECT_EQ(it->getDataLength(), 1);
+
+    ++it;
+    EXPECT_EQ(it->getId(), absSendTimeId);
+    EXPECT_EQ(it->getDataLength(), 3);
+    const auto expectedData = rtp::nsToSecondsFp6_18(0x102030);
+    EXPECT_EQ(it->data[0], expectedData >> 16);
+    EXPECT_EQ(it->data[1], (expectedData >> 8) & 0xFF);
+    EXPECT_EQ(it->data[2], expectedData & 0xFF);
+
+    EXPECT_TRUE(rtpHeader->getExtensionHeader()->isValid());
+}
+
+TEST(RtpTest, extHeader)
+{
+    const char* rawRtp = "\x90\x6f\x73\x53\x76\xd2\x24\x44\x05\xd2\x09\x1b\xbe\xde\x00\x02"
+                         "\x32\xb2\x78\x66\x10\xaa\x00\x00\x4a\xb2\x78\xb9\x73\x42\xb1\xda"
+                         "\x90\x4b\x5c\x18\x6b\x7f\x89\x61\xc6\xd7\x34\x2d\xf9\xbf\x41\xa9"
+                         "\x8d\x46\x90\x55\xc0\x27\xd1\x61\x06\x21\x06\x1e\xd8\x37\xb7\x46"
+                         "\xcc\xee\x15\x61\xe2\xf0\x25\xe1\x34\x92\xa2\xc1\x92\x3e\x56\x2c"
+                         "\x63\xed\x85\x67\x95\x69\x68\x20\x19\x12\xda\x16\xe8\xca\x69\x7f"
+                         "\x9d\x30\x1e\x1b\x59\x20\x3f\xad\xca\x0e\xef\x17\x08\x6d\x50\xa8"
+                         "\xdf\xf1\xee\x81\x78\xef\x25";
+    memory::Packet packet;
+    std::memcpy(packet.get(), rawRtp, 119);
+    packet.setLength(119);
+    const auto rtpHeader = rtp::RtpHeader::fromPacket(packet);
+
+    EXPECT_TRUE(rtpHeader->getExtensionHeader()->isValid());
+    int count = 0;
+    for (const auto& extension : rtpHeader->getExtensionHeader()->extensions())
+    {
+        ++count;
+        if (count > 2)
+        {
+            EXPECT_EQ(extension.getId(), 0);
+        }
+    }
+    EXPECT_EQ(count, 4);
+
+    EXPECT_EQ(rtpHeader->headerLength(), rtp::MIN_RTP_HEADER_SIZE + 12);
+}
+
+TEST(RtpTest, extHeader15)
+{
+    const char* rawRtp = "\x90\x6f\x73\x53\x76\xd2\x24\x44\x05\xd2\x09\x1b\xbe\xde\x00\x02"
+                         "\x32\xb2\x78\x66\x10\xaa\xF0\x00\x4a\xb2\x78\xb9\x73\x42\xb1\xda"
+                         "\x90\x4b\x5c\x18\x6b\x7f\x89\x61\xc6\xd7\x34\x2d\xf9\xbf\x41\xa9"
+                         "\x8d\x46\x90\x55\xc0\x27\xd1\x61\x06\x21\x06\x1e\xd8\x37\xb7\x46"
+                         "\xcc\xee\x15\x61\xe2\xf0\x25\xe1\x34\x92\xa2\xc1\x92\x3e\x56\x2c"
+                         "\x63\xed\x85\x67\x95\x69\x68\x20\x19\x12\xda\x16\xe8\xca\x69\x7f"
+                         "\x9d\x30\x1e\x1b\x59\x20\x3f\xad\xca\x0e\xef\x17\x08\x6d\x50\xa8"
+                         "\xdf\xf1\xee\x81\x78\xef\x25";
+    memory::Packet packet;
+    std::memcpy(packet.get(), rawRtp, 119);
+    packet.setLength(119);
+    const auto rtpHeader = rtp::RtpHeader::fromPacket(packet);
+
+    EXPECT_TRUE(rtpHeader->getExtensionHeader()->isValid());
+    int count = 0;
+    for (const auto& extension : rtpHeader->getExtensionHeader()->extensions())
+    {
+        ++count;
+        EXPECT_NE(extension.getId(), 0);
+    }
+    EXPECT_EQ(count, 2);
+    EXPECT_EQ(rtpHeader->headerLength(), rtp::MIN_RTP_HEADER_SIZE + 12);
 }

--- a/test/rtp/SendTimeTest.cpp
+++ b/test/rtp/SendTimeTest.cpp
@@ -185,3 +185,25 @@ TEST(RtpTest, extHeader15)
     EXPECT_EQ(count, 2);
     EXPECT_EQ(rtpHeader->headerLength(), rtp::MIN_RTP_HEADER_SIZE + 12);
 }
+
+TEST(RtpTest, extHeader2ByteHeaders)
+{
+    const char* rawRtp = "\x90\x6f\x73\x53\x76\xd2\x24\x44\x05\xd2\x09\x1b\x01\x00\x00\x02"
+                         "\x32\xb2\x78\x66\x10\xaa\xF0\x00\x4a\xb2\x78\xb9\x73\x42\xb1\xda"
+                         "\x90\x4b\x5c\x18\x6b\x7f\x89\x61\xc6\xd7\x34\x2d\xf9\xbf\x41\xa9"
+                         "\x8d\x46\x90\x55\xc0\x27\xd1\x61\x06\x21\x06\x1e\xd8\x37\xb7\x46"
+                         "\xcc\xee\x15\x61\xe2\xf0\x25\xe1\x34\x92\xa2\xc1\x92\x3e\x56\x2c"
+                         "\x63\xed\x85\x67\x95\x69\x68\x20\x19\x12\xda\x16\xe8\xca\x69\x7f"
+                         "\x9d\x30\x1e\x1b\x59\x20\x3f\xad\xca\x0e\xef\x17\x08\x6d\x50\xa8"
+                         "\xdf\xf1\xee\x81\x78\xef\x25";
+    memory::Packet packet;
+    std::memcpy(packet.get(), rawRtp, 119);
+    packet.setLength(119);
+    const auto rtpHeader = rtp::RtpHeader::fromPacket(packet);
+
+    EXPECT_TRUE(rtpHeader->getExtensionHeader()->isValid());
+    const auto extensionCollection = rtpHeader->getExtensionHeader()->extensions();
+
+    EXPECT_EQ(extensionCollection.begin(), extensionCollection.end());
+    EXPECT_EQ(rtpHeader->headerLength(), rtp::MIN_RTP_HEADER_SIZE + 12);
+}

--- a/test/rtp/SendTimeTest.cpp
+++ b/test/rtp/SendTimeTest.cpp
@@ -76,8 +76,7 @@ TEST(RtpSendTimeTest, multipleExtensions)
     const uint8_t audioLevelId = 1;
 
     memory::Packet packet;
-    auto rtpHeader = rtp::RtpHeader::create(packet.get(), 100);
-    rtpHeader->extension = 1;
+    auto rtpHeader = rtp::RtpHeader::create(packet);
     std::memset(rtpHeader->getPayload(), 0xCD, 200);
 
     rtp::RtpHeaderExtension header;

--- a/test/transport/RecordingTransportTest.cpp
+++ b/test/transport/RecordingTransportTest.cpp
@@ -94,9 +94,7 @@ private:
             rtpTimestamp += 16000;
 
             rtp::RtpHeaderExtension extensionHead(rtpHeader->getExtensionHeader());
-            rtp::GeneralExtension1Byteheader absSendTime;
-            absSendTime.id = 3;
-            absSendTime.setDataLength(3);
+            rtp::GeneralExtension1Byteheader absSendTime(3, 3);
             auto cursor = extensionHead.extensions().begin();
             extensionHead.addExtension(cursor, absSendTime);
             rtpHeader->setExtensions(extensionHead);

--- a/test/transport/RecordingTransportTest.cpp
+++ b/test/transport/RecordingTransportTest.cpp
@@ -86,7 +86,7 @@ private:
         auto* packet = memory::makePacket(allocator);
         if (packet)
         {
-            auto rtpHeader = rtp::RtpHeader::create(packet->get(), 100);
+            auto rtpHeader = rtp::RtpHeader::create(*packet);
             rtpHeader->payloadType = rtpPayload;
             rtpHeader->sequenceNumber = counter++;
             rtpHeader->ssrc = rtpSsrc;

--- a/test/transport/RtcTransportTest.cpp
+++ b/test/transport/RtcTransportTest.cpp
@@ -432,7 +432,7 @@ TEST(TransportStats, packetLoss)
     {
         memory::Packet packet;
         packet.setLength(200);
-        auto header = rtp::RtpHeader::create(packet.get(), packet.getLength());
+        auto header = rtp::RtpHeader::create(packet);
 
         header->ssrc = 101;
         header->sequenceNumber = i;
@@ -472,7 +472,7 @@ TEST(TransportStats, outboundLoss)
     for (int i = 0; i < 100; ++i)
     {
         memory::Packet rtpPacket;
-        auto header = rtp::RtpHeader::create(rtpPacket.get(), memory::Packet::size);
+        auto header = rtp::RtpHeader::create(rtpPacket);
         header->ssrc = 6000;
         header->sequenceNumber = i;
         header->payloadType = 8;

--- a/test/transport/RtpTest.cpp
+++ b/test/transport/RtpTest.cpp
@@ -68,7 +68,7 @@ TEST_F(RtcpTest, NTP)
 
     const auto start = utils::Time::getAbsoluteTime();
     memory::Packet p;
-    auto* header = rtp::RtpHeader::create(p.get(), 4000);
+    auto* header = rtp::RtpHeader::create(p);
     header->timestamp = 45000;
     header->sequenceNumber = 1001;
     header->ssrc = 110;
@@ -89,7 +89,7 @@ TEST_F(RtcpTest, SenderReport)
     const auto start = utils::Time::getAbsoluteTime();
     const auto timepoint = std::chrono::system_clock::now();
     memory::Packet p;
-    auto* header = rtp::RtpHeader::create(p.get(), 4000);
+    auto* header = rtp::RtpHeader::create(p);
     header->timestamp = 45000;
     header->sequenceNumber = 1001;
     header->ssrc = 110;
@@ -134,7 +134,7 @@ TEST_F(RtcpTest, padding)
     const auto timepoint = std::chrono::system_clock::now();
     const auto start = utils::Time::getAbsoluteTime();
     memory::Packet p;
-    auto* header = rtp::RtpHeader::create(p.get(), 4000);
+    auto* header = rtp::RtpHeader::create(p);
     header->timestamp = 45000;
     header->sequenceNumber = 1001;
     header->ssrc = 110;

--- a/test/transport/SctpTest.cpp
+++ b/test/transport/SctpTest.cpp
@@ -149,13 +149,9 @@ struct ClientPair : public transport::DataReceiver
             memory::Packet* packet = memory::makePacket(_sendAllocator);
             packet->setLength(160 + rtp::MIN_RTP_HEADER_SIZE);
 
-            auto rtpHeader = reinterpret_cast<rtp::RtpHeader*>(packet->get());
+            auto rtpHeader = rtp::RtpHeader::create(*packet);
             rtpHeader->payloadType = 8;
-            rtpHeader->version = 2;
-            rtpHeader->extension = 0;
             rtpHeader->ssrc = _ssrc;
-            rtpHeader->padding = 0;
-            rtpHeader->marker = 0;
             rtpHeader->sequenceNumber = _sequenceNumber++;
 
             _transport1->getJobQueue().addJob<transport::SendJob>(*_transport1, packet, _sendAllocator);

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1449,7 +1449,7 @@ void TransportImpl::sendPadding(uint64_t timestamp)
         auto padPacket = memory::makePacket(_mainAllocator);
         if (padPacket)
         {
-            std::memset(padPacket->get(), 0, memory::Packet::size);
+            padPacket->clear();
             padPacket->setLength(padding);
             auto padRtpHeader = rtp::RtpHeader::create(*padPacket);
             padRtpHeader->ssrc = _rtxProbeSsrc;
@@ -1461,7 +1461,7 @@ void TransportImpl::sendPadding(uint64_t timestamp)
             if (_absSendTimeExtensionId)
             {
                 padRtpHeader->extension = 1;
-                rtp::RtpHeaderExtension extensionHead(padRtpHeader->getExtensionHeader());
+                rtp::RtpHeaderExtension extensionHead;
                 rtp::GeneralExtension1Byteheader absSendTime(_absSendTimeExtensionId, 3);
                 auto cursor = extensionHead.extensions().begin();
                 extensionHead.addExtension(cursor, absSendTime);

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1451,7 +1451,7 @@ void TransportImpl::sendPadding(uint64_t timestamp)
         {
             std::memset(padPacket->get(), 0, memory::Packet::size);
             padPacket->setLength(padding);
-            auto padRtpHeader = rtp::RtpHeader::create(padPacket->get(), padPacket->getLength());
+            auto padRtpHeader = rtp::RtpHeader::create(*padPacket);
             padRtpHeader->ssrc = _rtxProbeSsrc;
             padRtpHeader->payloadType = rtxPayloadType;
             padRtpHeader->timestamp = 1293887;

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -485,6 +485,7 @@ TransportImpl::TransportImpl(jobmanager::JobManager& jobmanager,
       _outboundSsrcCounters(256),
       _inboundSsrcCounters(16),
       _isRunning(true),
+      _absSendTimeExtensionId(0),
       _sctpConfig(sctpConfig),
       _bwe(std::make_unique<bwe::BandwidthEstimator>(bweConfig)),
       _rateController(_loggableId.getInstanceId(), rateControllerConfig),
@@ -570,6 +571,7 @@ TransportImpl::TransportImpl(jobmanager::JobManager& jobmanager,
       _outboundSsrcCounters(256),
       _inboundSsrcCounters(16),
       _isRunning(true),
+      _absSendTimeExtensionId(0),
       _sctpConfig(sctpConfig),
       _bwe(std::make_unique<bwe::BandwidthEstimator>(bweConfig)),
       _rateController(_loggableId.getInstanceId(), rateControllerConfig),
@@ -882,7 +884,7 @@ void TransportImpl::internalRtpReceived(Endpoint& endpoint,
     }
 
     bool rembReady = false;
-    if (_absSendTimeExtensionId.isSet())
+    if (_absSendTimeExtensionId)
     {
         if (_packetLogger)
         {
@@ -890,7 +892,7 @@ void TransportImpl::internalRtpReceived(Endpoint& endpoint,
         }
         uint32_t absSendTime = 0;
 
-        if (rtp::getTransmissionTimestamp(*packet, _absSendTimeExtensionId.get(), absSendTime))
+        if (rtp::getTransmissionTimestamp(*packet, _absSendTimeExtensionId, absSendTime))
         {
             rembReady = doBandwidthEstimation(timestamp, utils::Optional<uint32_t>(absSendTime), packet->getLength());
         }
@@ -1456,13 +1458,11 @@ void TransportImpl::sendPadding(uint64_t timestamp)
             padRtpHeader->sequenceNumber = (*_rtxProbeSequenceCounter)++ & 0xFFFF;
             padRtpHeader->padding = 1;
             padPacket->get()[padPacket->getLength() - 1] = 0x01;
-            if (_absSendTimeExtensionId.isSet())
+            if (_absSendTimeExtensionId)
             {
                 padRtpHeader->extension = 1;
                 rtp::RtpHeaderExtension extensionHead(padRtpHeader->getExtensionHeader());
-                rtp::GeneralExtension1Byteheader absSendTime;
-                absSendTime.id = _absSendTimeExtensionId.get();
-                absSendTime.setDataLength(3);
+                rtp::GeneralExtension1Byteheader absSendTime(_absSendTimeExtensionId, 3);
                 auto cursor = extensionHead.extensions().begin();
                 extensionHead.addExtension(cursor, absSendTime);
                 padRtpHeader->setExtensions(extensionHead);
@@ -1574,9 +1574,9 @@ void TransportImpl::protectAndSendRtp(uint64_t timestamp,
     const auto isAudio = (payloadType <= 8 || payloadType == _audio.payloadType);
     const uint32_t rtpFrequency = isAudio ? _audio.rtpFrequency : 90000;
 
-    if (_absSendTimeExtensionId.isSet())
+    if (_absSendTimeExtensionId)
     {
-        rtp::setTransmissionTimestamp(packet, _absSendTimeExtensionId.get(), timestamp);
+        rtp::setTransmissionTimestamp(packet, _absSendTimeExtensionId, timestamp);
     }
 
     auto& ssrcState = getOutboundSsrc(rtpHeader->ssrc, rtpFrequency);
@@ -2247,9 +2247,12 @@ void TransportImpl::setAudioPayloadType(uint8_t payloadType, uint32_t rtpFrequen
     _audio.rtpFrequency = rtpFrequency;
 }
 
+/**
+ * extension id = 0 means off
+ */
 void TransportImpl::setAbsSendTimeExtensionId(uint8_t extensionId)
 {
-    _absSendTimeExtensionId.set(extensionId);
+    _absSendTimeExtensionId = extensionId;
 }
 
 uint16_t TransportImpl::allocateOutboundSctpStream()

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -367,7 +367,7 @@ private:
         uint8_t payloadType;
         uint32_t rtpFrequency;
     } _audio;
-    utils::Optional<uint8_t> _absSendTimeExtensionId;
+    uint8_t _absSendTimeExtensionId;
 
     const sctp::SctpConfig& _sctpConfig;
     utils::Optional<uint16_t> _remoteSctpPort;


### PR DESCRIPTION
RTC-12618
absSendTime was not set when not first hdr ext in packet.
Parsing of hdr ext could fail.
Invalid ext ids were allowed