### PR TITLE
Turn off Bandwidth Estimation for audio-only calls

### DIFF
--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -272,7 +272,6 @@ private:
         const SocketAddress& target,
         Endpoint* endpoint);
     void sendPadding(uint64_t timestamp);
-    void sendRtcpPadding(uint64_t timestamp, uint32_t ssrc, uint16_t nextPacketSize);
 
     void processRtcpReport(const rtp::RtcpHeader& packet,
         uint64_t timestamp,

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -303,7 +303,7 @@ private:
     RtpSenderState& getOutboundSsrc(uint32_t ssrc, uint32_t rtpFrequency);
 
     void onTransportConnected();
-    void drainPacingBuffer(uint64_t timestamp);
+    void drainPacingBuffer(uint64_t timestamp, bool useEstimatedBudget = true);
     inline memory::UniquePacket tryFetchPriorityPacket(size_t budget);
 
     std::atomic_bool _isInitialized;

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -41,6 +41,9 @@ struct SctpConfig;
 
 namespace transport
 {
+
+typedef memory::RandomAccessBacklog<memory::UniquePacket, 512> pacing_queue_t;
+
 class TransportImpl : public RtcTransport,
                       private SslWriteBioListener,
                       public Endpoint::IEvents,
@@ -301,6 +304,8 @@ private:
     RtpSenderState& getOutboundSsrc(uint32_t ssrc, uint32_t rtpFrequency);
 
     void onTransportConnected();
+    void drainPacingBuffer(uint64_t timestamp);
+    inline memory::UniquePacket tryFetchPriorityPacket(size_t budget);
 
     std::atomic_bool _isInitialized;
     logger::LoggableId _loggableId;
@@ -388,8 +393,8 @@ private:
     uint32_t _rtxProbeSsrc;
     uint32_t* _rtxProbeSequenceCounter;
 
-    memory::RandomAccessBacklog<memory::UniquePacket, 512> _pacingQueue;
-    memory::RandomAccessBacklog<memory::UniquePacket, 512> _rtxPacingQueue;
+    pacing_queue_t _pacingQueue;
+    pacing_queue_t _rtxPacingQueue;
     std::atomic_bool _pacingInUse;
 
     std::unique_ptr<logger::PacketLoggerThread> _packetLogger;


### PR DESCRIPTION
Bandwidth Estimator (BE) uses RTP/RTCP stress loading by sending extra "padding" in order to model the network condition and select the best possible configurations for video conferences. It makes no sense for audio-only calls, where it just consumes traffic, which negatively affect clients on metered connections.

- refactor pacing buffer draining;
- disable RTCP-padding for audio calls not using SSRC-rewriting;
- disable RTP-padding for video calls when video source becomes idle.