### PR TITLE
Add static ICE endpoints for probing STUN requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,8 @@ set(FILES
         transport/Endpoint.h
         transport/IceJob.cpp
         transport/IceJob.h
+        transport/ProbeServer.cpp
+        transport/ProbeServer.h
         transport/RecordingEndpoint.cpp
         transport/RecordingEndpoint.h
         transport/RecordingTransport.cpp

--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -8,6 +8,7 @@
 #include "jobmanager/WorkerThread.h"
 #include "transport/RtcePoll.h"
 #include "transport/TransportFactory.h"
+#include "transport/ProbeServer.h"
 #include "transport/dtls/SrtpClientFactory.h"
 #include "transport/dtls/SslDtls.h"
 #include "utils/IdGenerator.h"
@@ -151,6 +152,8 @@ void Bridge::initialize()
         logger::error("Failed to initialize transport factory", "main");
         return;
     }
+
+    _probeServer = std::make_unique<transport::ProbeServer>();
 
     _mixerManager = std::make_unique<bridge::MixerManager>(*_idGenerator,
         *_ssrcGenerator,

--- a/bridge/Bridge.h
+++ b/bridge/Bridge.h
@@ -25,6 +25,7 @@ class RtcePoll;
 class SrtpClientFactory;
 class SslDtls;
 class TransportFactory;
+class ProbeServer;
 } // namespace transport
 
 namespace httpd
@@ -68,6 +69,7 @@ private:
     const std::unique_ptr<memory::PacketPoolAllocator> _sendPacketAllocator;
     const std::unique_ptr<memory::AudioPacketPoolAllocator> _audioPacketAllocator;
     std::unique_ptr<transport::TransportFactory> _transportFactory;
+    std::unique_ptr<transport::ProbeServer> _probeServer;
     const std::unique_ptr<bridge::Engine> _engine;
     std::unique_ptr<bridge::MixerManager> _mixerManager;
     std::unique_ptr<bridge::ApiRequestHandler> _requestHandler;

--- a/transport/ProbeServer.cpp
+++ b/transport/ProbeServer.cpp
@@ -1,0 +1,110 @@
+#include "transport/ProbeServer.h"
+#include "transport/ice/Stun.h"
+#include "utils/Time.h"
+
+namespace transport
+{
+ProbeServer::ProbeServer()
+{
+    _probeCredentials = std::make_pair<std::string, std::string>("", "");
+}
+
+
+// Endpoint::IEvents
+void ProbeServer::onRtpReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet) {
+    }
+
+void ProbeServer::onDtlsReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet) {};
+
+void ProbeServer::onRtcpReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet) {}
+
+void ProbeServer::onIceReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet) 
+{
+    // TODO validate credentials?
+    replyStunOk(endpoint, source, std::move(packet));
+}
+
+void ProbeServer::onRegistered(Endpoint& endpoint) {}
+void ProbeServer::onUnregistered(Endpoint& endpoint) {}
+
+// ServerEndpoint::IEvents
+void ProbeServer::onServerPortRegistered(ServerEndpoint& endpoint) {}
+
+void ProbeServer::onServerPortUnregistered(ServerEndpoint& endpoint)
+{
+    // TODO do not re-register if unregistered on shutdown?
+    endpoint.registerListener(_probeCredentials.first, this);
+}
+
+void ProbeServer::onIceTcpConnect(std::shared_ptr<Endpoint> endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet) 
+{
+    if (endpoint->getTransportType() == ice::TransportType::TCP)
+    {
+        replyStunOk(*endpoint, source, std::move(packet));
+    }
+}
+
+void ProbeServer::replyStunOk(Endpoint& endpoint, 
+    const SocketAddress& destination,
+    memory::UniquePacket packet)
+{
+    uint64_t timestamp = utils::Time::getAbsoluteTime();
+    const void *data = packet->get();
+
+    auto* msg = ice::StunMessage::fromPtr(data);
+    const auto method = msg->header.getMethod();
+
+    // TODO
+    // verify the ufrag password
+
+    if (method == ice::StunHeader::BindingRequest)
+    {
+        ice::StunMessage response;
+        response.header.transactionId = msg->header.transactionId;
+        response.header.setMethod(ice::StunHeader::BindingResponse);
+        //response.add(StunGenericAttribute(StunAttribute::SOFTWARE, _config.software));
+        response.add(ice::StunXorMappedAddress(destination, response.header));
+        response.addMessageIntegrity(_probeCredentials.second);
+        response.addFingerprint();
+
+        endpoint.sendStunTo(
+            destination, 
+            response.header.transactionId.get(), 
+            &response, 
+            response.size(), 
+            timestamp);         
+    }    
+}
+
+void ProbeServer::registerEndpoint(Endpoint& endpoint)
+{
+    endpoint.registerListener(_probeCredentials.first, this);
+}
+
+void ProbeServer::registerEndpoint(ServerEndpoint& endpoint)
+{
+    endpoint.registerListener(_probeCredentials.first, this);
+}
+
+// ICE
+const std::pair<std::string, std::string>& ProbeServer::getProbeCredentials() const
+{
+    return _probeCredentials;
+}
+
+}

--- a/transport/ProbeServer.h
+++ b/transport/ProbeServer.h
@@ -1,0 +1,77 @@
+#pragma once
+#include "transport/Endpoint.h"
+#include "ice/IceCandidate.h"
+
+namespace transport {
+
+struct ProbeCandidate
+{
+    std::string protocol;
+    transport::SocketAddress address;
+    ice::TransportType transport;
+};
+
+
+class ProbeServer : public Endpoint::IEvents,
+                    public ServerEndpoint::IEvents 
+{
+
+public:
+    ProbeServer();
+    virtual ~ProbeServer() {};
+
+    // Endpoint::IEvents
+    virtual void onRtpReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onDtlsReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onRtcpReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onIceReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onRegistered(Endpoint&) override;
+    virtual void onUnregistered(Endpoint&) override;
+
+    // ServerEndpoint::IEvents
+    virtual void onServerPortRegistered(ServerEndpoint&) override;
+    virtual void onServerPortUnregistered(ServerEndpoint&) override;
+
+    virtual void onIceTcpConnect(std::shared_ptr<Endpoint>,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    // Ice
+    const std::pair<std::string, std::string>& getProbeCredentials() const;
+    //const std::vector<ProbeCandidate> getProbeCandidates() const;
+
+    // Endpoints
+    void registerEndpoint(Endpoint&);
+    void registerEndpoint(ServerEndpoint&);
+    void unregisterEndpoint(Endpoint&);
+    void unregisterEndpoint(ServerEndpoint&);    
+
+private:
+    std::pair<std::string, std::string> _probeCredentials;
+    //std::vector<ProbeCandidate> _probeCandidates;
+
+    void replyStunOk(Endpoint&,
+        const SocketAddress&,
+        memory::UniquePacket);
+};
+
+
+
+}

--- a/transport/TransportFactory.h
+++ b/transport/TransportFactory.h
@@ -35,6 +35,7 @@ class RtcePoll;
 class RtcTransport;
 class SocketAddress;
 class Endpoint;
+class ProbeServer;
 typedef std::vector<std::shared_ptr<Endpoint>> Endpoints;
 
 class TransportFactory
@@ -67,6 +68,12 @@ public:
     virtual bool openRtpMuxPorts(Endpoints& rtpPorts) const = 0;
 
     virtual void maintenance(uint64_t timestamp) = 0;
+
+    virtual void registerProbeServer(ProbeServer& server) = 0;
+    virtual void unregisterProbeServer(ProbeServer& server) = 0;
+    //virtual std::vector<SocketAddress> getProbingUdpEndpoints() const = 0;
+    //virtual std::vector<SocketAddress> getProbingTcpEndpoints() const = 0;
+
 };
 
 std::unique_ptr<TransportFactory> createTransportFactory(jobmanager::JobManager& jobManager,


### PR DESCRIPTION
So far I added new ProbeServer class which implements listener interfaces for both UdpEndpoint and TcpServerEndpoint. It will handle incoming probes and reply with OK STUN response.

Current questions/concerns:

- Ownership of "probing endpoints". Such simplified (protocol/IP/port) ICE candidates should be based on a shared (UDP) endpoint and TcpServerEndpoint. Currently the endpoints are created/owned by TransportFactory. It should either take on responsibility to build the probing endpoints and expose them or share actual endpoints with new ProbeServer.
- Closing TCP connection after replying to probing STUN request. As far as I understand we currently close TCP connection in these cases: 1) invalid STUN request 2) attack 3) connection closed by client. TcpEndpoint owns file descriptor and closes it when required. There is no mechanism to close connection from TCP endpoint listener as for now.
- Ownership of static ICE credentials. The credentials should be used to register listener on endpoints and also shared via API with MBR/CS. It seems more appropriate if ProbeServer generates and exposes them. However, it would mean that probing functionality is split between ProbeServer (credentials) and TransportFactory (probing endpoints), which doesn't seem good.