### PR TITLE
stop barbell transport earlier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cores/*
 *.a
 tools/vagrantdev/.vagrant/*
 tools/vagrant/.vagrant/*
+test/include/TestConfig.h
 
 # Docker
 el7/smb/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-stdlib=libc++ -O3 -DNDEBUG ${ADDITIONAL_CXX_FLAGS}
 set(CMAKE_C_FLAGS_DEBUG "-glldb -O0 -DDEBUG -Wall")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SYMRELEASE "-stdlib=libc++ -glldb -O2 -DNDEBUG ${ADDITIONAL_CXX_FLAGS} -fno-rtti -fno-omit-frame-pointer -Wall -Wno-missing-braces -Wuninitialized -Wsign-compare")
-set(CMAKE_CXX_FLAGS_LCOV "-stdlib=libc++ -glldb -O0 -DDEBUG ${ADDITIONAL_CXX_FLAGS} -fno-rtti -Wall -Wuninitialized -Wsign-compare -Wthread-safety -Wno-missing-braces -fno-omit-frame-pointer \
+set(CMAKE_CXX_FLAGS_LCOV "-stdlib=libc++ -glldb -O0 -DDEBUG -DLCOV_BUILD ${ADDITIONAL_CXX_FLAGS} -fno-rtti -Wall -Wuninitialized -Wsign-compare -Wthread-safety -Wno-missing-braces -fno-omit-frame-pointer \
                           -fprofile-arcs -ftest-coverage -fprofile-instr-generate -fcoverage-mapping")
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)

--- a/bridge/Mixer.cpp
+++ b/bridge/Mixer.cpp
@@ -2440,7 +2440,6 @@ void Mixer::engineBarbellRemoved(EngineBarbell* engineBarbell)
     }
 
     logTransportPacketLoss(barbell->id, *barbell->transport, _loggableId.c_str());
-    barbell->transport->stop();
     if (!waitForPendingJobs(700, 5, *barbell->transport))
     {
         logger::error("Transport for barbell %s did not finish pending jobs in time. Continuing "

--- a/bridge/MixerManager.cpp
+++ b/bridge/MixerManager.cpp
@@ -336,10 +336,11 @@ void MixerManager::run()
     }
 }
 
-void MixerManager::onMessage(EngineMessage::Message&& message)
+bool MixerManager::onMessage(EngineMessage::Message&& message)
 {
-    auto rc = _engineMessages.push(std::move(message));
-    assert(rc);
+    auto messagePosted = _engineMessages.push(std::move(message));
+    assert(messagePosted);
+    return messagePosted;
 }
 
 void MixerManager::engineMessageMixerRemoved(const EngineMessage::Message& message)

--- a/bridge/MixerManager.h
+++ b/bridge/MixerManager.h
@@ -66,7 +66,7 @@ public:
 
     void stop();
     void run();
-    void onMessage(EngineMessage::Message&& message) override;
+    bool onMessage(EngineMessage::Message&& message) override;
     Stats::MixerManagerStats getStats();
 
 private:

--- a/bridge/engine/EngineMessageListener.h
+++ b/bridge/engine/EngineMessageListener.h
@@ -10,7 +10,7 @@ class EngineMessageListener
 public:
     virtual ~EngineMessageListener() = default;
 
-    virtual void onMessage(EngineMessage::Message&& message) = 0;
+    virtual bool onMessage(EngineMessage::Message&& message) = 0;
 };
 
 } // namespace bridge

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -137,6 +137,44 @@ private:
     size_t _barbellIdHash;
 };
 
+class RemovePacketCacheJob : public jobmanager::CountedJob
+{
+public:
+    RemovePacketCacheJob(bridge::EngineMixer& mixer,
+        transport::RtcTransport& transport,
+        bridge::SsrcOutboundContext& outboundContext,
+        bridge::EngineMessageListener& mixerManager)
+        : CountedJob(transport.getJobCounter()),
+          _mixer(mixer),
+          _outboundContext(outboundContext),
+          _mixerManager(mixerManager),
+          _endpointIdHash(transport.getEndpointIdHash())
+    {
+    }
+
+    void run() override
+    {
+        if (_outboundContext.packetCache.isSet() && _outboundContext.packetCache.get())
+        {
+            bridge::EngineMessage::Message message(bridge::EngineMessage::Type::FreeVideoPacketCache);
+            message.command.freeVideoPacketCache.mixer = &_mixer;
+            message.command.freeVideoPacketCache.ssrc = _outboundContext.ssrc;
+            message.command.freeVideoPacketCache.endpointIdHash = _endpointIdHash;
+
+            if (_mixerManager.onMessage(std::move(message)))
+            {
+                _outboundContext.packetCache.set(nullptr);
+            }
+        }
+    }
+
+private:
+    bridge::EngineMixer& _mixer;
+    bridge::SsrcOutboundContext& _outboundContext;
+    bridge::EngineMessageListener& _mixerManager;
+    size_t _endpointIdHash;
+};
+
 /**
  * @return true if this ssrc should be skipped and not forwarded to the videoStream.
  */
@@ -1019,8 +1057,8 @@ void EngineMixer::checkPacketCounters(const uint64_t timestamp)
                 _engineStreamDirector->streamActiveStateChanged(endpointIdHash, ssrc, false);
                 inboundContext.inactiveCount++;
 
-                // The reason for checking if the ssrc is equal to inboundContext._rewriteSsrc, is because that is the
-                // default simulcast level. We don't want to drop the default level even if it's unstable.
+                // The reason for checking if the ssrc is equal to inboundContext._rewriteSsrc, is because that is
+                // the default simulcast level. We don't want to drop the default level even if it's unstable.
                 if (inboundContext.inactiveCount >= _config.dropInboundAfterInactive.get() &&
                     ssrc != inboundContext.rewriteSsrc)
                 {
@@ -1078,18 +1116,14 @@ void EngineMixer::checkPacketCounters(const uint64_t timestamp)
                     videoStreamEntry.second->transport.getJobQueue().addJob<RemoveSrtpSsrcJob>(
                         videoStreamEntry.second->transport,
                         feedbackSsrc);
-                    videoStreamEntry.second->ssrcOutboundContexts.erase(feedbackSsrc);
                 }
 
                 // Pending jobs with reference to this ssrc context has had 30s to complete.
                 // Removing the video packet cache can crash unfinished jobs.
-                {
-                    EngineMessage::Message message(EngineMessage::Type::FreeVideoPacketCache);
-                    message.command.freeVideoPacketCache.mixer = this;
-                    message.command.freeVideoPacketCache.ssrc = outboundContextEntry.first;
-                    message.command.freeVideoPacketCache.endpointIdHash = videoStreamEntry.first;
-                    _messageListener.onMessage(std::move(message));
-                }
+                videoStreamEntry.second->transport.getJobQueue().addJob<RemovePacketCacheJob>(*this,
+                    videoStreamEntry.second->transport,
+                    outboundContext,
+                    _messageListener);
 
                 logger::info("Removing idle outbound context ssrc %u, endpointIdHash %lu",
                     _loggableId.c_str(),
@@ -1098,7 +1132,6 @@ void EngineMixer::checkPacketCounters(const uint64_t timestamp)
                 videoStreamEntry.second->transport.getJobQueue().addJob<RemoveSrtpSsrcJob>(
                     videoStreamEntry.second->transport,
                     outboundContextEntry.first);
-                videoStreamEntry.second->ssrcOutboundContexts.erase(outboundContextEntry.first);
             }
         }
     }
@@ -1259,7 +1292,8 @@ void EngineMixer::onVideoRtpPacketReceived(SsrcInboundContext* ssrcContext,
         _engineStreamDirector->streamActiveStateChanged(endpointIdHash, ssrcContext->ssrc, true);
     }
 
-    // This must happen after checking ssrcContext->_activeMedia above, so that we can detect streamActiveStateChanged
+    // This must happen after checking ssrcContext->_activeMedia above, so that we can detect
+    // streamActiveStateChanged
     ssrcContext->onRtpPacket(timestamp);
 
     const auto isSenderInLastNList = _activeMediaList->isInActiveVideoList(endpointIdHash);
@@ -1924,9 +1958,9 @@ SsrcInboundContext* EngineMixer::emplaceInboundSsrcContext(const uint32_t ssrc,
 
         _ssrcInboundContexts.emplace(ssrc, &emplaceResult.first->second);
 
-        logger::info(
-            "Created new inbound context for video stream ssrc %u, level %u, rewrite ssrc %u, endpointIdHash %lu, rtp "
-            "format %u, %s",
+        logger::info("Created new inbound context for video stream ssrc %u, level %u, rewrite ssrc %u, "
+                     "endpointIdHash %lu, rtp "
+                     "format %u, %s",
             _loggableId.c_str(),
             ssrc,
             level,
@@ -3688,8 +3722,8 @@ void EngineMixer::addBarbell(EngineBarbell* barbell)
 }
 
 // executed on transport thread context
-// occupying the transport thread context assures inbound ssrc contexts are not used by transport while removing them
-// we also assure all ssrcs are removed before erasing the barbell
+// occupying the transport thread context assures inbound ssrc contexts are not used by transport while removing
+// them we also assure all ssrcs are removed before erasing the barbell
 void EngineMixer::internalRemoveBarbell(size_t idHash)
 {
     auto barbell = _engineBarbells.getItem(idHash);

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -3698,8 +3698,6 @@ void EngineMixer::internalRemoveBarbell(size_t idHash)
         return;
     }
 
-    barbell->transport.stop();
-
     for (auto& videoStream : barbell->videoStreams)
     {
         for (size_t i = 0; i < videoStream.stream.numLevels; ++i)
@@ -3733,6 +3731,8 @@ void EngineMixer::removeBarbell(size_t idHash)
     {
         return;
     }
+
+    barbell->transport.stop();
 
     for (auto& videoStream : barbell->videoStreams)
     {

--- a/test/concurrency/MpscTest.cpp
+++ b/test/concurrency/MpscTest.cpp
@@ -186,6 +186,9 @@ const int PRODUCER_COUNT = 5;
 
 TEST(Mpsc, DISABLED_mutexqueue)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new LockFullMpscQueue<Simple, 262144>();
     runQueueTest(1, PRODUCER_COUNT, *queue, reports, 4000);
@@ -205,6 +208,9 @@ TEST(Mpsc, DISABLED_mutexqueue)
 
 TEST(Mpsc, freequeue)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new MpmcQueue<Simple>(262144);
     runQueueTest(1, PRODUCER_COUNT, *queue, reports, 4000);
@@ -223,6 +229,9 @@ TEST(Mpsc, freequeue)
 
 TEST(Mpsc, freequeueSmall)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new MpmcQueue<SimpleSmall>(262144);
     runQueueTest(1, PRODUCER_COUNT, *queue, reports, 4000);
@@ -241,6 +250,9 @@ TEST(Mpsc, freequeueSmall)
 
 TEST(Mpmc, DISABLED_mutexqueue)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new LockFullMpscQueue<Simple, 262144>();
     runQueueTest(3, PRODUCER_COUNT, *queue, reports, 4000);
@@ -260,6 +272,9 @@ TEST(Mpmc, DISABLED_mutexqueue)
 
 TEST(Mpmc, freequeue)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new MpmcQueue<Simple>(262144 * 2);
     runQueueTest(3, PRODUCER_COUNT, *queue, reports, 4000);
@@ -277,6 +292,9 @@ TEST(Mpmc, freequeue)
 
 TEST(Mpmc, freequeueSmall)
 {
+#if LCOV_BUILD
+    GTEST_SKIP();
+#endif
     TransmissionReport reports[PRODUCER_COUNT];
     auto queue = new MpmcQueue<SimpleSmall>(262144);
     runQueueTest(3, PRODUCER_COUNT, *queue, reports, 4000);

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -45,10 +45,11 @@ struct IntegrationTest : public ::testing::Test
 
     void initBridge(config::Config& config);
 
+    void finalizeSimulation();
+
 protected:
     void runTestInThread(const size_t expectedNumThreads, std::function<void()> test);
     void startSimulation();
-    void finalizeSimulation();
 
 protected:
     bool _internetStartedAtLeastOnce;

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -45,6 +45,7 @@ struct IntegrationTest : public ::testing::Test
 
     void initBridge(config::Config& config);
 
+    void finalizeSimulationWithTimeout(uint64_t rampdownTimeout);
     void finalizeSimulation();
 
 protected:

--- a/test/integration/emulator/FakeUdpEndpoint.cpp
+++ b/test/integration/emulator/FakeUdpEndpoint.cpp
@@ -257,7 +257,7 @@ void FakeUdpEndpoint::stop(IStopEvents* listener)
             _receiveQueue.pop(packet);
         }
 
-        // Woulbe be closing epoll subscription in a job and call a stop callback...
+        // Would be closing epoll subscription in a job and call a stop callback...
         _state = CREATED;
 
         if (listener)

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -714,7 +714,7 @@ public:
         return false;
     }
 
-    bool startConference(std::string url)
+    static bool startConference(Conference& conf, std::string url)
     {
         conf.create(url);
         auto result = conf.isSuccess();
@@ -729,7 +729,6 @@ public:
     }
 
     std::vector<std::unique_ptr<TClient>> clients;
-    Conference conf;
 
 private:
     uint32_t& _idCounter;

--- a/test/integration/emulator/TimeTurner.cpp
+++ b/test/integration/emulator/TimeTurner.cpp
@@ -89,7 +89,7 @@ void TimeTurner::runFor(uint64_t durationNs)
         logger::awaitLogDrained(0.75);
         if (!_sleeperCountdown.wait(1000))
         {
-            logger::warn("Timeout waiting for threads to check", "TimeTurner");
+            logger::warn("Timeout waiting for threads to sleep", "TimeTurner");
             if (!_running)
             {
                 return;

--- a/test/transport/FakeNetwork.cpp
+++ b/test/transport/FakeNetwork.cpp
@@ -192,7 +192,7 @@ InternetRunner::InternetRunner(const uint64_t sleepTime)
 
 InternetRunner::~InternetRunner()
 {
-    exit();
+    shutdown();
     _thread->join();
 }
 
@@ -210,7 +210,7 @@ void InternetRunner::pause()
     _commandReady.notify_all();
 }
 
-void InternetRunner::exit()
+void InternetRunner::shutdown()
 {
     std::lock_guard<std::mutex> lock(_mutex);
     _command = quit;

--- a/test/transport/FakeNetwork.h
+++ b/test/transport/FakeNetwork.h
@@ -116,7 +116,7 @@ public:
     ~InternetRunner();
     void start();
     void pause();
-    void exit();
+    void shutdown();
     std::shared_ptr<Internet> get();
     bool isRunning() const { return _state == running; };
     bool isPaused() const { return _state == paused; }

--- a/test/transport/FakeNetwork.h
+++ b/test/transport/FakeNetwork.h
@@ -2,6 +2,7 @@
 #include "utils/SocketAddress.h"
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <thread>
 
@@ -104,21 +105,31 @@ private:
 class InternetRunner
 {
 public:
+    enum State
+    {
+        running = 1,
+        paused,
+        quit
+    };
+
     InternetRunner(uint64_t sleepTime);
     ~InternetRunner();
     void start();
-    void stop();
+    void pause();
+    void exit();
     std::shared_ptr<Internet> get();
-    bool isRunning() { return _isRunning; };
+    bool isRunning() const { return _state == running; };
+    bool isPaused() const { return _state == paused; }
+    State getState() const { return _state.load(); }
 
 private:
     void internetThreadRun();
     std::shared_ptr<Internet> _internet;
-    std::atomic_bool _isRunning;
-    std::atomic_bool _shouldStop;
-    std::unique_ptr<std::thread> _thread;
     std::mutex _mutex;
-    std::condition_variable _cv;
+    std::condition_variable _commandReady;
     const uint64_t _sleepTime;
+    std::atomic<State> _state;
+    std::atomic<State> _command;
+    std::unique_ptr<std::thread> _thread;
 };
 } // namespace fakenet


### PR DESCRIPTION
stop transport earlier so ssrc context are not recreated after we remove them