### PR TITLE
Fix recording issue

### DIFF
--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -667,7 +667,7 @@ void EngineMixer::recordingStart(EngineRecordingStream* stream, const RecordingD
         if (!packet)
         {
             // This need to be improved. If we can't allocate this event, the recording
-            // must fail. We have to find away to report this failier
+            // must fail. We have to find a way to report this glitch
             logger::error("No space available to allocate rec start event", _loggableId.c_str());
             continue;
         }
@@ -707,7 +707,7 @@ void EngineMixer::recordingStop(EngineRecordingStream* stream, const RecordingDe
         if (!packet)
         {
             // This need to be improved. If we can't allocate this event, the recording
-            // must fail as we will not know when it finish. We have to find away to report this failier
+            // must fail as we will not know when it finish. We have to find a way to report this glitch
             logger::error("No space available to allocate rec stop event", _loggableId.c_str());
             continue;
         }
@@ -2864,7 +2864,7 @@ void EngineMixer::sendRecordingAudioStream(EngineRecordingStream& targetStream,
                          .setTimestamp(timestamp)
                          .setSsrc(ssrc)
                          .setRtpPayloadType(static_cast<uint8_t>(audioStream._rtpMap._payloadType))
-                         .setBridgeCodecNumber(static_cast<uint8_t>(audioStream._rtpMap._format))
+                         .setPayloadFormat(audioStream._rtpMap._format)
                          .setEndpoint(audioStream._endpointId)
                          .setWallClock(std::chrono::system_clock::now())
                          .build();
@@ -3000,7 +3000,7 @@ void EngineMixer::sendRecordingSimulcast(EngineRecordingStream& targetStream,
                          .setSsrc(ssrc)
                          .setIsScreenSharing(simulcast._contentType == SimulcastStream::VideoContentType::SLIDES)
                          .setRtpPayloadType(static_cast<uint8_t>(videoStream._rtpMap._payloadType))
-                         .setBridgeCodecNumber(static_cast<uint8_t>(videoStream._rtpMap._format))
+                         .setPayloadFormat(videoStream._rtpMap._format)
                          .setEndpoint(videoStream._endpointId)
                          .setWallClock(std::chrono::system_clock::now())
                          .build();

--- a/test/transport/RecordingTransportTest.cpp
+++ b/test/transport/RecordingTransportTest.cpp
@@ -65,6 +65,7 @@ struct PacketGenerator
     uint16_t rtpSsrc;
     uint32_t rtpTimestamp;
     uint8_t rtpPayload;
+    bridge::RtpMap::Format rtpPayloadFormat;
     uint32_t counter;
 
     explicit PacketGenerator(memory::PacketPoolAllocator& packetAllocator)
@@ -72,6 +73,7 @@ struct PacketGenerator
           rtpSsrc(1),
           rtpTimestamp(3000),
           rtpPayload(100),
+          rtpPayloadFormat(bridge::RtpMap::Format::VP8),
           counter(0)
     {
     }
@@ -113,7 +115,7 @@ private:
             .setSsrc(rtpSsrc)
             .setIsScreenSharing(false)
             .setRtpPayloadType(rtpPayload)
-            .setBridgeCodecNumber(rtpPayload)
+            .setPayloadFormat(rtpPayloadFormat)
             .setEndpoint("test")
             .setWallClock(std::chrono::system_clock::now())
             .build();

--- a/test/transport/recp/RecStreamAddedEventBuilderTest.cpp
+++ b/test/transport/recp/RecStreamAddedEventBuilderTest.cpp
@@ -12,6 +12,21 @@ TEST(RecStreamAddedEventBuilderTest, buildEmptyPacket)
     EXPECT_STREQ(crypto::toHexString(packet->get(), packet->getLength()).c_str(), "00020000000000000000000000000000");
 }
 
+TEST(RecStreamAddedEventBuilderTest, payloadFormats)
+{
+    memory::PacketPoolAllocator allocator(4096 * 32, "testMain");
+    auto packetAddStreamOpus = RecStreamAddedEventBuilder(allocator)
+        .setPayloadFormat(bridge::RtpMap::Format::OPUS)
+        .build();
+
+    auto packetAddStreamVp8 = RecStreamAddedEventBuilder(allocator)
+        .setPayloadFormat(bridge::RtpMap::Format::VP8)
+        .build();
+
+    EXPECT_STREQ(crypto::toHexString(packetAddStreamOpus->get(), packetAddStreamOpus->getLength()).c_str(), "000200000000000000000000006f0000");
+    EXPECT_STREQ(crypto::toHexString(packetAddStreamVp8->get(), packetAddStreamVp8->getLength()).c_str(), "00020000000000000000000000640000");
+}
+
 TEST(RecStreamAddedEventBuilderTest, setWallClockAfterEndpoint)
 {
     const std::string endpointId = "endpoint-id-t";
@@ -26,7 +41,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockAfterEndpoint)
                       .setSsrc(0x11224400)
                       .setIsScreenSharing(true)
                       .setRtpPayloadType(0x70)
-                      .setBridgeCodecNumber(0xBB)
+                      .setPayloadFormat(bridge::RtpMap::Format::OPUS)
                       .setEndpoint(endpointId)
                       .setWallClock(wallClock)
                       .build();
@@ -40,7 +55,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockAfterEndpoint)
         .append("ffaa1122") // timestamp
         .append("11224400") // ssrc
         .append("f0") // Screen share flag + RTP payload type
-        .append("bb") // Bridge codec number
+        .append("6f") // Bridge codec number
         .append("000d") // Endpoint id size
         .append(crypto::toHexString(endpointId.c_str(), endpointId.size())) // endpoint value
         .append(std::string(expectedPaddingBytes * 2, '0')) // padding
@@ -63,7 +78,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockBeforeEndpointWithPadding)
                       .setSsrc(0x11224400)
                       .setIsScreenSharing(false)
                       .setRtpPayloadType(0x70)
-                      .setBridgeCodecNumber(0xBB)
+                      .setPayloadFormat(bridge::RtpMap::Format::OPUS)
                       .setWallClock(wallClock)
                       .setEndpoint(endpointId)
                       .build();
@@ -77,7 +92,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockBeforeEndpointWithPadding)
         .append("ffaa1122") // timestamp
         .append("11224400") // ssrc
         .append("70") // Screen share flag + RTP payload type
-        .append("bb") // Bridge codec number
+        .append("6f") // Bridge codec number
         .append("000d") // Endpoint id size
         .append(crypto::toHexString(endpointId.c_str(), endpointId.size())) // endpoint value
         .append(std::string(expectedPaddingBytes * 2, '0')) // padding
@@ -99,7 +114,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockBeforeEndpointWithoutPadding)
                       .setSsrc(0x11224400)
                       .setIsScreenSharing(true)
                       .setRtpPayloadType(0x70)
-                      .setBridgeCodecNumber(0xBB)
+                      .setPayloadFormat(bridge::RtpMap::Format::OPUS)
                       .setWallClock(wallClock)
                       .setEndpoint(endpointId)
                       .build();
@@ -113,7 +128,7 @@ TEST(RecStreamAddedEventBuilderTest, setWallClockBeforeEndpointWithoutPadding)
         .append("ffaa1122") // timestamp
         .append("11224400") // ssrc
         .append("f0") // Screen share flag + RTP payload type
-        .append("bb") // Bridge codec number
+        .append("6f") // Bridge codec number
         .append("0010") // Endpoint id size
         .append(crypto::toHexString(endpointId.c_str(), endpointId.size())) // endpoint value
         .append(expectedWallClockNtpValue); // padding

--- a/transport/recp/RecStreamAddedEventBuilder.cpp
+++ b/transport/recp/RecStreamAddedEventBuilder.cpp
@@ -18,6 +18,20 @@ uint8_t* getEndpointBuffRef(memory::Packet& packet)
     return &(packet.get()[REC_HEADER_SIZE + 6 + 2]);
 }
 
+uint8_t getCodecNumberFor(bridge::RtpMap::Format format)
+{
+    switch (format)
+    {
+    case bridge::RtpMap::Format::VP8:
+        return 100;
+    case bridge::RtpMap::Format::OPUS:
+        return 111;
+    default:
+        assert(false);
+        return 0xff;
+    }
+}
+
 } // namespace
 
 RecStreamAddedEventBuilder& RecStreamAddedEventBuilder::setSsrc(uint32_t ssrc)
@@ -38,9 +52,9 @@ RecStreamAddedEventBuilder& RecStreamAddedEventBuilder::setRtpPayloadType(uint8_
     return *this;
 }
 
-RecStreamAddedEventBuilder& RecStreamAddedEventBuilder::setBridgeCodecNumber(uint8_t codecNumber)
+RecStreamAddedEventBuilder& RecStreamAddedEventBuilder::setPayloadFormat(bridge::RtpMap::Format format)
 {
-    castPacket(getPacket())->codec = codecNumber;
+    castPacket(getPacket())->codec = getCodecNumberFor(format);
     return *this;
 }
 

--- a/transport/recp/RecStreamAddedEventBuilder.h
+++ b/transport/recp/RecStreamAddedEventBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "bridge/RtpMap.h"
 #include "transport/recp/RecEventBuilder.h"
 #include "transport/recp/RecStreamAddedEvent.h"
 #include <chrono>
@@ -17,7 +18,7 @@ public:
     RecStreamAddedEventBuilder& setSsrc(uint32_t ssrc);
     RecStreamAddedEventBuilder& setIsScreenSharing(bool isScreenSharing);
     RecStreamAddedEventBuilder& setRtpPayloadType(uint8_t payloadType);
-    RecStreamAddedEventBuilder& setBridgeCodecNumber(uint8_t codecNumber);
+    RecStreamAddedEventBuilder& setPayloadFormat(bridge::RtpMap::Format format);
     RecStreamAddedEventBuilder& setEndpoint(const std::string& endpoint);
     RecStreamAddedEventBuilder& setWallClock(std::chrono::system_clock::time_point wallClock);
 };


### PR DESCRIPTION
#88 has broken cloud compliance recordings because we were relying on enum integer value of `RtpMap::Format` to set the codec number on events to add a stream to be recorded. On #88 we removed the explicit int value of `RtpMap::Format` enum and recording converter couldn't decode the stream packets.

This change makes the assigning of codec number less prone to bugs by explicitly mapping the enums for the number that recording converter is expecting