### PR TITLE
Change srtp status to FAILED when dtls get a fatal error

### DIFF
--- a/transport/dtls/SrtpClient.cpp
+++ b/transport/dtls/SrtpClient.cpp
@@ -261,7 +261,7 @@ int64_t SrtpClient::processTimeout()
         // may be used to determine if the retransmit failed due to a non-fatal error at the write BIO.
         // However, the operation may not be retried until the next timeout fires
         const auto err = SSL_get_error(_ssl, rc);
-        const bool isFatalError = err != SSL_ERROR_WANT_WRITE;
+        const bool isFatalError = (err != SSL_ERROR_WANT_WRITE);
 
         logger::error("DTLS timeout error %s ,isFatal: %s", _loggableId.c_str(), getErrorMessage(err), isFatalError ? "t" : "f");
         if (isFatalError)


### PR DESCRIPTION
When `DTLSv1_handle_timeout` return a fatal error we should abort the timeout checking and change state to FAIL.
Otherwise we can end up in an infinite loop to check timeouts each millisecond

There are two examples of this issue in PROD.

- SrtpClient-32824: Has performed almost 450K timeout check cycles
 https://symphony.splunkcloud.com/en-GB/app/symphony_rtc/search?earliest=1647021600&latest=1647028800&q=search%20index%3Dsym_prod_rtc%20host%3Dsym-mt-stage-mbr-*%20%22%5BSrtpClient-32824%5D%20DTLS%20timeout%20error%22&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&sid=1649325924.1276016

- SrtpClient-96389: Has performed almost 900K timeout check cycles
https://symphony.splunkcloud.com/en-GB/app/symphony_rtc/search?earliest=1648684800&latest=1648771200&q=search%20index%3Dsym_prod_rtc%20host%3Dsym-mt-stage-mbr-*%20%22%5BSrtpClient-96389%5D%20DTLS%20timeout%20error%20SSL%22&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&sid=1649325844.1275884