### PR TITLE
Add static ICE endpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(FILES
         bridge/endpointActions/ApiActions.h
         bridge/endpointActions/GetConferenceInfo.cpp
         bridge/endpointActions/GetEndpointInfo.cpp
+        bridge/endpointActions/GetProbingInfo.cpp
         bridge/endpointActions/AllocateConference.cpp
         bridge/endpointActions/ConferenceActions.cpp
         bridge/endpointActions/GetConferences.cpp
@@ -317,6 +318,8 @@ set(FILES
         transport/Endpoint.h
         transport/IceJob.cpp
         transport/IceJob.h
+        transport/ProbeServer.cpp
+        transport/ProbeServer.h
         transport/RecordingEndpoint.cpp
         transport/RecordingEndpoint.h
         transport/RecordingTransport.cpp

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ The Symphony Media Bridge is a cmake based project that can be built and run for
 
 #### 2. Set Clang as compiler
 
-``` export CC=clang && export CXX=clang++```
+```export CC=clang && export CXX=clang++```
 
 #### 3. Generate the Makefile
 
 ```cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .```
-
 
 ### Building for MacOSX
 

--- a/api/Parser.cpp
+++ b/api/Parser.cpp
@@ -162,29 +162,7 @@ api::EndpointDescription::Transport parsePatchEndpointTransport(const nlohmann::
 
     if (data.find("ice") != data.end())
     {
-        const auto& iceJson = data["ice"];
-        api::EndpointDescription::Ice ice;
-        ice._ufrag = iceJson["ufrag"].get<std::string>();
-        ice._pwd = iceJson["pwd"].get<std::string>();
-
-        for (const auto& candidateJson : optionalJsonArray(iceJson, "candidates"))
-        {
-            api::EndpointDescription::Candidate candidate;
-            candidate._generation = candidateJson["generation"].get<uint32_t>();
-            candidate._component = candidateJson["component"].get<uint32_t>();
-            candidate._protocol = candidateJson["protocol"].get<std::string>();
-            candidate._port = candidateJson["port"].get<uint32_t>();
-            candidate._ip = candidateJson["ip"].get<std::string>();
-            setIfExists(candidate._relPort, candidateJson, "rel-port");
-            setIfExists(candidate._relAddr, candidateJson, "rel-addr");
-            candidate._foundation = candidateJson["foundation"].get<std::string>();
-            candidate._priority = candidateJson["priority"].get<uint32_t>();
-            candidate._type = candidateJson["type"].get<std::string>();
-            candidate._network =
-                candidateJson.find("network") != candidateJson.end() ? candidateJson["network"].get<uint32_t>() : 0;
-            ice._candidates.emplace_back(std::move(candidate));
-        }
-
+        api::EndpointDescription::Ice ice = api::Parser::parseIce(data["ice"]);
         transport._ice.set(ice);
     }
 
@@ -519,6 +497,32 @@ ConferenceEndpointExtendedInfo parseEndpointExtendedInfo(const nlohmann::json& d
     return endpoint;
 }
 
+EndpointDescription::Ice parseIce(const nlohmann::json& iceJson)
+{
+    api::EndpointDescription::Ice ice;
+    ice._ufrag = iceJson["ufrag"].get<std::string>();
+    ice._pwd = iceJson["pwd"].get<std::string>();
+
+    for (const auto& candidateJson : optionalJsonArray(iceJson, "candidates"))
+    {
+        api::EndpointDescription::Candidate candidate;
+        candidate._generation = candidateJson["generation"].get<uint32_t>();
+        candidate._component = candidateJson["component"].get<uint32_t>();
+        candidate._protocol = candidateJson["protocol"].get<std::string>();
+        candidate._port = candidateJson["port"].get<uint32_t>();
+        candidate._ip = candidateJson["ip"].get<std::string>();
+        setIfExists(candidate._relPort, candidateJson, "rel-port");
+        setIfExists(candidate._relAddr, candidateJson, "rel-addr");
+        candidate._foundation = candidateJson["foundation"].get<std::string>();
+        candidate._priority = candidateJson["priority"].get<uint32_t>();
+        candidate._type = candidateJson["type"].get<std::string>();
+        candidate._network =
+            candidateJson.find("network") != candidateJson.end() ? candidateJson["network"].get<uint32_t>() : 0;
+        ice._candidates.emplace_back(std::move(candidate));
+    }
+
+    return ice;
+}
 } // namespace Parser
 
 } // namespace api

--- a/api/Parser.h
+++ b/api/Parser.h
@@ -19,6 +19,7 @@ EndpointDescription parsePatchEndpoint(const nlohmann::json&, const std::string&
 Recording parseRecording(const nlohmann::json&);
 std::vector<ConferenceEndpoint> parseConferenceEndpoints(const nlohmann::json&);
 ConferenceEndpointExtendedInfo parseEndpointExtendedInfo(const nlohmann::json&);
+EndpointDescription::Ice parseIce(const nlohmann::json&);
 } // namespace Parser
 
 } // namespace api

--- a/bridge/ApiRequestHandler.h
+++ b/bridge/ApiRequestHandler.h
@@ -20,7 +20,8 @@ struct Recording;
 namespace transport
 {
 class SslDtls;
-}
+class ProbeServer;
+} // namespace transport
 
 namespace utils
 {
@@ -42,7 +43,9 @@ class RequestLogger;
 class ApiRequestHandler : public httpd::HttpRequestHandler, public ActionContext
 {
 public:
-    ApiRequestHandler(bridge::MixerManager& mixerManager, transport::SslDtls& sslDtls);
+    ApiRequestHandler(bridge::MixerManager& mixerManager,
+        transport::SslDtls& sslDtls,
+        transport::ProbeServer& probeServer);
     httpd::Response onRequest(const httpd::Request& request) override;
 
 private:

--- a/bridge/Bridge.h
+++ b/bridge/Bridge.h
@@ -26,6 +26,7 @@ class SrtpClientFactory;
 class SslDtls;
 class TransportFactory;
 class EndpointFactory;
+class ProbeServer;
 } // namespace transport
 
 namespace httpd
@@ -70,6 +71,7 @@ private:
     const std::unique_ptr<memory::PacketPoolAllocator> _sendPacketAllocator;
     const std::unique_ptr<memory::AudioPacketPoolAllocator> _audioPacketAllocator;
     std::unique_ptr<transport::TransportFactory> _transportFactory;
+    std::unique_ptr<transport::ProbeServer> _probeServer;
     const std::unique_ptr<bridge::Engine> _engine;
     std::unique_ptr<bridge::MixerManager> _mixerManager;
     std::unique_ptr<bridge::ApiRequestHandler> _requestHandler;

--- a/bridge/endpointActions/ActionContext.h
+++ b/bridge/endpointActions/ActionContext.h
@@ -8,6 +8,7 @@ class MixerManager;
 
 namespace transport
 {
+class ProbeServer;
 class SslDtls;
 } // namespace transport
 
@@ -15,12 +16,14 @@ namespace bridge
 {
 struct ActionContext
 {
-    ActionContext(bridge::MixerManager& mixerManager, transport::SslDtls& sslDtls)
+    ActionContext(bridge::MixerManager& mixerManager, transport::SslDtls& sslDtls, transport::ProbeServer& probeServer)
         : mixerManager(mixerManager),
-          sslDtls(sslDtls)
+          sslDtls(sslDtls),
+          probeServer(probeServer)
     {
     }
     bridge::MixerManager& mixerManager;
     transport::SslDtls& sslDtls;
+    transport::ProbeServer& probeServer;
 };
 } // namespace bridge

--- a/bridge/endpointActions/ApiActions.h
+++ b/bridge/endpointActions/ApiActions.h
@@ -45,4 +45,8 @@ httpd::Response processBarbellAction(ActionContext*,
     RequestLogger&,
     const httpd::Request&,
     const ::utils::StringTokenizer::Token&);
+httpd::Response getProbingInfo(ActionContext*,
+    RequestLogger&,
+    const httpd::Request&,
+    const ::utils::StringTokenizer::Token&);
 } // namespace bridge

--- a/bridge/endpointActions/ApiHelpers.cpp
+++ b/bridge/endpointActions/ApiHelpers.cpp
@@ -145,6 +145,12 @@ std::pair<std::vector<ice::IceCandidate>, std::pair<std::string, std::string>> g
     const api::EndpointDescription::Transport& transport)
 {
     const auto& ice = transport._ice.get();
+    return getIceCandidatesAndCredentials(ice);
+}
+
+std::pair<std::vector<ice::IceCandidate>, std::pair<std::string, std::string>> getIceCandidatesAndCredentials(
+    const api::EndpointDescription::Ice& ice)
+{
     std::vector<ice::IceCandidate> candidates;
 
     for (const auto& candidate : ice._candidates)

--- a/bridge/endpointActions/ApiHelpers.h
+++ b/bridge/endpointActions/ApiHelpers.h
@@ -17,6 +17,8 @@ namespace bridge
 
 std::pair<std::vector<ice::IceCandidate>, std::pair<std::string, std::string>> getIceCandidatesAndCredentials(
     const api::EndpointDescription::Transport&);
+std::pair<std::vector<ice::IceCandidate>, std::pair<std::string, std::string>> getIceCandidatesAndCredentials(
+    const api::EndpointDescription::Ice& ice);
 std::unique_lock<std::mutex> getConferenceMixer(ActionContext*,
     const std::string& conferenceId,
     bridge::Mixer*& outMixer);

--- a/bridge/endpointActions/GetProbingInfo.cpp
+++ b/bridge/endpointActions/GetProbingInfo.cpp
@@ -1,0 +1,63 @@
+#include "ApiActions.h"
+#include "ApiHelpers.h"
+#include "api/ConferenceEndpoint.h"
+#include "bridge/Mixer.h"
+#include "bridge/MixerManager.h"
+#include "bridge/RequestLogger.h"
+#include "nlohmann/json.hpp"
+#include "transport/ProbeServer.h"
+
+namespace bridge
+{
+httpd::Response getProbingInfo(ActionContext* context,
+    RequestLogger& requestLogger,
+    const httpd::Request&,
+    const utils::StringTokenizer::Token&)
+{
+    nlohmann::json responseBodyJson;
+    nlohmann::json iceJson;
+
+    auto& probeServer = context->probeServer;
+
+    const auto credentials = probeServer.getCredentials();
+
+    iceJson["ufrag"] = credentials.first;
+    iceJson["pwd"] = credentials.second;
+
+    nlohmann::json candidatesJson = nlohmann::json::array();
+
+    for (const auto& candidate : probeServer.getCandidates())
+    {
+        api::EndpointDescription::Candidate description = iceCandidateToApi(candidate);
+
+        nlohmann::json candidateJson;
+        candidateJson["generation"] = description._generation;
+        candidateJson["component"] = description._component;
+        candidateJson["protocol"] = description._protocol;
+        candidateJson["port"] = description._port;
+        candidateJson["ip"] = description._ip;
+        candidateJson["foundation"] = description._foundation;
+        candidateJson["priority"] = description._priority;
+        candidateJson["type"] = description._type;
+        candidateJson["network"] = description._network;
+        if (description._relAddr.isSet())
+        {
+            candidateJson["rel-addr"] = description._relAddr.get();
+        }
+        if (description._relPort.isSet())
+        {
+            candidateJson["rel-port"] = description._relPort.get();
+        }
+
+        candidatesJson.push_back(candidateJson);
+    }
+
+    iceJson["candidates"] = candidatesJson;
+    responseBodyJson["ice"] = iceJson;
+
+    httpd::Response response(httpd::StatusCode::OK, responseBodyJson.dump(4));
+    response._headers["Content-type"] = "text/json";
+    requestLogger.setResponse(response);
+    return response;
+}
+} // namespace bridge

--- a/test/transport/FakeNetwork.cpp
+++ b/test/transport/FakeNetwork.cpp
@@ -1,4 +1,5 @@
 #include "FakeNetwork.h"
+#include "concurrency/ThreadUtils.h"
 #include "logger/Logger.h"
 #include "utils/Time.h"
 #include <algorithm>
@@ -225,6 +226,7 @@ std::shared_ptr<Internet> InternetRunner::get()
 
 void InternetRunner::internetThreadRun()
 {
+    concurrency::setThreadName("Internet");
     while (_command != quit)
     {
         if (_command == State::running)

--- a/transport/ProbeServer.cpp
+++ b/transport/ProbeServer.cpp
@@ -1,0 +1,368 @@
+#include "transport/ProbeServer.h"
+#include "concurrency/ThreadUtils.h"
+#include "ice/IceCandidate.h"
+#include "logger/Logger.h"
+#include "transport/ice/IceSession.h"
+#include "transport/ice/Stun.h"
+#include "utils/ContainerAlgorithms.h"
+#include "utils/Time.h"
+#include <unistd.h>
+
+namespace transport
+{
+ProbeServer::ProbeServer(const ice::IceConfig& iceConfig, const config::Config& config)
+    : _iceConfig(iceConfig),
+      _config(config),
+      _queue(1024),
+      _maintenanceThreadIsRunning(true),
+      _maintenanceThread(new std::thread([this] { this->run(); }))
+{
+    char ufrag[14 + 1];
+    char pwd[24 + 1]; // length selected to make attribute *4 length
+
+    ice::IceSession::generateCredentialString(_idGenerator, ufrag, sizeof(ufrag) - 1);
+    ice::IceSession::generateCredentialString(_idGenerator, pwd, sizeof(pwd) - 1);
+
+    _credentials = std::make_pair<std::string, std::string>(ufrag, pwd);
+}
+
+// Endpoint::IEvents
+void ProbeServer::onRtpReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet)
+{
+}
+
+void ProbeServer::onDtlsReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet){};
+
+void ProbeServer::onRtcpReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet)
+{
+}
+
+void ProbeServer::onIceReceived(Endpoint& endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet)
+{
+    replyStunOk(endpoint, source, std::move(packet));
+}
+
+void ProbeServer::onRegistered(Endpoint& endpoint)
+{
+    if (endpoint.getTransportType() != ice::TransportType::UDP)
+    {
+        return;
+    }
+
+    const auto localAddress = endpoint.getLocalPort();
+    const auto localPort = localAddress.getPort();
+
+    int interfacePreference = 256 - getInterfaceIndex(localAddress);
+
+    addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+        ice::TransportType::UDP,
+        ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::HOST,
+            interfacePreference,
+            ice::IceComponent::RTP,
+            ice::TransportType::UDP),
+        localAddress,
+        localAddress,
+        ice::IceCandidate::Type::HOST));
+
+    if (!_iceConfig.publicIpv4.empty() && localAddress.getFamily() == AF_INET)
+    {
+        auto publicAddress = _iceConfig.publicIpv4;
+        publicAddress.setPort(localPort);
+
+        addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+            ice::TransportType::UDP,
+            ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                interfacePreference,
+                ice::IceComponent::RTP,
+                ice::TransportType::UDP),
+            publicAddress,
+            localAddress,
+            ice::IceCandidate::Type::SRFLX));
+
+        logger::debug("Registered UDP endpoint %s:%u", _name, publicAddress.ipToString().c_str(), localPort);
+    }
+
+    if (!_iceConfig.publicIpv6.empty() && localAddress.getFamily() == AF_INET6)
+    {
+        auto publicAddress = _iceConfig.publicIpv6;
+        publicAddress.setPort(localPort);
+
+        addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+            ice::TransportType::UDP,
+            ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                interfacePreference,
+                ice::IceComponent::RTP,
+                ice::TransportType::UDP),
+            publicAddress,
+            localAddress,
+            ice::IceCandidate::Type::SRFLX));
+
+        logger::debug("Registered UDP endpoint %s:%u", _name, publicAddress.ipToString().c_str(), localPort);
+    }
+}
+
+void ProbeServer::onUnregistered(Endpoint& endpoint)
+{
+    const SocketAddress& address = endpoint.getLocalPort();
+
+    if (endpoint.getTransportType() == ice::TransportType::UDP)
+    {
+        std::remove_if(_iceCandidates.begin(), _iceCandidates.end(), [address](const ice::IceCandidate& c) {
+            return c.transportType == ice::TransportType::UDP && c.baseAddress == address;
+        });
+    }
+}
+
+// ServerEndpoint::IEvents
+void ProbeServer::onServerPortRegistered(ServerEndpoint& endpoint)
+{
+    const auto localAddress = endpoint.getLocalPort();
+    const auto localPort = localAddress.getPort();
+
+    int interfacePreference = 128 - getInterfaceIndex(localAddress);
+
+    addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+        ice::TransportType::TCP,
+        ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::HOST,
+            interfacePreference,
+            ice::IceComponent::RTP,
+            ice::TransportType::TCP),
+        localAddress,
+        localAddress,
+        ice::IceCandidate::Type::HOST,
+        ice::TcpType::PASSIVE));
+
+    if (!_iceConfig.publicIpv4.empty() && endpoint.getLocalPort().getFamily() == AF_INET)
+    {
+        auto publicAddress = _iceConfig.publicIpv4;
+        publicAddress.setPort(localPort);
+
+        addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+            ice::TransportType::TCP,
+            ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                interfacePreference,
+                ice::IceComponent::RTP,
+                ice::TransportType::TCP),
+            publicAddress,
+            localAddress,
+            ice::IceCandidate::Type::SRFLX));
+
+        logger::debug("Registered TCP server endpoint %s:%u", _name, publicAddress.ipToString().c_str(), localPort);
+
+        if (_config.ice.tcp.aliasPort != 0)
+        {
+            publicAddress.setPort(_config.ice.tcp.aliasPort);
+
+            addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+                ice::TransportType::TCP,
+                ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                    interfacePreference,
+                    ice::IceComponent::RTP,
+                    ice::TransportType::TCP),
+                publicAddress,
+                localAddress,
+                ice::IceCandidate::Type::SRFLX));
+
+            logger::debug("Registered TCP server endpoint %s:%u",
+                _name,
+                publicAddress.ipToString().c_str(),
+                _config.ice.tcp.aliasPort.get());
+        }
+    }
+
+    if (!_iceConfig.publicIpv6.empty() && endpoint.getLocalPort().getFamily() == AF_INET6)
+    {
+        auto publicAddress = _iceConfig.publicIpv6;
+        publicAddress.setPort(localPort);
+
+        addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+            ice::TransportType::TCP,
+            ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                interfacePreference,
+                ice::IceComponent::RTP,
+                ice::TransportType::TCP),
+            publicAddress,
+            localAddress,
+            ice::IceCandidate::Type::SRFLX));
+
+        logger::debug("Registered TCP server endpoint %s:%u", _name, publicAddress.ipToString().c_str(), localPort);
+
+        if (_config.ice.tcp.aliasPort != 0)
+        {
+            publicAddress.setPort(_config.ice.tcp.aliasPort);
+
+            addCandidate(ice::IceCandidate(ice::IceComponent::RTP,
+                ice::TransportType::TCP,
+                ice::IceCandidate::computeCandidatePriority(ice::IceCandidate::Type::SRFLX,
+                    interfacePreference,
+                    ice::IceComponent::RTP,
+                    ice::TransportType::TCP),
+                publicAddress,
+                localAddress,
+                ice::IceCandidate::Type::SRFLX));
+
+            logger::debug("Registered TCP server endpoint %s:%u",
+                _name,
+                publicAddress.ipToString().c_str(),
+                _config.ice.tcp.aliasPort.get());
+        }
+    }
+}
+
+void ProbeServer::onServerPortUnregistered(ServerEndpoint& endpoint)
+{
+    // Re-register to keep listening on probes;
+    // TcpServerEndpoint unregisters the listener after dispatching onIceTcpConnect
+    endpoint.registerListener(_credentials.first, this);
+}
+
+void ProbeServer::onIceTcpConnect(std::shared_ptr<Endpoint> endpoint,
+    const SocketAddress& source,
+    const SocketAddress& target,
+    memory::UniquePacket packet)
+{
+    if (endpoint->getTransportType() == ice::TransportType::TCP)
+    {
+        replyStunOk(*endpoint, source, std::move(packet));
+
+        ProbeTcpConnection connection;
+        connection.endpoint = endpoint;
+        connection.timestamp = utils::Time::getAbsoluteTime();
+        _queue.push(connection);
+    }
+}
+
+// Endpoint::IStopEvents
+void ProbeServer::onEndpointStopped(Endpoint* endpoint) {}
+
+void ProbeServer::replyStunOk(Endpoint& endpoint, const SocketAddress& destination, memory::UniquePacket packet)
+{
+    uint64_t timestamp = utils::Time::getAbsoluteTime();
+    const void* data = packet->get();
+
+    auto* stunMessage = ice::StunMessage::fromPtr(data);
+
+    if (stunMessage && stunMessage->isValid() && stunMessage->header.isRequest() &&
+        stunMessage->isAuthentic(_credentials.second))
+    {
+        ice::StunMessage response;
+        response.header.transactionId = stunMessage->header.transactionId;
+        response.header.setMethod(ice::StunHeader::BindingResponse);
+        response.add(ice::StunXorMappedAddress(destination, response.header));
+        response.addMessageIntegrity(_credentials.second);
+        response.addFingerprint();
+
+        endpoint.sendStunTo(destination, response.header.transactionId.get(), &response, response.size(), timestamp);
+    }
+    else
+    {
+        endpoint.stop(this);
+    }
+}
+
+void ProbeServer::addCandidate(const ice::IceCandidate& candidate)
+{
+    if (!utils::contains(_iceCandidates, [candidate](const ice::IceCandidate& x) {
+            return x.address == candidate.address && x.baseAddress == candidate.baseAddress &&
+                x.transportType == candidate.transportType;
+        }))
+    {
+        _iceCandidates.push_back(candidate);
+    }
+
+    std::sort(_iceCandidates.begin(), _iceCandidates.end(), [](const ice::IceCandidate& a, const ice::IceCandidate& b) {
+        return a.priority > b.priority;
+    });
+}
+
+void ProbeServer::run()
+{
+    concurrency::setThreadName("ProbeServerMaintenance");
+
+    while (_maintenanceThreadIsRunning)
+    {
+        while (!_queue.empty())
+        {
+            ProbeTcpConnection connection;
+            if (_queue.pop(connection))
+            {
+                _tcpConnections.emplace_back(connection);
+            }
+        }
+
+        auto now = utils::Time::getAbsoluteTime();
+
+        for (auto it = _tcpConnections.begin(); it != _tcpConnections.end(); ++it)
+        {
+            if (utils::Time::diffGT(it->timestamp, now, _iceConfig.probeConnectionExpirationTimeout * utils::Time::sec))
+            {
+                it->endpoint->stop(this);
+                _tcpConnections.erase(it);
+            }
+        }
+
+        utils::Time::nanoSleep(100 * utils::Time::ms);
+    }
+}
+
+void ProbeServer::stop()
+{
+    _maintenanceThreadIsRunning = false;
+    _maintenanceThread->join();
+
+    while (!_queue.empty())
+    {
+        ProbeTcpConnection connection;
+        if (_queue.pop(connection))
+        {
+            _tcpConnections.emplace_back(connection);
+        }
+    }
+
+    for (auto it = _tcpConnections.begin(); it != _tcpConnections.end(); ++it)
+    {
+        it->endpoint->stop(this);
+        _tcpConnections.erase(it);
+    }
+}
+
+// ICE
+const std::pair<std::string, std::string>& ProbeServer::getCredentials() const
+{
+    return _credentials;
+}
+
+const std::vector<ice::IceCandidate>& ProbeServer::getCandidates()
+{
+    return _iceCandidates;
+}
+
+int ProbeServer::getInterfaceIndex(transport::SocketAddress address)
+{
+    int index = 0;
+    for (auto& interface : _interfaces)
+    {
+        if (interface == address)
+        {
+            return index;
+        }
+        index++;
+    }
+
+    _interfaces.emplace_back(address);
+    return index;
+}
+
+} // namespace transport

--- a/transport/ProbeServer.h
+++ b/transport/ProbeServer.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "concurrency/MpmcQueue.h"
+#include "ice/IceCandidate.h"
+#include "ice/Stun.h"
+#include "transport/Endpoint.h"
+#include <config/Config.h>
+#include <mutex>
+#include <unordered_set>
+
+namespace transport
+{
+
+class ProbeServer : public Endpoint::IEvents, public ServerEndpoint::IEvents, public Endpoint::IStopEvents
+{
+
+public:
+    ProbeServer(const ice::IceConfig& iceConfig, const config::Config& config);
+    virtual ~ProbeServer(){};
+
+    // Endpoint::IEvents
+    virtual void onRtpReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onDtlsReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onRtcpReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onIceReceived(Endpoint&,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    virtual void onRegistered(Endpoint&) override;
+    virtual void onUnregistered(Endpoint&) override;
+
+    // ServerEndpoint::IEvents
+    virtual void onServerPortRegistered(ServerEndpoint&) override;
+    virtual void onServerPortUnregistered(ServerEndpoint&) override;
+
+    virtual void onIceTcpConnect(std::shared_ptr<Endpoint>,
+        const SocketAddress& source,
+        const SocketAddress& target,
+        memory::UniquePacket) override;
+
+    // Endpoint::IStopEvents
+    virtual void onEndpointStopped(Endpoint*) override;
+
+    // Ice
+    const std::pair<std::string, std::string>& getCredentials() const;
+    const std::vector<ice::IceCandidate>& getCandidates();
+
+    // Maintenance
+    void run();
+    void stop();
+
+private:
+    std::pair<std::string, std::string> _credentials;
+    const ice::IceConfig& _iceConfig;
+    const config::Config& _config;
+    ice::StunTransactionIdGenerator _idGenerator;
+    std::vector<ice::IceCandidate> _iceCandidates;
+    std::vector<transport::SocketAddress> _interfaces;
+
+    const char* _name = "ProbeServer";
+
+    struct ProbeTcpConnection
+    {
+        std::shared_ptr<Endpoint> endpoint;
+        uint64_t timestamp;
+    };
+
+    std::vector<ProbeTcpConnection> _tcpConnections;
+    concurrency::MpmcQueue<ProbeTcpConnection> _queue;
+    std::atomic_bool _maintenanceThreadIsRunning;
+    std::unique_ptr<std::thread> _maintenanceThread;
+
+    void replyStunOk(Endpoint&, const SocketAddress&, memory::UniquePacket);
+    void addCandidate(const ice::IceCandidate& candidate);
+    int getInterfaceIndex(transport::SocketAddress address);
+};
+} // namespace transport

--- a/transport/TransportFactory.cpp
+++ b/transport/TransportFactory.cpp
@@ -509,6 +509,41 @@ public:
         endpoint->stop(this);
     }
 
+    void registerIceListener(Endpoint::IEvents& listener, const std::string& ufrag) override
+    {
+        for (auto& endpoint : _sharedEndpoints[0])
+        {
+            endpoint->registerListener(ufrag, &listener);
+        }
+    }
+
+    void registerIceListener(ServerEndpoint::IEvents& listener, const std::string& ufrag) override
+    {
+        for (auto& endpoint : _tcpServerEndpoints)
+        {
+            endpoint->registerListener(ufrag, &listener);
+        }
+    }
+
+    void unregisterIceListener(Endpoint::IEvents& listener, const std::string& ufrag) override
+    {
+        for (auto& endpoints : _sharedEndpoints)
+        {
+            for (auto& endpoint : endpoints)
+            {
+                endpoint->unregisterListener(&listener);
+            }
+        }
+    }
+
+    void unregisterIceListener(ServerEndpoint::IEvents& listener, const std::string& ufrag) override
+    {
+        for (auto& endpoint : _tcpServerEndpoints)
+        {
+            endpoint->unregisterListener(ufrag, &listener);
+        }
+    }
+
 private:
     template <typename T>
     class DeleteJob : public jobmanager::CountedJob

--- a/transport/TransportFactory.h
+++ b/transport/TransportFactory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "memory/PacketPoolAllocator.h"
+#include "transport/Endpoint.h"
 #include "transport/EndpointFactory.h"
 #include "transport/EndpointMetrics.h"
 #include "transport/ice/IceSession.h"
@@ -35,7 +36,7 @@ class RecordingTransport;
 class RtcePoll;
 class RtcTransport;
 class SocketAddress;
-class Endpoint;
+class ProbeServer;
 typedef std::vector<std::shared_ptr<Endpoint>> Endpoints;
 
 class TransportFactory
@@ -72,6 +73,11 @@ public:
     virtual bool openRtpMuxPorts(Endpoints& rtpPorts) const = 0;
 
     virtual void maintenance(uint64_t timestamp) = 0;
+
+    virtual void registerIceListener(Endpoint::IEvents&, const std::string& ufrag) = 0;
+    virtual void registerIceListener(ServerEndpoint::IEvents&, const std::string& ufrag) = 0;
+    virtual void unregisterIceListener(Endpoint::IEvents&, const std::string& ufrag) = 0;
+    virtual void unregisterIceListener(ServerEndpoint::IEvents&, const std::string& ufrag) = 0;
 };
 
 std::unique_ptr<TransportFactory> createTransportFactory(jobmanager::JobManager& jobManager,

--- a/transport/ice/IceCandidate.cpp
+++ b/transport/ice/IceCandidate.cpp
@@ -123,7 +123,6 @@ IceCandidate& IceCandidate::operator=(const IceCandidate& b)
     return *this;
 }
 
-
 const std::string& toString(IceCandidate::Type type)
 {
     switch (type)
@@ -154,6 +153,30 @@ const std::string& toString(TransportType type)
     }
 
     return UNKNOWN;
+}
+
+uint32_t IceCandidate::computeCandidatePriority(IceCandidate::Type type,
+    int localInterfacePreference,
+    IceComponent component,
+    TransportType transportType)
+{
+    int typePreference = 0;
+    switch (type)
+    {
+    case IceCandidate::Type::HOST:
+        typePreference = 126;
+        break;
+    case IceCandidate::Type::PRFLX:
+        typePreference = 110;
+        break;
+    case IceCandidate::Type::SRFLX:
+        typePreference = 100;
+        break;
+    case IceCandidate::Type::RELAY:
+        typePreference = 0;
+    }
+    return ((8 - int(transportType)) << 24) + (typePreference << 16) + (localInterfacePreference << 8) +
+        (256 - static_cast<int>(component));
 }
 
 } // namespace ice

--- a/transport/ice/IceCandidate.h
+++ b/transport/ice/IceCandidate.h
@@ -67,6 +67,11 @@ public:
     const char* getFoundation() const { return _foundation; }
     void setFoundation(const char* f) { std::strncpy(_foundation, f, MAX_FOUNDATION); }
 
+    static uint32_t computeCandidatePriority(IceCandidate::Type type,
+        int localInterfacePreference,
+        IceComponent component,
+        TransportType transportType);
+
     IceComponent component;
     TransportType transportType;
     uint32_t priority;

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -25,6 +25,8 @@ struct IceConfig
     uint32_t RTO = 50;
     uint32_t maxRTO = 500;
     uint32_t probeReplicates = 1;
+    uint32_t probeConnectionExpirationTimeout = 5000;
+
     std::string software = "slice"; // keep short please.
     transport::SocketAddress publicIpv4;
     transport::SocketAddress publicIpv6;
@@ -137,6 +139,7 @@ public:
     bool hasRemoteCredentials() const { return !_credentials.remote.first.empty(); }
     void probeRemoteCandidates(IceRole role, uint64_t timestamp);
     IceCandidates getRemoteCandidates() const { return _remoteCandidates; }
+    static void generateCredentialString(StunTransactionIdGenerator& idGenerator, char* targetBuffer, int length);
 
     std::pair<IceCandidate, IceCandidate> getSelectedPair() const;
     uint64_t getSelectedPairRtt() const;
@@ -256,7 +259,6 @@ private:
         const SessionCredentials& _credentials;
     };
 
-    void generateCredentialString(char* targetBuffer, int length);
     void addProbeForRemoteCandidate(EndpointInfo& endpoint, const IceCandidate& remoteCandidate);
     void sortCheckList();
 


### PR DESCRIPTION
Added new API endpoint "probing", which returns list of ICE endpoints so that clients could perform RTT measurements.
Each endpoint expects STUN Binding Request with provided ICE credentials and replies with  "ok" STUN response.
Static ICE credentials are generated on every SMB startup.

RTC-13083