### PR TITLE
fix ice map full

### DIFF
--- a/test/transport/IceTest.cpp
+++ b/test/transport/IceTest.cpp
@@ -360,6 +360,9 @@ public:
     {
         _socket.sendTo(static_cast<const char*>(data), len, target);
     }
+
+    void cancelStunTransaction(__uint128_t transactionId) override {}
+
     transport::SocketAddress getLocalPort() const override { return _ip; }
     ice::TransportType getTransportType() const override { return ice::TransportType::UDP; }
     transport::RtcSocket _socket;
@@ -521,6 +524,8 @@ public:
         const void* data,
         size_t len,
         uint64_t timestamp) override;
+    void cancelStunTransaction(__uint128_t transactionId) override {}
+
     transport::SocketAddress getLocalPort() const override { return _address; }
     bool hasIp(const transport::SocketAddress& target) override { return target == _address; }
 

--- a/transport/RecordingEndpoint.h
+++ b/transport/RecordingEndpoint.h
@@ -35,6 +35,8 @@ public:
         assert(false);
     };
 
+    void cancelStunTransaction(__uint128_t transactionId) override { assert(false); }
+
     void registerListener(const std::string& stunUserName, IEvents* listener) override { assert(false); };
     void registerListener(const SocketAddress& remotePort, IEvents* listener) override { assert(false); };
 

--- a/transport/RtpReceiveState.h
+++ b/transport/RtpReceiveState.h
@@ -2,6 +2,7 @@
 
 #include "concurrency/MpmcPublish.h"
 #include "transport/PacketCounters.h"
+#include "utils/SocketAddress.h"
 #include <algorithm>
 
 namespace memory
@@ -46,6 +47,7 @@ public:
     int64_t timeToReceiveReport(uint64_t timestamp) const;
 
     std::atomic_uint8_t payloadType;
+    SocketAddress currentRtpSource;
 
     struct ReceiveCounters
     {

--- a/transport/TcpEndpoint.h
+++ b/transport/TcpEndpoint.h
@@ -100,6 +100,7 @@ public:
     void closePort() override;
 
     SocketAddress getLocalPort() const override { return _socket.getBoundPort(); }
+    void cancelStunTransaction(__uint128_t transactionId) override{};
 
     bool configureBufferSizes(size_t sendBufferSize, size_t receiveBufferSize) override;
 

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -911,6 +911,12 @@ void TransportImpl::internalRtpReceived(Endpoint& endpoint,
     auto& ssrcState = getInboundSsrc(ssrc); // will do nothing if already exists
     ssrcState.onRtpReceived(*packet, timestamp);
 
+    if (ssrcState.currentRtpSource != source)
+    {
+        logger::debug("RTP from %s", _loggableId.c_str(), source.toString().c_str());
+        ssrcState.currentRtpSource = source;
+    }
+
     const uint32_t extendedSequenceNumber = ssrcState.getExtendedSequenceNumber() -
         static_cast<int16_t>(
             static_cast<uint16_t>(ssrcState.getExtendedSequenceNumber() & 0xFFFFu) - rtpHeader->sequenceNumber.get());
@@ -931,7 +937,7 @@ void TransportImpl::onDtlsReceived(Endpoint& endpoint,
             allocator,
             &TransportImpl::internalDtlsReceived))
     {
-        logger::error("job queue full DTLS", _loggableId.c_str());
+        logger::warn("job queue full DTLS", _loggableId.c_str());
         allocator.free(packet);
     }
 }
@@ -955,7 +961,10 @@ void TransportImpl::internalDtlsReceived(Endpoint& endpoint,
     }
     else
     {
-        logger::debug("received DTLS protocol message, %zu", _loggableId.c_str(), packet->getLength());
+        logger::debug("received DTLS protocol message from %s, %zu",
+            _loggableId.c_str(),
+            source.toString().c_str(),
+            packet->getLength());
         _srtpClient->onMessageReceived(reinterpret_cast<const char*>(packet->get()), packet->getLength());
     }
 
@@ -975,7 +984,7 @@ void TransportImpl::onRtcpReceived(Endpoint& endpoint,
             allocator,
             &TransportImpl::internalRtcpReceived))
     {
-        logger::error("job queue full RTCP", _loggableId.c_str());
+        logger::warn("job queue full RTCP", _loggableId.c_str());
         allocator.free(packet);
     }
 }
@@ -1219,7 +1228,7 @@ RtpReceiveState& TransportImpl::getInboundSsrc(const uint32_t ssrc)
                 nominee = it;
             }
         }
-        logger::info("unexpected number of inbound streams. Discarding %u", _loggableId.c_str(), nominee->first);
+        logger::warn("unexpected number of inbound streams. Discarding %u", _loggableId.c_str(), nominee->first);
         _inboundSsrcCounters.erase(nominee->first);
 
         auto pairIt = _inboundSsrcCounters.emplace(ssrc, _config);

--- a/transport/UdpEndpoint.cpp
+++ b/transport/UdpEndpoint.cpp
@@ -25,6 +25,22 @@ private:
     UdpEndpoint& _endpoint;
     Endpoint::IEvents* _listener;
 };
+
+class UnRegisterStunListenerJob : public jobmanager::Job
+{
+public:
+    UnRegisterStunListenerJob(UdpEndpoint& endpoint, __uint128_t transactionId)
+        : _endpoint(endpoint),
+          _transactionId(transactionId)
+    {
+    }
+
+    void run() override { _endpoint.internalUnregisterStunListener(_transactionId); }
+
+private:
+    UdpEndpoint& _endpoint;
+    __uint128_t _transactionId;
+};
 } // namespace
 
 // When this endpoint is shared the number of registration jobs and packets in queue will be plenty
@@ -49,7 +65,7 @@ void UdpEndpoint::sendStunTo(const transport::SocketAddress& target,
     uint64_t timestamp)
 {
     auto* msg = ice::StunMessage::fromPtr(data);
-    if (msg->header.isRequest() && _iceResponseListeners.find(transactionId) == _iceResponseListeners.cend())
+    if (msg->header.isRequest() && !_iceResponseListeners.contains(transactionId) && !_dtlsListeners.contains(target))
     {
         auto names = msg->getAttribute<ice::StunUserName>(ice::StunAttribute::USERNAME);
         if (names)
@@ -59,7 +75,11 @@ void UdpEndpoint::sendStunTo(const transport::SocketAddress& target,
             if (it != _iceListeners.cend())
             {
                 assert(it->second);
-                _iceResponseListeners.emplace(transactionId, it->second);
+                auto pair = _iceResponseListeners.emplace(transactionId, it->second);
+                if (!pair.second)
+                {
+                    logger::warn("Pending ICE request lookup table is full", _name.c_str());
+                }
             }
         }
     }
@@ -71,6 +91,14 @@ void UdpEndpoint::unregisterListener(IEvents* listener)
     if (!_receiveJobs.addJob<UnRegisterListenerJob>(*this, listener))
     {
         logger::error("failed to post unregister job", _name.c_str());
+    }
+}
+
+void UdpEndpoint::cancelStunTransaction(__uint128_t transactionId)
+{
+    if (!_receiveJobs.addJob<UnRegisterStunListenerJob>(*this, transactionId))
+    {
+        logger::error("failed to post unregister stun job", _name.c_str());
     }
 }
 
@@ -103,6 +131,12 @@ void UdpEndpoint::internalUnregisterListener(IEvents* listener)
     }
 
     listener->onUnregistered(*this);
+}
+
+void UdpEndpoint::internalUnregisterStunListener(__uint128_t transactionId)
+{
+    // Hashmap allows erasing elements while iterating.
+    _iceResponseListeners.erase(transactionId);
 }
 
 namespace
@@ -142,9 +176,11 @@ void UdpEndpoint::dispatchReceivedPacket(const SocketAddress& srcAddress, memory
             listener = findListener(_iceResponseListeners, transactionId);
             if (listener)
             {
-                // TODO there is still risk of depletion as not all transactions are responded to.
-                // Only when channel is brought down will it clear its transaction listeners
                 _iceResponseListeners.erase(transactionId);
+            }
+            else
+            {
+                listener = findListener(_dtlsListeners, srcAddress);
             }
         }
         if (listener)
@@ -204,7 +240,7 @@ void UdpEndpoint::registerListener(const std::string& stunUserName, IEvents* lis
     _iceListeners.emplace(stunUserName, listener);
 }
 
-// If using ICE, must be called from receive job queue to sync unregister
+/** If using ICE, must be called from receive job queue to sync unregister */
 void UdpEndpoint::registerListener(const SocketAddress& srcAddress, IEvents* listener)
 {
     auto dtlsIt = _dtlsListeners.find(srcAddress);

--- a/transport/UdpEndpoint.cpp
+++ b/transport/UdpEndpoint.cpp
@@ -71,8 +71,7 @@ void UdpEndpoint::sendStunTo(const transport::SocketAddress& target,
         if (names)
         {
             auto localUser = names->getNames().second;
-            auto it = _iceListeners.find(localUser);
-            if (it != _iceListeners.cend())
+            if (_iceListeners.contains(localUser))
             {
                 assert(it->second);
                 auto pair = _iceResponseListeners.emplace(transactionId, it->second);

--- a/transport/UdpEndpoint.cpp
+++ b/transport/UdpEndpoint.cpp
@@ -53,7 +53,7 @@ UdpEndpoint::UdpEndpoint(jobmanager::JobManager& jobManager,
     bool isShared)
     : BaseUdpEndpoint("UdpEndpoint", jobManager, maxSessionCount, allocator, localPort, epoll, isShared),
       _iceListeners(maxSessionCount),
-      _dtlsListeners(maxSessionCount),
+      _dtlsListeners(maxSessionCount * 8),
       _iceResponseListeners(maxSessionCount * 4)
 {
 }
@@ -71,7 +71,8 @@ void UdpEndpoint::sendStunTo(const transport::SocketAddress& target,
         if (names)
         {
             auto localUser = names->getNames().second;
-            if (_iceListeners.contains(localUser))
+            auto it = _iceListeners.find(localUser);
+            if (it != _iceListeners.cend())
             {
                 assert(it->second);
                 auto pair = _iceResponseListeners.emplace(transactionId, it->second);

--- a/transport/UdpEndpoint.h
+++ b/transport/UdpEndpoint.h
@@ -22,6 +22,8 @@ public:
         size_t len,
         uint64_t timestamp) override;
 
+    void cancelStunTransaction(__uint128_t transactionId) override;
+
     void registerListener(const std::string& stunUserName, IEvents* listener) override;
     void registerListener(const SocketAddress& remotePort, IEvents* listener) override;
 
@@ -31,6 +33,7 @@ public: // internal job interface
     void dispatchReceivedPacket(const SocketAddress& srcAddress, memory::Packet* packet) override;
 
     void internalUnregisterListener(IEvents* listener);
+    void internalUnregisterStunListener(__uint128_t transactionId);
 
 private:
     concurrency::MpmcHashmap32<std::string, IEvents*> _iceListeners;

--- a/transport/ice/IceSession.cpp
+++ b/transport/ice/IceSession.cpp
@@ -659,7 +659,7 @@ void IceSession::onPacketReceived(IceEndpoint* socketEndpoint,
     {
         if (!msg->isValid())
         {
-            logger::debug("corrupt STUN response from %s", _logId.c_str(), sender.toString().c_str());
+            logger::debug("corrupt ICE response from %s", _logId.c_str(), sender.toString().c_str());
             return;
         }
         onResponseReceived(socketEndpoint, sender, *msg, timestamp);

--- a/transport/ice/IceSession.cpp
+++ b/transport/ice/IceSession.cpp
@@ -1007,7 +1007,7 @@ void IceSession::generateCredentialString(char* targetBuffer, int length)
                                   "abcdefghijklmnopqrstuvwxyz"
                                   "0123456789"
                                   "+/";
-    const int COUNT = strlen(approvedLetters);
+    const int COUNT = std::strlen(approvedLetters);
     __uint64_t id = 0;
     for (int i = 0; i < length; i++)
     {
@@ -1153,7 +1153,7 @@ void IceSession::CandidatePair::send(const uint64_t now)
         state = InProgress;
     }
     _transactions.push_back(transaction);
-    if (_transactions.size() > 25)
+    if (_transactions.size() > 10)
     {
         if (localEndpoint.endpoint)
         {

--- a/transport/ice/IceSession.cpp
+++ b/transport/ice/IceSession.cpp
@@ -457,6 +457,7 @@ void IceSession::onRequestReceived(IceEndpoint* endpoint,
         }
     }
 
+    logger::debug("probe from %s", _logId.c_str(), sender.toString().c_str());
     sendResponse(endpoint, sender, 0, msg, now);
     if (_eventSink)
     {
@@ -602,6 +603,8 @@ void IceSession::onResponseReceived(IceEndpoint* endpoint,
     {
         return;
     }
+
+    logger::debug("response from %s", _logId.c_str(), sender.toString().c_str());
 
     if (candidatePair->localCandidate.address != mappedAddress)
     {
@@ -1150,8 +1153,16 @@ void IceSession::CandidatePair::send(const uint64_t now)
         state = InProgress;
     }
     _transactions.push_back(transaction);
-    if (_transactions.size() > 50)
+    if (_transactions.size() > 25)
     {
+        if (localEndpoint.endpoint)
+        {
+            auto& frontTransaction = _transactions.front();
+            if (!frontTransaction.acknowledged())
+            {
+                localEndpoint.endpoint->cancelStunTransaction(frontTransaction.id.get());
+            }
+        }
         _transactions.erase(_transactions.begin());
     }
 
@@ -1200,6 +1211,7 @@ void IceSession::CandidatePair::onResponse(uint64_t now, const StunMessage& resp
         }
         else
         {
+            failCandidate();
             state = CandidatePair::Failed;
             errorCode = static_cast<IceError>(errorAttribute->getCode());
             ++replies;
@@ -1215,7 +1227,7 @@ void IceSession::CandidatePair::onResponse(uint64_t now, const StunMessage& resp
 
 void IceSession::CandidatePair::onDisconnect()
 {
-    state = CandidatePair::Failed;
+    failCandidate();
     errorCode = IceError::ConnectionTimeoutOrFailure;
     return;
 }
@@ -1230,6 +1242,29 @@ void IceSession::CandidatePair::nominate(uint64_t now)
 void IceSession::CandidatePair::freeze()
 {
     state = State::Frozen;
+    cancelPendingTransactions();
+}
+
+void IceSession::CandidatePair::failCandidate()
+{
+    state = State::Failed;
+    cancelPendingTransactions();
+}
+
+void IceSession::CandidatePair::cancelPendingTransactions()
+{
+    if (localEndpoint.endpoint)
+    {
+        return;
+    }
+    for (auto& transaction : _transactions)
+    {
+        if (!transaction.acknowledged())
+        {
+            localEndpoint.endpoint->cancelStunTransaction(transaction.id.get());
+        }
+    }
+    _transactions.clear();
 }
 
 bool IceSession::CandidatePair::isRecent(uint64_t now) const
@@ -1250,7 +1285,7 @@ void IceSession::CandidatePair::processTimeout(const uint64_t now)
     }
     if (gatheringProbe && state == InProgress && now - startTime > _config.gather.probeTimeout * utils::Time::ms)
     {
-        state = Failed;
+        failCandidate();
         errorCode = IceError::RequestTimeout;
         return;
     }
@@ -1269,11 +1304,11 @@ void IceSession::CandidatePair::processTimeout(const uint64_t now)
         if (remoteCandidate.type == IceCandidate::Type::HOST &&
             now - startTime > _config.hostProbeTimeout * utils::Time::ms)
         {
-            state = Failed;
+            failCandidate();
         }
         else if (now - startTime > _config.reflexiveProbeTimeout * utils::Time::ms)
         {
-            state = Failed;
+            failCandidate();
         }
     }
 }

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -43,6 +43,7 @@ public:
 
     virtual ice::TransportType getTransportType() const = 0;
     virtual transport::SocketAddress getLocalPort() const = 0;
+    virtual void cancelStunTransaction(__uint128_t transactionId) = 0;
 };
 
 enum class IceRole
@@ -183,6 +184,8 @@ private:
         StunTransactionId id;
         uint64_t time = 0;
         uint64_t rtt = 0;
+
+        bool acknowledged() const { return rtt != 0; }
     };
 
     class CandidatePair
@@ -215,6 +218,8 @@ private:
         void onDisconnect();
         void nominate(uint64_t now);
         void freeze();
+        void failCandidate();
+
         uint64_t getRtt() const;
         std::string getLoggableId() const;
 
@@ -241,6 +246,8 @@ private:
         StunMessage original;
 
     private:
+        void cancelPendingTransactions();
+
         const std::string& _name;
         std::vector<StunTransaction> _transactions; // TODO replace with inplace circular container
         StunTransactionIdGenerator& _idGenerator;


### PR DESCRIPTION
RTC-12666 TCP Fallback during load
Fix for this. Main problem was that pending stun transaction map in UdpEndpoint became full. It is cleared at call shutdown but all failed candidates will create a number of transactions that are not cleared until end of call.
The fix is that stun requests, that will result in responses from ports that are routed anyway to the transport, do not need to be tracked by transacation id. Also, all transactions are cleaned up and earlier.