### PR TITLE
switch in unmuted faster

### DIFF
--- a/bridge/engine/ActiveMediaList.h
+++ b/bridge/engine/ActiveMediaList.h
@@ -156,7 +156,6 @@ private:
 
         int32_t _totalLevelLongWindow;
         int32_t _totalLevelShortWindow;
-        int32_t _nonZeroLevelsLongWindow;
         int32_t _nonZeroLevelsShortWindow;
         float _maxRecentLevel;
         float _noiseLevel;
@@ -218,6 +217,8 @@ private:
     uint64_t _lastRunTimestampMs;
     uint64_t _lastChangeTimestampMs;
 
+    size_t rankSpeakers(float& currentDominantSpeakerScore);
+    void updateLevels(const uint64_t timestampMs);
     void updateActiveAudioList(size_t endpointIdHash);
     bool updateActiveVideoList(const size_t endpointIdHash);
 };

--- a/memory/PriorityQueue.h
+++ b/memory/PriorityQueue.h
@@ -52,7 +52,7 @@ public:
         --_nextFree;
     }
 
-    bool isEmpty() const { return _nextFree == 0; }
+    bool empty() const { return _nextFree == 0; }
     void clear() { _nextFree = 0; }
 
 private:

--- a/test/memory/PriorityQueueTest.cpp
+++ b/test/memory/PriorityQueueTest.cpp
@@ -50,7 +50,7 @@ TEST_F(PriorityQueueTest, popRemovesMax)
     EXPECT_EQ(1, priorityQueue.top());
 
     priorityQueue.pop();
-    EXPECT_TRUE(priorityQueue.isEmpty());
+    EXPECT_TRUE(priorityQueue.empty());
 }
 
 TEST_F(PriorityQueueTest, pushPop)
@@ -80,5 +80,5 @@ TEST_F(PriorityQueueTest, pushPop)
         priorityQueue.pop();
     }
 
-    EXPECT_TRUE(priorityQueue.isEmpty());
+    EXPECT_TRUE(priorityQueue.empty());
 }


### PR DESCRIPTION
Refactored a bit.
Switching conditions unmuted (>2s) speakers is same as before.
Recently unmuted participants can bargein faster as their score does not have to build up over 2s.