### PR TITLE
Allow not specify ice candidates when there is no candidates to present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
 
 set(TEST_FILES
+    test/api/ParserTest.cpp
     test/memory/MapTest.cpp
     test/memory/PoolAllocatorTest.cpp
     test/memory/RingAllocatorTest.cpp
@@ -484,6 +485,7 @@ set(TEST_FILES
     test/gtest_main.cpp
     test/CsvWriter.h
     test/CsvWriter.cpp
+    test/ResourceLoader.cpp
     test/concurrency/MpscTest.cpp
     test/concurrency/MpmcMapTest.cpp
     test/concurrency/LockFreeListTest.cpp
@@ -541,9 +543,19 @@ set(TEST_FILES
     test/bridge/VideoNackReceiveJobTest.cpp
     test/bridge/DummyRtcTransport.h)
 
+
+set(CMAKE_TEST_DIRECTORY "${CMAKE_BINARY_DIR}/test")
+set(CMAKE_TEST_INCLUDE "${CMAKE_TEST_DIRECTORY}/include")
+configure_file(test/TestConfig.h.in ${CMAKE_TEST_INCLUDE}/TestConfig.h)
+
 add_executable(UnitTest
     ${FILES}
     ${TEST_FILES})
+
+target_include_directories(UnitTest PRIVATE ${CMAKE_TEST_INCLUDE})
+
+# Copy test Data
+file(COPY "${CMAKE_SOURCE_DIR}/test/resources" DESTINATION "${CMAKE_TEST_DIRECTORY}")
 
 target_link_libraries(UnitTest gtest gmock ${THIRD_PARTY_LIBS})
 

--- a/api/Parser.cpp
+++ b/api/Parser.cpp
@@ -167,7 +167,7 @@ api::EndpointDescription::Transport parsePatchEndpointTransport(const nlohmann::
         ice._ufrag = iceJson["ufrag"].get<std::string>();
         ice._pwd = iceJson["pwd"].get<std::string>();
 
-        for (const auto& candidateJson : iceJson["candidates"])
+        for (const auto& candidateJson : optionalJsonArray(iceJson, "candidates"))
         {
             api::EndpointDescription::Candidate candidate;
             candidate._generation = candidateJson["generation"].get<uint32_t>();

--- a/test/ResourceLoader.cpp
+++ b/test/ResourceLoader.cpp
@@ -1,0 +1,27 @@
+#include "ResourceLoader.h"
+#include <TestConfig.h>
+#include <fstream>
+#include <iterator>
+
+namespace
+{
+
+}
+
+std::string ResourceLoader::loadAsString(const std::string& resource)
+{
+    const std::string resourcePath = TestConfig::getResourcePath(resource);
+    std::ifstream input(resourcePath, std::ios::binary);
+    if (!input.good())
+    {
+        const std::string message = std::string("Can't open file: ") + resourcePath;
+        throw std::ios_base::failure(message);
+    }
+
+    return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+nlohmann::json ResourceLoader::loadAsJson(const std::string& resource)
+{
+    return nlohmann::json::parse(loadAsString(resource));
+}

--- a/test/ResourceLoader.cpp
+++ b/test/ResourceLoader.cpp
@@ -3,11 +3,6 @@
 #include <fstream>
 #include <iterator>
 
-namespace
-{
-
-}
-
 std::string ResourceLoader::loadAsString(const std::string& resource)
 {
     const std::string resourcePath = TestConfig::getResourcePath(resource);

--- a/test/ResourceLoader.h
+++ b/test/ResourceLoader.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "nlohmann/json.hpp"
+#include <string>
+
+struct ResourceLoader
+{
+    static std::string loadAsString(const std::string& resource);
+    static nlohmann::json loadAsJson(const std::string& resource);
+};

--- a/test/TestConfig.h.in
+++ b/test/TestConfig.h.in
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include <string>
+
+#ifndef _TEST_OUTPUT_FOLDER
+#define _TEST_OUTPUT_FOLDER "${CMAKE_TEST_DIRECTORY}"
+#endif
+
+#ifndef _TEST_RESOURCES_FOLDER
+#define _TEST_RESOURCES_FOLDER _TEST_OUTPUT_FOLDER "/resources"
+#endif
+
+struct TestConfig
+{
+    static std::string getResourceDirectory() { return _TEST_RESOURCES_FOLDER; }
+    static std::string getResourcePath(const std::string& resourceName)
+    {
+        return getResourceDirectory() + "/" + resourceName;
+    }
+};

--- a/test/api/ParserTest.cpp
+++ b/test/api/ParserTest.cpp
@@ -1,0 +1,39 @@
+#include "api/Parser.h"
+#include "test/ResourceLoader.h"
+#include <gtest/gtest.h>
+
+TEST(ParserTest, patchNoIceCandidates)
+{
+    auto patchBody = ResourceLoader::loadAsJson("api-patch-no-ice-candidates.json");
+    api::EndpointDescription endpointDescription = api::Parser::parsePatchEndpoint(patchBody, "endpointId-0");
+
+    ASSERT_EQ("endpointId-0", endpointDescription._endpointId);
+
+    ASSERT_EQ(true, endpointDescription._bundleTransport.isSet());
+    auto& bundleTransport = endpointDescription._bundleTransport.get();
+    ASSERT_EQ(true, bundleTransport._rtcpMux);
+
+    ASSERT_EQ(true, bundleTransport._ice.isSet());
+    auto& ice = bundleTransport._ice.get();
+    ASSERT_EQ("Rl3b", ice._ufrag);
+    ASSERT_EQ("gb4ISfk9Ppy6M5zYcZdtqldd", ice._pwd);
+    ASSERT_EQ(0, ice._candidates.size());
+}
+
+TEST(ParserTest, patchEmptyIceCandidates)
+{
+    auto patchBody = ResourceLoader::loadAsJson("api-patch-empty-ice-candidates.json");
+    api::EndpointDescription endpointDescription = api::Parser::parsePatchEndpoint(patchBody, "endpointId-0");
+
+    ASSERT_EQ("endpointId-0", endpointDescription._endpointId);
+
+    ASSERT_EQ(true, endpointDescription._bundleTransport.isSet());
+    auto& bundleTransport = endpointDescription._bundleTransport.get();
+    ASSERT_EQ(true, bundleTransport._rtcpMux);
+
+    ASSERT_EQ(true, bundleTransport._ice.isSet());
+    auto& ice = bundleTransport._ice.get();
+    ASSERT_EQ("Rl3b", ice._ufrag);
+    ASSERT_EQ("gb4ISfk9Ppy6M5zYcZdtqldd", ice._pwd);
+    ASSERT_EQ(0, ice._candidates.size());
+}

--- a/test/legacyapi/ParserTest.cpp
+++ b/test/legacyapi/ParserTest.cpp
@@ -187,7 +187,7 @@ const std::string requestData =
 
 }
 
-class ParserTest : public ::testing::Test
+class LegacyParserTest : public ::testing::Test
 {
     void SetUp() override
     {
@@ -201,12 +201,12 @@ protected:
     legacyapi::Conference _conference;
 };
 
-TEST_F(ParserTest, conferenceId)
+TEST_F(LegacyParserTest, conferenceId)
 {
     EXPECT_EQ("b554cdfd47c6133d", _conference._id);
 }
 
-TEST_F(ParserTest, channelBundle)
+TEST_F(LegacyParserTest, channelBundle)
 {
     EXPECT_EQ(1, _conference._channelBundles.size());
     const auto& channelBundle = _conference._channelBundles[0];
@@ -250,7 +250,7 @@ TEST_F(ParserTest, channelBundle)
     EXPECT_EQ(0, channelBundle._transport._candidates[1]._network);
 }
 
-TEST_F(ParserTest, contents)
+TEST_F(LegacyParserTest, contents)
 {
     EXPECT_EQ(3, _conference._contents.size());
 
@@ -314,7 +314,7 @@ TEST_F(ParserTest, contents)
     }
 }
 
-TEST_F(ParserTest, payloadTypes)
+TEST_F(LegacyParserTest, payloadTypes)
 {
     {
         const auto& audioChannel = _conference._contents[0]._channels[0];

--- a/test/resources/api-patch-empty-ice-candidates.json
+++ b/test/resources/api-patch-empty-ice-candidates.json
@@ -1,0 +1,68 @@
+{
+  "action" : "configure",
+  "bundle-transport" : {
+    "rtcp-mux" : true,
+    "ice" : {
+      "ufrag" : "Rl3b",
+      "pwd" : "gb4ISfk9Ppy6M5zYcZdtqldd",
+      "candidates": [ ]
+    },
+    "dtls" : {
+      "setup" : "active",
+      "type" : "sha-256",
+      "hash" : "2C:F8:DD:0D:BD:E6:18:0D:6E:83:0F:F3:A9:FD:CD:BA:18:C6:8E:34:91:EC:D1:4C:A5:1A:BC:26:FB:0B:92:02"
+    }
+  },
+  "audio" : {
+    "payload-type" : {
+      "id" : 111,
+      "parameters" : {
+        "minptime" : "10",
+        "useinbandfec" : "1"
+      },
+      "rtcp-fbs" : [ ],
+      "name" : "opus",
+      "clockrate" : 48000,
+      "channels" : 2
+    },
+    "rtp-hdrexts" : [ {
+      "id" : 1,
+      "uri" : "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+    } ],
+    "ssrcs" : [ 3455980998 ]
+  },
+  "video" : {
+    "payload-types" : [ {
+      "id" : 100,
+      "parameters" : { },
+      "rtcp-fbs" : [ {
+        "type" : "goog-remb"
+      }, {
+        "type" : "ccm",
+        "subtype" : "fir"
+      }, {
+        "type" : "nack"
+      }, {
+        "type" : "nack",
+        "subtype" : "pli"
+      } ],
+      "name" : "VP8",
+      "clockrate" : 90000
+    }, {
+      "id" : 96,
+      "parameters" : {
+        "apt" : "100"
+      },
+      "rtcp-fbs" : [ ],
+      "name" : "rtx",
+      "clockrate" : 90000
+    } ],
+    "rtp-hdrexts" : [ {
+      "id" : 3,
+      "uri" : "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+    } ]
+  },
+  "data" : {
+    "port" : 5000
+  }
+}

--- a/test/resources/api-patch-no-ice-candidates.json
+++ b/test/resources/api-patch-no-ice-candidates.json
@@ -1,0 +1,67 @@
+{
+  "action" : "configure",
+  "bundle-transport" : {
+    "rtcp-mux" : true,
+    "ice" : {
+      "ufrag" : "Rl3b",
+      "pwd" : "gb4ISfk9Ppy6M5zYcZdtqldd"
+    },
+    "dtls" : {
+      "setup" : "active",
+      "type" : "sha-256",
+      "hash" : "2C:F8:DD:0D:BD:E6:18:0D:6E:83:0F:F3:A9:FD:CD:BA:18:C6:8E:34:91:EC:D1:4C:A5:1A:BC:26:FB:0B:92:02"
+    }
+  },
+  "audio" : {
+    "payload-type" : {
+      "id" : 111,
+      "parameters" : {
+        "minptime" : "10",
+        "useinbandfec" : "1"
+      },
+      "rtcp-fbs" : [ ],
+      "name" : "opus",
+      "clockrate" : 48000,
+      "channels" : 2
+    },
+    "rtp-hdrexts" : [ {
+      "id" : 1,
+      "uri" : "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+    } ],
+    "ssrcs" : [ 3455980998 ]
+  },
+  "video" : {
+    "payload-types" : [ {
+      "id" : 100,
+      "parameters" : { },
+      "rtcp-fbs" : [ {
+        "type" : "goog-remb"
+      }, {
+        "type" : "ccm",
+        "subtype" : "fir"
+      }, {
+        "type" : "nack"
+      }, {
+        "type" : "nack",
+        "subtype" : "pli"
+      } ],
+      "name" : "VP8",
+      "clockrate" : 90000
+    }, {
+      "id" : 96,
+      "parameters" : {
+        "apt" : "100"
+      },
+      "rtcp-fbs" : [ ],
+      "name" : "rtx",
+      "clockrate" : 90000
+    } ],
+    "rtp-hdrexts" : [ {
+      "id" : 3,
+      "uri" : "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+    } ]
+  },
+  "data" : {
+    "port" : 5000
+  }
+}


### PR DESCRIPTION
Some Integration Tests were failing because CS was not sending "candidates" field when there are no candidates and that was consider a bad request smb. That was fixed on CS but I changed SMB to not require to specify "candidates" array when there is no candidates.

I also added unit tests bout this scenario and some util code to load test resources