### PR TITLE
Switch off RC for audio-only calls

### DIFF
--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -810,7 +810,7 @@ void EngineMixer::run(const uint64_t engineIterationStartTimestamp)
     // 3. Update bandwidth estimates
     if (_config.bwe.useUplinkEstimate)
     {
-        checkIfBandwidthEstimationIsNeeded(engineIterationStartTimestamp);
+        checkIfRateControlIsNeeded(engineIterationStartTimestamp);
         updateDirectorUplinkEstimates(engineIterationStartTimestamp);
         checkVideoBandwidth(engineIterationStartTimestamp);
     }
@@ -3236,7 +3236,7 @@ bool EngineMixer::isVideoInUse(const uint64_t timestamp, const uint64_t threshol
     return utils::Time::diffLE(_lastVideoPacketProcessed, timestamp, threshold);
 }
 
-void EngineMixer::checkIfBandwidthEstimationIsNeeded(const uint64_t timestamp)
+void EngineMixer::checkIfRateControlIsNeeded(const uint64_t timestamp)
 {
     auto enableBEProbing = isVideoInUse(timestamp, utils::Time::sec * _config.rctl.cooldownInterval);
 

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -186,7 +186,9 @@ EngineMixer::EngineMixer(const std::string& id,
       _config(config),
       _lastN(lastN),
       _numMixedAudioStreams(0),
-      _lastVideoBandwidthCheck(0)
+      _lastVideoBandwidthCheck(0),
+      _lastVideoPacketProcessed(0),
+      _probingVideoStreams(false)
 {
     assert(audioSsrcs.size() <= SsrcRewrite::ssrcArraySize);
     assert(videoSsrcs.size() <= SsrcRewrite::ssrcArraySize);
@@ -290,15 +292,9 @@ void EngineMixer::addVideoStream(EngineVideoStream* engineVideoStream)
         engineVideoStream->_transport.getLoggableId().c_str(),
         endpointIdHash);
 
-    auto* outboundContext = obtainOutboundSsrcContext(*engineVideoStream,
-        engineVideoStream->_localSsrc,
-        engineVideoStream->_feedbackRtpMap);
-    if (outboundContext)
+    if (_probingVideoStreams)
     {
-        engineVideoStream->_transport.getJobQueue().addJob<SetRtxProbeSourceJob>(engineVideoStream->_transport,
-            engineVideoStream->_localSsrc,
-            &outboundContext->_sequenceCounter,
-            outboundContext->_rtpMap._payloadType);
+        startProbingVideoStream(*engineVideoStream);
     }
 
     _engineVideoStreams.emplace(endpointIdHash, engineVideoStream);
@@ -331,10 +327,7 @@ void EngineMixer::removeVideoStream(EngineVideoStream* engineVideoStream)
         outboundContext->_markedForDeletion = true;
         if (engineVideoStream->_transport.isConnected())
         {
-            engineVideoStream->_transport.getJobQueue().addJob<SetRtxProbeSourceJob>(engineVideoStream->_transport,
-                engineVideoStream->_localSsrc,
-                nullptr,
-                engineVideoStream->_feedbackRtpMap._payloadType);
+            stopProbingVideoStream(*engineVideoStream);
             auto goodByePacket = createGoodBye(outboundContext->_ssrc, outboundContext->_allocator);
             if (goodByePacket)
             {
@@ -817,6 +810,7 @@ void EngineMixer::run(const uint64_t engineIterationStartTimestamp)
     // 3. Update bandwidth estimates
     if (_config.bwe.useUplinkEstimate)
     {
+        checkIfBandwidthEstimationIsNeeded(engineIterationStartTimestamp);
         updateDirectorUplinkEstimates(engineIterationStartTimestamp);
         checkVideoBandwidth(engineIterationStartTimestamp);
     }
@@ -2012,6 +2006,8 @@ uint32_t EngineMixer::processIncomingVideoRtpPackets(const uint64_t timestamp)
             continue;
         }
         const auto senderEndpointIdHash = packetInfo.transport()->getEndpointIdHash();
+
+        _lastVideoPacketProcessed = timestamp;
 
         for (auto& videoStreamEntry : _engineVideoStreams)
         {
@@ -3211,6 +3207,58 @@ void EngineMixer::checkVideoBandwidth(const uint64_t timestamp)
             slidesLimit,
             _sendAllocator);
     }
+}
+
+void EngineMixer::startProbingVideoStream(EngineVideoStream& engineVideoStream)
+{
+    auto* outboundContext =
+        obtainOutboundSsrcContext(engineVideoStream, engineVideoStream._localSsrc, engineVideoStream._feedbackRtpMap);
+    if (outboundContext)
+    {
+        engineVideoStream._transport.getJobQueue().addJob<SetRtxProbeSourceJob>(engineVideoStream._transport,
+            engineVideoStream._localSsrc,
+            &outboundContext->_sequenceCounter,
+            outboundContext->_rtpMap._payloadType);
+    }
+    _probingVideoStreams = true;
+}
+
+void EngineMixer::stopProbingVideoStream(const EngineVideoStream& engineVideoStream)
+{
+    engineVideoStream._transport.getJobQueue().addJob<SetRtxProbeSourceJob>(engineVideoStream._transport,
+        engineVideoStream._localSsrc,
+        nullptr,
+        engineVideoStream._feedbackRtpMap._payloadType);
+}
+
+bool EngineMixer::isVideoInUse(const uint64_t timestamp, const uint64_t threshold) const
+{
+    return utils::Time::diffLE(_lastVideoPacketProcessed, timestamp, threshold);
+}
+
+void EngineMixer::checkIfBandwidthEstimationIsNeeded(const uint64_t timestamp)
+{
+    auto enableBEProbing = isVideoInUse(timestamp, utils::Time::sec * _config.beCooldownInterval);
+
+    if (enableBEProbing == _probingVideoStreams)
+        return;
+
+    for (auto& videoStream : _engineVideoStreams)
+    {
+        if (videoStream.second)
+        {
+            if (enableBEProbing)
+            {
+                startProbingVideoStream(*videoStream.second);
+            }
+            else
+            {
+                stopProbingVideoStream(*videoStream.second);
+            }
+        }
+    }
+
+    _probingVideoStreams = enableBEProbing;
 }
 
 void EngineMixer::runTransportTicks(const uint64_t timestamp)

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -3238,7 +3238,7 @@ bool EngineMixer::isVideoInUse(const uint64_t timestamp, const uint64_t threshol
 
 void EngineMixer::checkIfBandwidthEstimationIsNeeded(const uint64_t timestamp)
 {
-    auto enableBEProbing = isVideoInUse(timestamp, utils::Time::sec * _config.beCooldownInterval);
+    auto enableBEProbing = isVideoInUse(timestamp, utils::Time::sec * _config.rctl.cooldownInterval);
 
     if (enableBEProbing == _probingVideoStreams)
         return;

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -322,6 +322,8 @@ private:
     uint32_t _numMixedAudioStreams;
 
     uint64_t _lastVideoBandwidthCheck;
+    uint64_t _lastVideoPacketProcessed;
+    bool _probingVideoStreams;
 
     void processIncomingRtpPackets(const uint64_t timestamp);
     uint32_t processIncomingVideoRtpPackets(const uint64_t timestamp);
@@ -340,6 +342,8 @@ private:
     void updateDirectorUplinkEstimates(const uint64_t engineIterationStartTimestamp);
     void processMissingPackets(const uint64_t timestamp);
     void checkPacketCounters(const uint64_t timestamp);
+    void checkIfBandwidthEstimationIsNeeded(const uint64_t timestamp);
+    bool isVideoInUse(const uint64_t timestamp, const uint64_t threshold) const;
     void onVideoRtpPacketReceived(SsrcInboundContext* ssrcContext,
         transport::RtcTransport* sender,
         memory::UniquePacket packet,
@@ -407,6 +411,8 @@ private:
         EngineRecordingStream& recordingStream);
 
     void processRecordingMissingPackets(const uint64_t timestamp);
+    void startProbingVideoStream(EngineVideoStream&);
+    void stopProbingVideoStream(const EngineVideoStream&);
 };
 
 } // namespace bridge

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -342,7 +342,7 @@ private:
     void updateDirectorUplinkEstimates(const uint64_t engineIterationStartTimestamp);
     void processMissingPackets(const uint64_t timestamp);
     void checkPacketCounters(const uint64_t timestamp);
-    void checkIfBandwidthEstimationIsNeeded(const uint64_t timestamp);
+    void checkIfRateControlIsNeeded(const uint64_t timestamp);
     bool isVideoInUse(const uint64_t timestamp, const uint64_t threshold) const;
     void onVideoRtpPacketReceived(SsrcInboundContext* ssrcContext,
         transport::RtcTransport* sender,

--- a/config/Config.h
+++ b/config/Config.h
@@ -104,6 +104,7 @@ public:
 
     CFG_PROP(uint32_t, mtu, 1480);
     CFG_PROP(uint32_t, ipOverhead, 20 + 14);
+    CFG_PROP(uint64_t, beCooldownInterval, 30); // Time after the last video packet BE still works.
 };
 
 } // namespace config

--- a/config/Config.h
+++ b/config/Config.h
@@ -70,7 +70,7 @@ public:
     CFG_PROP(uint32_t, ceiling, 9000);
     CFG_PROP(uint32_t, initialEstimate, 1200);
     CFG_PROP(bool, debugLog, false);
-    CFG_PROP(uint64_t, cooldownInterval, 30); // Time after the last video packet BE still works.
+    CFG_PROP(uint64_t, cooldownInterval, 30); // Time until rtcl inactivates after last received video
     CFG_GROUP_END(rctl)
 
     CFG_GROUP()

--- a/config/Config.h
+++ b/config/Config.h
@@ -70,6 +70,7 @@ public:
     CFG_PROP(uint32_t, ceiling, 9000);
     CFG_PROP(uint32_t, initialEstimate, 1200);
     CFG_PROP(bool, debugLog, false);
+    CFG_PROP(uint64_t, cooldownInterval, 30); // Time after the last video packet BE still works.
     CFG_GROUP_END(rctl)
 
     CFG_GROUP()
@@ -104,7 +105,6 @@ public:
 
     CFG_PROP(uint32_t, mtu, 1480);
     CFG_PROP(uint32_t, ipOverhead, 20 + 14);
-    CFG_PROP(uint64_t, beCooldownInterval, 30); // Time after the last video packet BE still works.
 };
 
 } // namespace config

--- a/test/bwe/FakeVideoSource.h
+++ b/test/bwe/FakeVideoSource.h
@@ -28,6 +28,7 @@ public:
     uint32_t getSsrc() const override { return _ssrc; }
 
 private:
+    void tryFillFramePayload(unsigned char*, size_t, bool) const;
     void setNextFrameSize();
 
     memory::PacketPoolAllocator& _allocator;
@@ -43,6 +44,7 @@ private:
     uint32_t _sequenceCounter;
     utils::AvgRateTracker _avgRate;
     uint32_t _rtpTimestamp;
+    bool _keyFrame;
 };
 
 } // namespace fakenet

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1278,20 +1278,20 @@ TEST_F(IntegrationTest, plain)
             EXPECT_NEAR(freqVector[0], 600.0, 25.0);
             EXPECT_NEAR(freqVector[1], 1300.0, 25.0);
 
-            EXPECT_GE(amplitudeProfile.size(), 4);
+            EXPECT_GE(amplitudeProfile.size(), 2);
             for (auto& item : amplitudeProfile)
             {
                 logger::debug("%.3fs, %.3f", "", item.first / 48000.0, item.second);
             }
-            if (amplitudeProfile.size() >= 4)
+            // We expect a ramp-up of volume like this:
+            // start from 0;
+            // ramp-up to about 1826 (+-250) in 1.67s (+-0,2s)
+            if (amplitudeProfile.size() >= 2)
             {
                 EXPECT_EQ(amplitudeProfile[0].second, 0);
 
-                EXPECT_NEAR(amplitudeProfile[3].second, 1826, 250);
-                EXPECT_NEAR(amplitudeProfile[3].first, 48000 * 1.67, 2400);
-
-                EXPECT_NEAR(amplitudeProfile.back().second, 1730, 250);
-                EXPECT_LE(amplitudeProfile.back().first, 2 * 48000);
+                EXPECT_NEAR(amplitudeProfile.back().second, 1826, 250);
+                EXPECT_NEAR(amplitudeProfile.back().first, 48000 * 1.67, 48000 * 0.2);
             }
 
             // item.second->dumpPcmData();

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1756,20 +1756,20 @@ TEST_F(IntegrationTest, plainNewApi)
                 EXPECT_NEAR(freqVector[1], 1300.0, 25.0);
             }
 
-            EXPECT_GE(amplitudeProfile.size(), 4);
+            EXPECT_GE(amplitudeProfile.size(), 2);
             for (auto& item : amplitudeProfile)
             {
                 logger::debug("%.3fs, %.3f", "", item.first / 48000.0, item.second);
             }
-            if (amplitudeProfile.size() >= 4)
+            // We expect a ramp-up of volume like this:
+            // start from 0;
+            // ramp-up to about 1826 (+-250) in 1.67s (+-0,2s)
+            if (amplitudeProfile.size() >= 2)
             {
                 EXPECT_EQ(amplitudeProfile[0].second, 0);
 
-                EXPECT_NEAR(amplitudeProfile[3].second, 1826, 250);
-                EXPECT_NEAR(amplitudeProfile[3].first, 48000 * 1.67, 2400);
-
-                EXPECT_NEAR(amplitudeProfile.back().second, 1730, 250);
-                EXPECT_LE(amplitudeProfile.back().first, 2 * 48000);
+                EXPECT_NEAR(amplitudeProfile.back().second, 1826, 250);
+                EXPECT_NEAR(amplitudeProfile.back().first, 48000 * 1.67, 48000 * 0.2);
             }
 
             // item.second->dumpPcmData();
@@ -1978,20 +1978,20 @@ TEST_F(IntegrationTest, ptime10)
                 EXPECT_NEAR(freqVector[1], 1300.0, 25.0);
             }
 
-            EXPECT_GE(amplitudeProfile.size(), 4);
+            EXPECT_GE(amplitudeProfile.size(), 2);
             for (auto& item : amplitudeProfile)
             {
                 logger::debug("%.3fs, %.3f", "", item.first / 48000.0, item.second);
             }
-            if (amplitudeProfile.size() >= 4)
+            // We expect a ramp-up of volume like this:
+            // start from 0;
+            // ramp-up to about 1826 (+-250) in 1.67s (+-0,2s)
+            if (amplitudeProfile.size() >= 2)
             {
                 EXPECT_EQ(amplitudeProfile[0].second, 0);
 
-                EXPECT_NEAR(amplitudeProfile[3].second, 1826, 250);
-                EXPECT_NEAR(amplitudeProfile[3].first, 48000 * 1.67, 2400);
-
-                EXPECT_NEAR(amplitudeProfile.back().second, 1730, 250);
-                EXPECT_LE(amplitudeProfile.back().first, 2 * 48000);
+                EXPECT_NEAR(amplitudeProfile.back().second, 1826, 250);
+                EXPECT_NEAR(amplitudeProfile.back().first, 48000 * 1.67, 48000 * 0.2);
             }
 
             // item.second->dumpPcmData();

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1426,7 +1426,7 @@ TEST_F(IntegrationTest, videoOffPaddingOff)
 
     _config.readFromString(
         "{\"ip\":\"127.0.0.1\", "
-        "\"ice.preferredIp\":\"127.0.0.1\",\"ice.publicIpv4\":\"127.0.0.1\", \"beCooldownInterval\":1}");
+        "\"ice.preferredIp\":\"127.0.0.1\",\"ice.publicIpv4\":\"127.0.0.1\", \"rctl.cooldownInterval\":1}");
     initBridge(_config);
 
     const std::string baseUrl = "http://127.0.0.1:8080";
@@ -1501,7 +1501,7 @@ TEST_F(IntegrationTest, videoOffPaddingOff)
 
     const auto numSsrcClient1Received = client1.getReceiveStats().size();
 
-    // Video producer (client2) stopped, waiting 1.5s for beCooldownInterval timeout to take effect
+    // Video producer (client2) stopped, waiting 1.5s for rctl.cooldownInterval timeout to take effect
     // (configured for 1 s for this test).
 
     for (int i = 0; i < 150; ++i)

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -8,6 +8,7 @@
 #include "jobmanager/WorkerThread.h"
 #include "memory/PacketPoolAllocator.h"
 #include "nlohmann/json.hpp"
+#include "test/bwe/FakeVideoSource.h"
 #include "test/integration/SampleDataUtils.h"
 #include "test/integration/emulator/AudioSource.h"
 #include "transport/DataReceiver.h"
@@ -236,6 +237,7 @@ public:
         _conferenceId = conferenceId;
         _relayType = forwardMedia ? "ssrc-rewrite" : "mixed";
         _baseUrl = baseUrl;
+        _videoEnabled = video;
 
         using namespace nlohmann;
         json body = {{"action", "allocate"},
@@ -384,6 +386,7 @@ public:
     }
 
     bool isSuccess() const { return !raw.empty(); }
+    bool isVideoEnabled() const { return _videoEnabled; }
 
     nlohmann::json getOffer() const { return _offer; }
     std::string getEndpointId() const { return _id; }
@@ -400,6 +403,7 @@ private:
     std::string _relayType;
     nlohmann::json _offer;
     std::string _baseUrl;
+    bool _videoEnabled;
 };
 
 nlohmann::json newContent(const std::string& endpointId, const char* type, const char* relayType, bool initiator)
@@ -432,6 +436,7 @@ public:
         _conferenceId = conferenceId;
         _relayType = forwardMedia ? "ssrc-rewrite" : "mixer";
         _baseUrl = baseUrl;
+        _videoEnabled = video;
 
         using namespace nlohmann;
         json body = {{"id", conferenceId}, {"contents", json::array()}};
@@ -628,6 +633,7 @@ public:
     }
 
     bool isSuccess() const { return !raw.empty(); }
+    bool isVideoEnabled() const { return _videoEnabled; }
 
     nlohmann::json getOffer() const { return _offer; }
     std::string getEndpointId() const { return _id; }
@@ -644,12 +650,13 @@ private:
     std::string _relayType;
     nlohmann::json _offer;
     std::string _baseUrl;
+    bool _videoEnabled;
 };
 
-class AudioSendJob : public jobmanager::Job
+class MediaSendJob : public jobmanager::Job
 {
 public:
-    AudioSendJob(transport::Transport& transport, memory::UniquePacket packet, uint64_t timestamp)
+    MediaSendJob(transport::Transport& transport, memory::UniquePacket packet, uint64_t timestamp)
         : _transport(transport),
           _packet(std::move(packet))
     {
@@ -796,10 +803,18 @@ public:
     void connect()
     {
         uint32_t videoSsrcs[7];
-        videoSsrcs[6] = 0;
-        for (int i = 0; i < 6; ++i)
+        if (_channel.isVideoEnabled())
         {
-            videoSsrcs[i] = _idGenerator.next();
+            videoSsrcs[6] = 0;
+            for (int i = 0; i < 6; ++i)
+            {
+                videoSsrcs[i] = _idGenerator.next();
+                if (0 == i % 2)
+                {
+                    _videoSources.emplace(videoSsrcs[i],
+                        std::make_unique<fakenet::FakeVideoSource>(_allocator, 1024, videoSsrcs[i]));
+                }
+            }
         }
 
         assert(_audioSource);
@@ -808,13 +823,15 @@ public:
             _transport->getLocalCandidates(),
             _sslDtls.getLocalFingerprint(),
             _audioSource->getSsrc(),
-            videoSsrcs);
+            _channel.isVideoEnabled() ? videoSsrcs : nullptr);
 
         _transport->start();
         _transport->connect();
     }
 
-    void process(uint64_t timestamp)
+    void process(uint64_t timestamp) { process(timestamp, true); }
+
+    void process(uint64_t timestamp, bool sendVideo)
     {
         auto packet = _audioSource->getPacket(timestamp);
         if (packet)
@@ -827,7 +844,19 @@ public:
                 _allocator.free(packet);
                 return;
             }*/
-            _transport->getJobQueue().addJob<AudioSendJob>(*_transport, std::move(packet), timestamp);
+            _transport->getJobQueue().addJob<MediaSendJob>(*_transport, std::move(packet), timestamp);
+        }
+
+        if (sendVideo)
+        {
+            for (const auto& videoSource : _videoSources)
+            {
+                auto packet = videoSource.second->getPacket(timestamp);
+                if (packet)
+                {
+                    _transport->getJobQueue().addJob<MediaSendJob>(*_transport, std::move(packet), timestamp);
+                }
+            }
         }
     }
 
@@ -916,11 +945,7 @@ public:
             bridge::RtpMap rtpMap(bridge::RtpMap::Format::OPUS);
             rtpMap._audioLevelExtId.set(1);
             _receivedData.emplace(rtpHeader->ssrc.get(),
-                new RtpReceiver(_loggableId.getInstanceId(),
-                    rtpHeader->ssrc.get(),
-                    rtpMap,
-                    sender,
-                    timestamp));
+                new RtpReceiver(_loggableId.getInstanceId(), rtpHeader->ssrc.get(), rtpMap, sender, timestamp));
             it = _receivedData.find(rtpHeader->ssrc.get());
         }
 
@@ -978,6 +1003,7 @@ public:
 
     std::unique_ptr<emulator::AudioSource> _audioSource;
     // Video source that produces fake VP8
+    std::unordered_map<uint32_t, std::unique_ptr<fakenet::FakeVideoSource>> _videoSources;
 
     const concurrency::MpmcHashmap32<uint32_t, RtpReceiver*>& getReceiveStats() const { return _receivedData; }
     const logger::LoggableId& getLoggableId() const { return _loggableId; }
@@ -1230,8 +1256,8 @@ TEST_F(IntegrationTest, plain)
         EXPECT_EQ(audioCounters.lostPackets, 0);
 
         const auto& rData1 = client3.getReceiveStats();
-        // We expect one audio ssrc and 1 video (where we receive padding data due to RateController)
-        EXPECT_EQ(rData1.size(), 2);
+        // We expect one audio ssrc, three video and one padding
+        EXPECT_EQ(rData1.size(), 4);
         size_t audioSsrcCount = 0;
         for (const auto& item : rData1)
         {
@@ -1273,6 +1299,263 @@ TEST_F(IntegrationTest, plain)
 
         EXPECT_EQ(audioSsrcCount, 1);
     }
+}
+
+TEST_F(IntegrationTest, audioOnlyNoPadding)
+{
+    if (__has_feature(address_sanitizer) || __has_feature(thread_sanitizer))
+    {
+        return;
+    }
+#if !ENABLE_LEGACY_API
+    return;
+#endif
+
+    _config.readFromString("{\"ip\":\"127.0.0.1\", "
+                           "\"ice.preferredIp\":\"127.0.0.1\",\"ice.publicIpv4\":\"127.0.0.1\"}");
+    initBridge(_config);
+
+    const std::string baseUrl = "http://127.0.0.1:8080";
+
+    Conference conf;
+    conf.create(baseUrl + "/colibri");
+    EXPECT_TRUE(conf.isSuccess());
+    utils::Time::nanoSleep(1 * utils::Time::sec);
+
+    SfuClient<ColibriChannel> client1(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+    SfuClient<ColibriChannel> client2(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+    SfuClient<ColibriChannel> client3(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+
+    // Audio only for all three participants.
+    client1.initiateCall(baseUrl, conf.getId(), true, true, false, false);
+    client2.initiateCall(baseUrl, conf.getId(), false, true, false, false);
+    client3.initiateCall(baseUrl, conf.getId(), false, true, false, false);
+
+    EXPECT_TRUE(client1._channel.isSuccess());
+    EXPECT_TRUE(client2._channel.isSuccess());
+    EXPECT_TRUE(client3._channel.isSuccess());
+
+    if (!client1._channel.isSuccess() && client2._channel.isSuccess() && client3._channel.isSuccess())
+    {
+        return;
+    }
+
+    client1.processLegacyOffer();
+    client2.processLegacyOffer();
+    client3.processLegacyOffer();
+
+    client1.connect();
+    client2.connect();
+    client3.connect();
+
+    while (
+        !client1._transport->isConnected() || !client2._transport->isConnected() || !client3._transport->isConnected())
+    {
+        utils::Time::nanoSleep(1 * utils::Time::sec);
+        logger::debug("waiting for connect...", "test");
+    }
+
+    client1._audioSource->setFrequency(600);
+    client2._audioSource->setFrequency(1300);
+    client3._audioSource->setFrequency(2100);
+
+    client1._audioSource->setVolume(0.6);
+    client2._audioSource->setVolume(0.6);
+    client3._audioSource->setVolume(0.6);
+
+    utils::Pacer pacer(10 * utils::Time::ms);
+    for (int i = 0; i < 500; ++i)
+    {
+        const auto timestamp = utils::Time::getAbsoluteTime();
+        client1.process(timestamp, false);
+        client2.process(timestamp, false);
+        client3.process(timestamp, false);
+        pacer.tick(utils::Time::getAbsoluteTime());
+        utils::Time::nanoSleep(pacer.timeToNextTick(utils::Time::getAbsoluteTime()));
+    }
+
+    client3.stopRecording();
+    client2.stopRecording();
+    client1.stopRecording();
+
+    client1._transport->stop();
+    client2._transport->stop();
+    client3._transport->stop();
+
+    for (int i = 0; i < 10 &&
+         (client1._transport->hasPendingJobs() || client2._transport->hasPendingJobs() ||
+             client3._transport->hasPendingJobs());
+         ++i)
+    {
+        utils::Time::nanoSleep(1 * utils::Time::sec);
+    }
+    const auto& rData1 = client1.getReceiveStats();
+    const auto& rData2 = client2.getReceiveStats();
+    const auto& rData3 = client3.getReceiveStats();
+    // We expect only one ssrc (audio), since padding (that comes on video ssrc) is disabled for audio only calls).
+    EXPECT_EQ(rData1.size(), 1);
+    EXPECT_EQ(rData2.size(), 1);
+    EXPECT_EQ(rData3.size(), 1);
+}
+
+TEST_F(IntegrationTest, videoOffPaddingOff)
+{
+    /*
+       Test checks that after video is off and cooldown interval passed, no padding will be sent for the call that
+       became audio-only.
+    */
+    if (__has_feature(address_sanitizer) || __has_feature(thread_sanitizer))
+    {
+        return;
+    }
+#if !ENABLE_LEGACY_API
+    return;
+#endif
+
+    _config.readFromString(
+        "{\"ip\":\"127.0.0.1\", "
+        "\"ice.preferredIp\":\"127.0.0.1\",\"ice.publicIpv4\":\"127.0.0.1\", \"beCooldownInterval\":1}");
+    initBridge(_config);
+
+    const std::string baseUrl = "http://127.0.0.1:8080";
+
+    Conference conf;
+    conf.create(baseUrl + "/colibri");
+    EXPECT_TRUE(conf.isSuccess());
+    utils::Time::nanoSleep(1 * utils::Time::sec);
+
+    SfuClient<ColibriChannel> client1(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+    SfuClient<ColibriChannel> client2(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+    SfuClient<ColibriChannel> client3(++_instanceCounter,
+        *_mainPoolAllocator,
+        _audioAllocator,
+        *_transportFactory,
+        *_sslDtls);
+
+    // Audio only for all three participants.
+    client1.initiateCall(baseUrl, conf.getId(), true, true, true, true);
+    client2.initiateCall(baseUrl, conf.getId(), false, true, true, true);
+    // Client 3 will join after client 2, which produce video, will leave.
+    client3.initiateCall(baseUrl, conf.getId(), false, true, true, true);
+
+    EXPECT_TRUE(client1._channel.isSuccess());
+    EXPECT_TRUE(client2._channel.isSuccess());
+
+    if (!client1._channel.isSuccess() && client2._channel.isSuccess())
+    {
+        return;
+    }
+
+    client1.processLegacyOffer();
+    client2.processLegacyOffer();
+
+    client1.connect();
+    client2.connect();
+
+    while (!client1._transport->isConnected() || !client2._transport->isConnected())
+    {
+        utils::Time::nanoSleep(1 * utils::Time::sec);
+        logger::debug("waiting for connect...", "test");
+    }
+
+    // Have to produce some audio volume above "silence threshold", otherwise audio packats
+    // won't be forwarded by SFU.
+    client1._audioSource->setFrequency(600);
+    client2._audioSource->setFrequency(1300);
+
+    client1._audioSource->setVolume(0.6);
+    client2._audioSource->setVolume(0.6);
+
+    utils::Pacer pacer(10 * utils::Time::ms);
+    for (int i = 0; i < 100; ++i)
+    {
+        const auto timestamp = utils::Time::getAbsoluteTime();
+        client1.process(timestamp, false);
+        client2.process(timestamp, true);
+        pacer.tick(utils::Time::getAbsoluteTime());
+        utils::Time::nanoSleep(pacer.timeToNextTick(utils::Time::getAbsoluteTime()));
+    }
+
+    client2.stopRecording();
+    client2._transport->stop();
+
+    const auto numSsrcClient1Received = client1.getReceiveStats().size();
+
+    // Video producer (client2) stopped, waiting 1.5s for beCooldownInterval timeout to take effect
+    // (configured for 1 s for this test).
+
+    for (int i = 0; i < 150; ++i)
+    {
+        const auto timestamp = utils::Time::getAbsoluteTime();
+        client1.process(timestamp, false);
+        utils::Time::nanoSleep(pacer.timeToNextTick(utils::Time::getAbsoluteTime()));
+    }
+
+    // client 3 joins.
+    client3.processLegacyOffer();
+    client3.connect();
+
+    while (!client3._transport->isConnected())
+    {
+        utils::Time::nanoSleep(1 * utils::Time::sec);
+        logger::debug("waiting for connect...", "test");
+    }
+
+    client3._audioSource->setFrequency(2100);
+    client3._audioSource->setVolume(0.6);
+
+    for (int i = 0; i < 100; ++i)
+    {
+        const auto timestamp = utils::Time::getAbsoluteTime();
+        client1.process(timestamp, false);
+        client3.process(timestamp, false);
+        pacer.tick(utils::Time::getAbsoluteTime());
+        utils::Time::nanoSleep(pacer.timeToNextTick(utils::Time::getAbsoluteTime()));
+    }
+
+    client1.stopRecording();
+    client3.stopRecording();
+
+    client1._transport->stop();
+    client3._transport->stop();
+
+    for (int i = 0; i < 10 &&
+         (client1._transport->hasPendingJobs() || client2._transport->hasPendingJobs() ||
+             client3._transport->hasPendingJobs());
+         ++i)
+    {
+        utils::Time::nanoSleep(1 * utils::Time::sec);
+    }
+
+    const auto& rData1 = client1.getReceiveStats();
+    const auto& rData2 = client2.getReceiveStats();
+    const auto& rData3 = client3.getReceiveStats();
+
+    EXPECT_EQ(numSsrcClient1Received, 3); // s2's audio, s2's video + padding
+    EXPECT_EQ(rData1.size(), 4); // s2's audio, s3's audio, s2's video + padding
+    EXPECT_EQ(rData2.size(), 2); // s1's aidio, + padding
+    EXPECT_EQ(rData3.size(),
+        1); // s1's aidio, no padding, since it joined the call whith no video.  !!!TODO config timeout
 }
 
 class Foo
@@ -1449,7 +1732,7 @@ TEST_F(IntegrationTest, plainNewApi)
 
         const auto& rData1 = client3.getReceiveStats();
         // We expect one audio ssrc and 1 video (where we receive padding data due to RateController)
-        EXPECT_EQ(rData1.size(), 2);
+        EXPECT_EQ(rData1.size(), 4);
         size_t audioSsrcCount = 0;
         for (const auto& item : rData1)
         {
@@ -1671,7 +1954,7 @@ TEST_F(IntegrationTest, ptime10)
 
         const auto& rData1 = client3.getReceiveStats();
         // We expect one audio ssrc and 1 video (where we receive padding data due to RateController)
-        EXPECT_EQ(rData1.size(), 2);
+        EXPECT_EQ(rData1.size(), 4);
         size_t audioSsrcCount = 0;
         for (const auto& item : rData1)
         {

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1383,17 +1383,7 @@ void TransportImpl::sendPadding(uint64_t timestamp)
         return;
     }
 
-    auto budget = _rateController.getPacingBudget(timestamp);
-    auto* pacingQueue = _rtxPacingQueue.empty() ? &_pacingQueue : &_rtxPacingQueue;
-    while (!pacingQueue->empty() && budget >= pacingQueue->back()->getLength() + _config.ipOverhead)
-    {
-        auto packet = std::move(pacingQueue->back());
-        pacingQueue->pop_back();
-        budget -= std::min(budget, packet->getLength() + _config.ipOverhead);
-
-        protectAndSendRtp(timestamp, std::move(packet));
-        pacingQueue = _rtxPacingQueue.empty() ? &_pacingQueue : &_rtxPacingQueue;
-    }
+    drainPacingBuffer(timestamp, DrainPacingBufferMode::UseBudget);
 
     uint16_t padding = 0;
     auto& rtxSenderState = getOutboundSsrc(_rtxProbeSsrc, 90000);
@@ -1430,28 +1420,6 @@ void TransportImpl::sendPadding(uint64_t timestamp)
         else
         {
             break;
-        }
-    }
-}
-
-void TransportImpl::sendRtcpPadding(uint64_t timestamp, uint32_t ssrc, uint16_t nextPacketSize)
-{
-    if (!_config.rctl.enable || _rtxProbeSequenceCounter)
-    {
-        return;
-    }
-
-    uint16_t padding = 0;
-    const auto paddingCount = _rateController.getPadding(timestamp, nextPacketSize, padding);
-    for (uint32_t i = 0; i < paddingCount && _selectedRtcp; ++i)
-    {
-        auto padPacket = memory::makeUniquePacket(_mainAllocator);
-        if (padPacket)
-        {
-            auto* rtcpPadding = rtp::RtcpApplicationSpecific::create(padPacket->get(), ssrc, "BRPP", padding);
-            padPacket->setLength(rtcpPadding->header.size());
-            _rateController.onRtcpPaddingSent(timestamp, ssrc, padPacket->getLength());
-            doProtectAndSend(timestamp, std::move(padPacket), _peerRtcpPort, _selectedRtcp);
         }
     }
 }
@@ -1498,7 +1466,6 @@ void TransportImpl::protectAndSend(memory::UniquePacket packet)
         }
         else
         {
-            sendRtcpPadding(timestamp, rtpHeader->ssrc, packet->getLength());
             protectAndSendRtp(timestamp, std::move(packet));
         }
 
@@ -2390,44 +2357,30 @@ void TransportImpl::runTick(uint64_t timestamp)
 
 void TransportImpl::doRunTick(const uint64_t timestamp)
 {
-    if (!_config.rctl.enable || !_config.bwe.useUplinkEstimate)
+    auto drainMode = _config.rctl.enable && _config.bwe.useUplinkEstimate ? DrainPacingBufferMode::UseBudget
+                                                                          : DrainPacingBufferMode::DrainAll;
+    drainPacingBuffer(timestamp, drainMode);
+    if (DrainPacingBufferMode::UseBudget == drainMode)
     {
-        while (!_rtxPacingQueue.empty())
-        {
-            protectAndSendRtp(timestamp, _rtxPacingQueue.fetchBack());
-        }
-        while (!_pacingQueue.empty())
-        {
-            protectAndSendRtp(timestamp, _pacingQueue.fetchBack());
-        }
-        _pacingInUse = false;
-        return;
+        sendPadding(timestamp);
     }
-
-    auto budget = _rateController.getPacingBudget(timestamp);
-    while (!_pacingQueue.empty() || !_rtxPacingQueue.empty())
-    {
-        auto* pacingQueue = &_pacingQueue;
-        if (!_rtxPacingQueue.empty())
-        {
-            pacingQueue = &_rtxPacingQueue;
-        }
-
-        if (pacingQueue->back()->getLength() + _config.ipOverhead <= budget)
-        {
-            memory::UniquePacket packet(pacingQueue->fetchBack());
-            budget -= packet->getLength() + _config.ipOverhead;
-            protectAndSendRtp(timestamp, std::move(packet));
-        }
-        else
-        {
-            break;
-        }
-    }
-
-    sendPadding(timestamp);
-
     _pacingInUse = !_pacingQueue.empty() || !_rtxPacingQueue.empty();
+}
+
+memory::UniquePacket TransportImpl::tryFetchPriorityPacket(size_t budget)
+{
+    auto& queue = _rtxPacingQueue.empty() ? _pacingQueue : _rtxPacingQueue;
+    return !queue.empty() && budget >= queue.back()->getLength() + _config.ipOverhead ? queue.fetchBack() : nullptr;
+}
+
+void TransportImpl::drainPacingBuffer(uint64_t timestamp, DrainPacingBufferMode mode)
+{
+    auto budget = DrainPacingBufferMode::UseBudget == mode ? _rateController.getPacingBudget(timestamp) : SIZE_MAX;
+    while (auto packet = tryFetchPriorityPacket(budget))
+    {
+        budget -= packet->getLength() + _config.ipOverhead;
+        protectAndSendRtp(timestamp, std::move(packet));
+    }
 }
 
 } // namespace transport

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -41,6 +41,9 @@ struct SctpConfig;
 
 namespace transport
 {
+
+typedef memory::RandomAccessBacklog<memory::UniquePacket, 512> pacing_queue_t;
+
 class TransportImpl : public RtcTransport,
                       private SslWriteBioListener,
                       public Endpoint::IEvents,
@@ -263,13 +266,17 @@ private:
     friend class ConnectSctpJob;
     friend class RunTickJob;
 
+    enum class DrainPacingBufferMode {
+        DrainAll,
+        UseBudget,
+    };
+
     void protectAndSendRtp(uint64_t timestamp, memory::UniquePacket packet);
     void doProtectAndSend(uint64_t timestamp,
         memory::UniquePacket packet,
         const SocketAddress& target,
         Endpoint* endpoint);
     void sendPadding(uint64_t timestamp);
-    void sendRtcpPadding(uint64_t timestamp, uint32_t ssrc, uint16_t nextPacketSize);
 
     void processRtcpReport(const rtp::RtcpHeader& packet,
         uint64_t timestamp,
@@ -301,6 +308,8 @@ private:
     RtpSenderState& getOutboundSsrc(uint32_t ssrc, uint32_t rtpFrequency);
 
     void onTransportConnected();
+    void drainPacingBuffer(uint64_t timestamp, DrainPacingBufferMode);
+    memory::UniquePacket tryFetchPriorityPacket(size_t budget);
 
     std::atomic_bool _isInitialized;
     logger::LoggableId _loggableId;
@@ -388,8 +397,8 @@ private:
     uint32_t _rtxProbeSsrc;
     uint32_t* _rtxProbeSequenceCounter;
 
-    memory::RandomAccessBacklog<memory::UniquePacket, 512> _pacingQueue;
-    memory::RandomAccessBacklog<memory::UniquePacket, 512> _rtxPacingQueue;
+    pacing_queue_t _pacingQueue;
+    pacing_queue_t _rtxPacingQueue;
     std::atomic_bool _pacingInUse;
 
     std::unique_ptr<logger::PacketLoggerThread> _packetLogger;

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -41,9 +41,6 @@ struct SctpConfig;
 
 namespace transport
 {
-
-typedef memory::RandomAccessBacklog<memory::UniquePacket, 512> pacing_queue_t;
-
 class TransportImpl : public RtcTransport,
                       private SslWriteBioListener,
                       public Endpoint::IEvents,
@@ -266,7 +263,8 @@ private:
     friend class ConnectSctpJob;
     friend class RunTickJob;
 
-    enum class DrainPacingBufferMode {
+    enum class DrainPacingBufferMode
+    {
         DrainAll,
         UseBudget,
     };
@@ -397,8 +395,9 @@ private:
     uint32_t _rtxProbeSsrc;
     uint32_t* _rtxProbeSequenceCounter;
 
-    pacing_queue_t _pacingQueue;
-    pacing_queue_t _rtxPacingQueue;
+    using PacingQueue = memory::RandomAccessBacklog<memory::UniquePacket, 512>;
+    PacingQueue _pacingQueue;
+    PacingQueue _rtxPacingQueue;
     std::atomic_bool _pacingInUse;
 
     std::unique_ptr<logger::PacketLoggerThread> _packetLogger;

--- a/utils/Time.h
+++ b/utils/Time.h
@@ -31,10 +31,10 @@ inline uint32_t toNtp32(const uint64_t ntpTimestamp)
     return 0xFFFFFFFFu & (ntpTimestamp >> 16);
 }
 
-const uint64_t us = 1000;
-const uint64_t ms = 1000 * us;
-const uint64_t sec = ms * 1000;
-const uint64_t minute = sec * 60;
+constexpr uint64_t us = 1000;
+constexpr uint64_t ms = 1000 * us;
+constexpr uint64_t sec = ms * 1000;
+constexpr uint64_t minute = sec * 60;
 
 inline uint32_t absToNtp32(const uint64_t timestamp)
 {


### PR DESCRIPTION
Activate uplink bandwidth estimation only calls with at least one active video stream.
Stop doing bandwidth probing on video channels after 30s  of video being inactive (no inbound video RTP packets).