### PR TITLE
RTC-12935 Fix video RTX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,8 @@ set(TEST_FILES
     test/integration/SampleDataUtils.cpp
     test/integration/IntegrationTest.cpp
     test/integration/IntegrationTest.h
+    test/integration/BarbellTest.cpp
+    test/integration/BarbellTest.h
 #    test/integration/MixerTimeoutTest.cpp
 #    test/integration/StatsTest.cpp
     test/sctp/SctpEndpoint.h

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -2630,23 +2630,27 @@ void EngineMixer::processIncomingTransportFbRtcpPacket(const transport::RtcTrans
 
     if (fromBarbell)
     {
-        const auto bb = _engineBarbells.getItem(transport->getEndpointIdHash());
-        if (bb)
+        const auto barbell = _engineBarbells.getItem(transport->getEndpointIdHash());
+        if (barbell)
         {
             uint32_t feedbackSsrc = 0;
             _activeMediaList->getFeedbackSsrc(mediaSsrc, feedbackSsrc);
 
-            auto& bbTransport = bb->transport;
-            auto* mediaSsrcOutboundContext =
-                obtainOutboundSsrcContext(bb->idHash, bb->ssrcOutboundContexts, mediaSsrc, bb->audioRtpMap);
+            auto& bbTransport = barbell->transport;
+            auto* mediaSsrcOutboundContext = obtainOutboundSsrcContext(barbell->idHash,
+                barbell->ssrcOutboundContexts,
+                mediaSsrc,
+                barbell->audioRtpMap);
             if (!mediaSsrcOutboundContext || !mediaSsrcOutboundContext->packetCache.isSet() ||
                 !mediaSsrcOutboundContext->packetCache.get())
             {
                 return;
             }
 
-            auto* feedbackSsrcOutboundContext =
-                obtainOutboundSsrcContext(bb->idHash, bb->ssrcOutboundContexts, feedbackSsrc, bb->audioRtpMap);
+            auto* feedbackSsrcOutboundContext = obtainOutboundSsrcContext(barbell->idHash,
+                barbell->ssrcOutboundContexts,
+                feedbackSsrc,
+                barbell->audioRtpMap);
             if (!feedbackSsrcOutboundContext)
             {
                 return;
@@ -3572,15 +3576,15 @@ void EngineMixer::processEngineMissingPackets(bridge::SsrcInboundContext& ssrcIn
 
 void EngineMixer::processBarbellMissingPackets(bridge::SsrcInboundContext& ssrcInboundContext)
 {
-    const auto bb = _engineBarbells.getItem(ssrcInboundContext.sender->getEndpointIdHash());
-    if (bb)
+    const auto barbell = _engineBarbells.getItem(ssrcInboundContext.sender->getEndpointIdHash());
+    if (barbell)
     {
-        auto videoStream = bb->videoSsrcMap.getItem(ssrcInboundContext.ssrc);
+        auto videoStream = barbell->videoSsrcMap.getItem(ssrcInboundContext.ssrc);
         if (videoStream)
         {
-            bb->transport.getJobQueue().addJob<bridge::ProcessMissingVideoPacketsJob>(ssrcInboundContext,
+            barbell->transport.getJobQueue().addJob<bridge::ProcessMissingVideoPacketsJob>(ssrcInboundContext,
                 0,
-                bb->transport,
+                barbell->transport,
                 _sendAllocator);
             return;
         }

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -2615,6 +2615,49 @@ void EngineMixer::processIncomingPayloadSpecificRtcpPacket(const size_t rtcpSend
     }
 }
 
+void EngineMixer::processIncomingBarbellFbRtcpPacket(EngineBarbell& barbell,
+    const rtp::RtcpFeedback& rtcpFeedback,
+    const uint64_t timestamp)
+{
+    uint32_t feedbackSsrc = 0;
+    const auto mediaSsrc = rtcpFeedback.mediaSsrc.get();
+    _activeMediaList->getFeedbackSsrc(mediaSsrc, feedbackSsrc);
+
+    auto& bbTransport = barbell.transport;
+    auto* mediaSsrcOutboundContext =
+        obtainOutboundSsrcContext(barbell.idHash, barbell.ssrcOutboundContexts, mediaSsrc, barbell.audioRtpMap);
+    if (!mediaSsrcOutboundContext || !mediaSsrcOutboundContext->packetCache.isSet() ||
+        !mediaSsrcOutboundContext->packetCache.get())
+    {
+        return;
+    }
+
+    auto* feedbackSsrcOutboundContext =
+        obtainOutboundSsrcContext(barbell.idHash, barbell.ssrcOutboundContexts, feedbackSsrc, barbell.audioRtpMap);
+    if (!feedbackSsrcOutboundContext)
+    {
+        return;
+    }
+
+    mediaSsrcOutboundContext->onRtpSent(timestamp);
+    const auto numFeedbackControlInfos = rtp::getNumFeedbackControlInfos(&rtcpFeedback);
+    uint16_t pid = 0;
+    uint16_t blp = 0;
+    for (size_t i = 0; i < numFeedbackControlInfos; ++i)
+    {
+        feedbackSsrcOutboundContext->onRtpSent(timestamp);
+        rtp::getFeedbackControlInfo(&rtcpFeedback, i, numFeedbackControlInfos, pid, blp);
+        bbTransport.getJobQueue().addJob<bridge::VideoNackReceiveJob>(*feedbackSsrcOutboundContext,
+            bbTransport,
+            *(mediaSsrcOutboundContext->packetCache.get()),
+            pid,
+            blp,
+            feedbackSsrc,
+            timestamp,
+            barbell.transport.getRtt());
+    }
+}
+
 void EngineMixer::processIncomingTransportFbRtcpPacket(const transport::RtcTransport* transport,
     const rtp::RtcpHeader& rtcpPacket,
     const uint64_t timestamp)
@@ -2633,46 +2676,7 @@ void EngineMixer::processIncomingTransportFbRtcpPacket(const transport::RtcTrans
         const auto barbell = _engineBarbells.getItem(transport->getEndpointIdHash());
         if (barbell)
         {
-            uint32_t feedbackSsrc = 0;
-            _activeMediaList->getFeedbackSsrc(mediaSsrc, feedbackSsrc);
-
-            auto& bbTransport = barbell->transport;
-            auto* mediaSsrcOutboundContext = obtainOutboundSsrcContext(barbell->idHash,
-                barbell->ssrcOutboundContexts,
-                mediaSsrc,
-                barbell->audioRtpMap);
-            if (!mediaSsrcOutboundContext || !mediaSsrcOutboundContext->packetCache.isSet() ||
-                !mediaSsrcOutboundContext->packetCache.get())
-            {
-                return;
-            }
-
-            auto* feedbackSsrcOutboundContext = obtainOutboundSsrcContext(barbell->idHash,
-                barbell->ssrcOutboundContexts,
-                feedbackSsrc,
-                barbell->audioRtpMap);
-            if (!feedbackSsrcOutboundContext)
-            {
-                return;
-            }
-
-            mediaSsrcOutboundContext->onRtpSent(timestamp);
-            const auto numFeedbackControlInfos = rtp::getNumFeedbackControlInfos(rtcpFeedback);
-            uint16_t pid = 0;
-            uint16_t blp = 0;
-            for (size_t i = 0; i < numFeedbackControlInfos; ++i)
-            {
-                feedbackSsrcOutboundContext->onRtpSent(timestamp);
-                rtp::getFeedbackControlInfo(rtcpFeedback, i, numFeedbackControlInfos, pid, blp);
-                bbTransport.getJobQueue().addJob<bridge::VideoNackReceiveJob>(*feedbackSsrcOutboundContext,
-                    bbTransport,
-                    *(mediaSsrcOutboundContext->packetCache.get()),
-                    pid,
-                    blp,
-                    feedbackSsrc,
-                    timestamp,
-                    transport->getRtt());
-            }
+            processIncomingBarbellFbRtcpPacket(*barbell, *rtcpFeedback, timestamp);
         }
         return;
     }
@@ -3579,14 +3583,14 @@ void EngineMixer::processBarbellMissingPackets(bridge::SsrcInboundContext& ssrcI
     const auto barbell = _engineBarbells.getItem(ssrcInboundContext.sender->getEndpointIdHash());
     if (barbell)
     {
+        const uint32_t REPORTER_SSRC = 0;
         auto videoStream = barbell->videoSsrcMap.getItem(ssrcInboundContext.ssrc);
         if (videoStream)
         {
             barbell->transport.getJobQueue().addJob<bridge::ProcessMissingVideoPacketsJob>(ssrcInboundContext,
-                0,
+                REPORTER_SSRC,
                 barbell->transport,
                 _sendAllocator);
-            return;
         }
     }
 }

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -33,6 +33,11 @@ namespace webrtc
 struct SctpStreamMessageHeader;
 }
 
+namespace rtp
+{
+struct RtcpFeedback;
+}
+
 namespace jobmanager
 {
 class JobManager;
@@ -365,6 +370,9 @@ private:
     void processIncomingPayloadSpecificRtcpPacket(const size_t rtcpSenderEndpointIdHash,
         const rtp::RtcpHeader& rtcpPacket,
         uint64_t timestamp);
+    void processIncomingBarbellFbRtcpPacket(EngineBarbell& barbell,
+        const rtp::RtcpFeedback& rtcpFeedback,
+        const uint64_t timestamp);
     void processIncomingTransportFbRtcpPacket(const transport::RtcTransport* transport,
         const rtp::RtcpHeader& rtcpPacket,
         const uint64_t timestamp);

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -425,6 +425,8 @@ private:
     void allocateRecordingRtpPacketCacheIfNecessary(SsrcOutboundContext& ssrcOutboundContext,
         EngineRecordingStream& recordingStream);
 
+    void processEngineMissingPackets(bridge::SsrcInboundContext& ssrcInboundContext);
+    void processBarbellMissingPackets(bridge::SsrcInboundContext& ssrcInboundContext);
     void processRecordingMissingPackets(const uint64_t timestamp);
     void startProbingVideoStream(EngineVideoStream&);
     void stopProbingVideoStream(const EngineVideoStream&);

--- a/bridge/engine/ProcessMissingVideoPacketsJob.cpp
+++ b/bridge/engine/ProcessMissingVideoPacketsJob.cpp
@@ -65,6 +65,7 @@ void ProcessMissingVideoPacketsJob::run()
     {
         return;
     }
+
     _transport.protectAndSend(std::move(packet));
 }
 

--- a/bridge/engine/VideoForwarderRtxReceiveJob.cpp
+++ b/bridge/engine/VideoForwarderRtxReceiveJob.cpp
@@ -1,4 +1,5 @@
 #include "bridge/engine/VideoForwarderRtxReceiveJob.h"
+#include "bridge/engine/EngineBarbell.h"
 #include "bridge/engine/EngineMixer.h"
 #include "bridge/engine/Vp8Rewriter.h"
 #include "logger/Logger.h"
@@ -11,6 +12,7 @@ namespace bridge
 VideoForwarderRtxReceiveJob::VideoForwarderRtxReceiveJob(memory::UniquePacket packet,
     transport::RtcTransport* sender,
     bridge::EngineMixer& engineMixer,
+    bridge::SsrcInboundContext& ssrcFeedbackContext,
     bridge::SsrcInboundContext& ssrcContext,
     const uint32_t mainSsrc,
     const uint32_t extendedSequenceNumber)
@@ -18,6 +20,7 @@ VideoForwarderRtxReceiveJob::VideoForwarderRtxReceiveJob(memory::UniquePacket pa
       _packet(std::move(packet)),
       _engineMixer(engineMixer),
       _sender(sender),
+      _ssrcFeedbackContext(ssrcFeedbackContext),
       _ssrcContext(ssrcContext),
       _mainSsrc(mainSsrc),
       _extendedSequenceNumber(extendedSequenceNumber)
@@ -40,16 +43,18 @@ void VideoForwarderRtxReceiveJob::run()
         return;
     }
 
-    const auto oldRolloverCounter = _ssrcContext.lastUnprotectedExtendedSequenceNumber >> 16;
+    const auto oldRolloverCounter = _ssrcFeedbackContext.lastUnprotectedExtendedSequenceNumber >> 16;
     const auto newRolloverCounter = _extendedSequenceNumber >> 16;
     if (newRolloverCounter > oldRolloverCounter)
     {
-        logger::debug("Setting new rollover counter for ssrc %u", "VideoForwarderRtxReceiveJob", _ssrcContext.ssrc);
-        if (!_sender->setSrtpRemoteRolloverCounter(_ssrcContext.ssrc, newRolloverCounter))
+        logger::debug("Setting new rollover counter for ssrc %u",
+            "VideoForwarderRtxReceiveJob",
+            _ssrcFeedbackContext.ssrc);
+        if (!_sender->setSrtpRemoteRolloverCounter(_ssrcFeedbackContext.ssrc, newRolloverCounter))
         {
             logger::error("Failed to set rollover counter srtp %u, mixer %s",
                 "VideoForwarderReceiveJob",
-                _ssrcContext.ssrc,
+                _ssrcFeedbackContext.ssrc,
                 _engineMixer.getLoggableId().c_str());
             return;
         }
@@ -59,22 +64,22 @@ void VideoForwarderRtxReceiveJob::run()
     {
         logger::error("Failed to unprotect srtp %u, mixer %s",
             "VideoForwarderRtxReceiveJob",
-            _ssrcContext.ssrc,
+            _ssrcFeedbackContext.ssrc,
             _engineMixer.getLoggableId().c_str());
         return;
     }
 
-    _ssrcContext.lastUnprotectedExtendedSequenceNumber = _extendedSequenceNumber;
+    _ssrcFeedbackContext.lastUnprotectedExtendedSequenceNumber = _extendedSequenceNumber;
     Vp8Rewriter::rewriteRtxPacket(*_packet, _mainSsrc);
 
-    if (!_ssrcContext.videoMissingPacketsTracker.get())
+    if (!_ssrcFeedbackContext.videoMissingPacketsTracker.get())
     {
         assert(false);
         return;
     }
 
     uint32_t extendedSequenceNumber = 0;
-    if (!_ssrcContext.videoMissingPacketsTracker->onPacketArrived(rtpHeader->sequenceNumber.get(),
+    if (!_ssrcFeedbackContext.videoMissingPacketsTracker->onPacketArrived(rtpHeader->sequenceNumber.get(),
             extendedSequenceNumber))
     {
         return;

--- a/bridge/engine/VideoForwarderRtxReceiveJob.h
+++ b/bridge/engine/VideoForwarderRtxReceiveJob.h
@@ -26,6 +26,7 @@ public:
     VideoForwarderRtxReceiveJob(memory::UniquePacket packet,
         transport::RtcTransport* sender,
         bridge::EngineMixer& engineMixer,
+        bridge::SsrcInboundContext& ssrcFeedbackContext,
         bridge::SsrcInboundContext& ssrcContext,
         const uint32_t mainSsrc,
         const uint32_t extendedSequenceNumber);
@@ -36,6 +37,7 @@ private:
     memory::UniquePacket _packet;
     bridge::EngineMixer& _engineMixer;
     transport::RtcTransport* _sender;
+    bridge::SsrcInboundContext& _ssrcFeedbackContext;
     bridge::SsrcInboundContext& _ssrcContext;
     uint32_t _mainSsrc;
     uint32_t _extendedSequenceNumber;

--- a/test/bwe/EstimatorReRun.cpp
+++ b/test/bwe/EstimatorReRun.cpp
@@ -330,7 +330,7 @@ TEST_P(BweRerunLimit, DISABLED_limitedLink)
 
     std::array<std::string, 56> trace = {"Transport-5", "Transport-20", "Transport-17"};
     memory::PacketPoolAllocator allocator(8092, "rerun");
-    fakenet::NetworkLink link(GetParam(), 1950 * 1024, 3000);
+    fakenet::NetworkLink link("EstimatorReRunLink", GetParam(), 1950 * 1024, 3000);
     link.setLossRate(0);
     uint64_t wallClock = 0;
     const char* formatLine = "%u, %.1f,%.1f,%.f,%.3f,%.3f,%u,%u,%.6f, %.2f";

--- a/test/bwe/EstimatorTestEasy.cpp
+++ b/test/bwe/EstimatorTestEasy.cpp
@@ -66,7 +66,7 @@ TEST(BweTest, basic)
 {
     bwe::Config config;
 
-    fakenet::NetworkLink* link = new fakenet::NetworkLink(5000, 64 * 1024, 1500);
+    fakenet::NetworkLink* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 5000, 64 * 1024, 1500);
     memory::PacketPoolAllocator allocator(512, "test");
 
     bwe::BandwidthEstimator estimator(config);
@@ -79,7 +79,7 @@ TEST(BweTest, burstDelivery)
 {
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
-    fakenet::NetworkLink* link = new fakenet::NetworkLink(200, 64 * 1024, 1500);
+    fakenet::NetworkLink* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 200, 64 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     link->setBurstDeliveryInterval(45);
@@ -94,7 +94,7 @@ TEST(BweTest, plainVideo)
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
 
-    auto* link = new fakenet::NetworkLink(4800, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 4800, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     // link->setBurstDeliveryInterval(45);
@@ -115,7 +115,7 @@ TEST(BweTest, plainVideoLong)
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
 
-    auto* link = new fakenet::NetworkLink(148000, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 148000, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     // link->setBurstDeliveryInterval(45);
@@ -135,7 +135,7 @@ TEST(BweTest, plainVideoStartLow)
 {
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
-    auto* link = new fakenet::NetworkLink(3800, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 3800, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     // link->setBurstDeliveryInterval(5);
@@ -155,7 +155,7 @@ TEST(BweTest, plainVideoBwDrop)
 {
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
-    auto* link = new fakenet::NetworkLink(3800, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 3800, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     link->setBurstDeliveryInterval(5);
@@ -182,7 +182,7 @@ TEST(BweTest, startCongested)
 {
     bwe::Config config;
     bwe::BandwidthEstimator estimator(config);
-    auto* link = new fakenet::NetworkLink(800, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 800, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     auto* video = new fakenet::FakeVideoSource(allocator, 150, 1);
@@ -223,7 +223,7 @@ TEST(BweTest, networkPause)
     bwe::Config config;
 
     bwe::BandwidthEstimator estimator(config);
-    auto* link = new fakenet::NetworkLink(2000, 256 * 1024, 1500);
+    auto* link = new fakenet::NetworkLink("EstimatorTestEasyLink", 2000, 256 * 1024, 1500);
     memory::PacketPoolAllocator allocator(1024, "test");
 
     auto* video = new fakenet::FakeVideoSource(allocator, 150, 1);

--- a/test/bwe/FakeVideoSource.h
+++ b/test/bwe/FakeVideoSource.h
@@ -28,6 +28,7 @@ public:
     uint32_t getSsrc() const override { return _ssrc; }
 
     void requestKeyFrame() { _keyFrame = true; }
+    bool isKeyFrameRequested() { return _keyFrame; }
 
     uint32_t getPacketsSent() const { return _packetsSent; }
 

--- a/test/bwe/RateControllerTest.cpp
+++ b/test/bwe/RateControllerTest.cpp
@@ -26,9 +26,9 @@ TEST_P(RateControllerTestLongRtt, longRtt)
     rcConfig.initialEstimateKbps = 300;
     rcConfig.debugLog = true;
     bwe::RateController rateControl(1, rcConfig);
-    auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
+    auto* uplink = new fakenet::NetworkLink("upLink", capacityKbps, 75000, 1480);
     uplink->setStaticDelay(90);
-    auto* downLink = new fakenet::NetworkLink(6500, 75000, 1480);
+    auto* downLink = new fakenet::NetworkLink("downLink", 6500, 75000, 1480);
     downLink->setStaticDelay(70);
 
     fakenet::RcCall call(_allocator, _config, rateControl, uplink, downLink, true, 24 * utils::Time::sec);
@@ -76,9 +76,9 @@ TEST_P(RateControllerTestShortRtt, shortRtt)
     rcConfig.initialEstimateKbps = 300;
     rcConfig.debugLog = true;
     bwe::RateController rateControl(1, rcConfig);
-    auto* uplink = new fakenet::NetworkLink(capacityKbps, 75000, 1480);
+    auto* uplink = new fakenet::NetworkLink("upLink", capacityKbps, 75000, 1480);
     uplink->setStaticDelay(0);
-    auto* downLink = new fakenet::NetworkLink(6500, 75000, 1480);
+    auto* downLink = new fakenet::NetworkLink("downLink", 6500, 75000, 1480);
     downLink->setStaticDelay(0);
 
     fakenet::RcCall call(_allocator, _config, rateControl, uplink, downLink, true, 24 * utils::Time::sec);

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -153,9 +153,6 @@ TEST_F(BarbellTest, packetLossViaBarbell)
         auto bridge2 = std::make_unique<bridge::Bridge>(config2);
         bridge2->initialize(_bridgeEndpointFactory);
 
-        ScopedFinalize finalize(std::bind(&IntegrationTest::finalizeSimulation, this));
-        startSimulation();
-
         const auto baseUrl = "http://127.0.0.1:8080";
         const auto baseUrl2 = "http://127.0.0.1:8090";
 
@@ -171,6 +168,9 @@ TEST_F(BarbellTest, packetLossViaBarbell)
 
         Conference conf2;
         group.startConference(conf2, baseUrl2);
+
+        ScopedFinalize finalize(std::bind(&IntegrationTest::finalizeSimulation, this));
+        startSimulation();
 
         Barbell bb1;
         Barbell bb2;

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -223,10 +223,12 @@ TEST_F(BarbellTest, packetLossViaBarbell)
         logVideoSent("client2", *group.clients[1]);
         logVideoSent("client3", *group.clients[2]);
 
-        const auto audioPacketSampleCount = codec::Opus::sampleRate / codec::Opus::packetsPerSecond;
         {
             auto videoCounters = group.clients[0]->_transport->getCumulativeVideoReceiveCounters();
             EXPECT_EQ(videoCounters.lostPackets, 0);
+
+            auto autioCounters = group.clients[0]->_transport->getCumulativeAudioReceiveCounters();
+            EXPECT_NE(autioCounters.lostPackets, 0);
 
             const auto& rData1 = group.clients[0]->getAudioReceiveStats();
             std::vector<double> allFreq;
@@ -243,11 +245,6 @@ TEST_F(BarbellTest, packetLossViaBarbell)
                 std::vector<std::pair<uint64_t, double>> amplitudeProfile;
                 auto rec = item.second->getRecording();
                 analyzeRecording(rec, freqVector, amplitudeProfile, item.second->getLoggableId().c_str());
-
-                const auto expectedLostPacketCount = PACKET_LOSS_RATE * 5 * codec::Opus::packetsPerSecond;
-                EXPECT_NEAR(rec.size(),
-                    5 * codec::Opus::sampleRate - expectedLostPacketCount * audioPacketSampleCount,
-                    3 * audioPacketSampleCount);
 
                 allFreq.insert(allFreq.begin(), freqVector.begin(), freqVector.end());
 

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -1,0 +1,294 @@
+#include "BarbellTest.h"
+
+#include "api/ConferenceEndpoint.h"
+#include "api/Parser.h"
+#include "api/utils.h"
+#include "bridge/Mixer.h"
+#include "bridge/engine/SsrcInboundContext.h"
+#include "codec/Opus.h"
+#include "codec/OpusDecoder.h"
+#include "concurrency/MpmcHashmap.h"
+#include "emulator/FakeEndpointFactory.h"
+#include "external/http.h"
+#include "jobmanager/JobManager.h"
+#include "jobmanager/WorkerThread.h"
+#include "memory/PacketPoolAllocator.h"
+#include "nlohmann/json.hpp"
+#include "test/bwe/FakeVideoSource.h"
+#include "test/integration/IntegrationTest.h"
+#include "test/integration/SampleDataUtils.h"
+#include "test/integration/emulator/ApiChannel.h"
+#include "test/integration/emulator/AudioSource.h"
+#include "test/integration/emulator/HttpRequests.h"
+#include "test/integration/emulator/SfuClient.h"
+#include "transport/DataReceiver.h"
+#include "transport/EndpointFactoryImpl.h"
+#include "transport/RtcTransport.h"
+#include "transport/RtcePoll.h"
+#include "transport/Transport.h"
+#include "transport/TransportFactory.h"
+#include "transport/dtls/SrtpClientFactory.h"
+#include "transport/dtls/SslDtls.h"
+#include "utils/IdGenerator.h"
+#include "utils/StringBuilder.h"
+#include <complex>
+#include <memory>
+#include <sstream>
+#include <unordered_set>
+
+BarbellTest::BarbellTest() {}
+
+void BarbellTest::SetUp()
+{
+    IntegrationTest::SetUp();
+}
+void BarbellTest::TearDown()
+{
+    IntegrationTest::TearDown();
+}
+
+namespace
+{
+template <typename T>
+void logVideoSent(const char* clientName, T& client)
+{
+    for (auto& itPair : client._videoSources)
+    {
+        auto& videoSource = itPair.second;
+        logger::info("%s video source %u, sent %u packets",
+            "bbTest",
+            clientName,
+            videoSource->getSsrc(),
+            videoSource->getPacketsSent());
+    }
+}
+
+template <typename T>
+void logTransportSummary(const char* clientName, transport::RtcTransport* transport, T& summary)
+{
+    for (auto& report : summary)
+    {
+        logger::debug("%s %s ssrc %u sent video pkts %u",
+            "bbTest",
+            clientName,
+            transport->getLoggableId().c_str(),
+            report.first,
+            report.second.packetsSent);
+    }
+}
+} // namespace
+
+using namespace emulator;
+
+template <typename TChannel>
+void make5secCallWithDefaultAudioProfile(GroupCall<SfuClient<TChannel>>& groupCall)
+{
+    static const double frequencies[] = {600, 1300, 2100, 3200, 4100, 4800, 5200};
+    for (size_t i = 0; i < groupCall.clients.size(); ++i)
+    {
+        groupCall.clients[i]->_audioSource->setFrequency(frequencies[i]);
+    }
+
+    for (auto& client : groupCall.clients)
+    {
+        client->_audioSource->setVolume(0.6);
+    }
+
+    groupCall.run(utils::Time::sec * 5);
+    utils::Time::nanoSleep(utils::Time::sec * 1);
+
+    for (auto& client : groupCall.clients)
+    {
+        client->stopRecording();
+    }
+}
+
+TEST_F(BarbellTest, packetLossViaBarbell)
+{
+    runTestInThread(_numWorkerThreads + 4, [this]() {
+        _config.readFromString(R"({
+        "ip":"127.0.0.1",
+        "ice.preferredIp":"127.0.0.1",
+        "ice.publicIpv4":"127.0.0.1",
+        "rctl.enable": false,
+        "bwe.enable":false
+        })");
+
+        initBridge(_config);
+
+        config::Config config1;
+        config1.readFromString(R"({
+        "ip":"127.0.0.1",
+        "ice.preferredIp":"127.0.0.1",
+        "ice.publicIpv4":"127.0.0.1",
+        "rctl.enable": false
+        })");
+
+        config::Config config2;
+        config2.readFromString(
+            R"({
+        "ip":"127.0.0.1",
+        "ice.preferredIp":"127.0.0.1",
+        "ice.publicIpv4":"127.0.0.1",
+        "ice.singlePort":12000,
+        "port":8090,
+        "recording.singlePort":12500,
+        "rctl.enable": false
+        })");
+
+        auto bridge2 = std::make_unique<bridge::Bridge>(config2);
+        bridge2->initialize(_bridgeEndpointFactory);
+
+        ScopedFinalize finalize(std::bind(&IntegrationTest::finalizeSimulation, this));
+        startSimulation();
+
+        const auto baseUrl = "http://127.0.0.1:8080";
+        const auto baseUrl2 = "http://127.0.0.1:8090";
+
+        GroupCall<SfuClient<Channel>> group(_instanceCounter,
+            *_mainPoolAllocator,
+            _audioAllocator,
+            *_transportFactory,
+            *_sslDtls,
+            3);
+
+        Conference conf;
+        group.startConference(conf, baseUrl);
+
+        Conference conf2;
+        group.startConference(conf2, baseUrl2);
+
+        Barbell bb1;
+        Barbell bb2;
+
+        _endpointNetworkLinkMap.clear();
+        auto sdp1 = bb1.allocate(baseUrl, conf.getId(), true);
+        auto interBridgeEndpoints1 = _endpointNetworkLinkMap;
+
+        _endpointNetworkLinkMap.clear();
+        auto sdp2 = bb2.allocate(baseUrl2, conf2.getId(), false);
+        auto interBridgeEndpoints2 = _endpointNetworkLinkMap;
+
+        bb1.configure(sdp2);
+        bb2.configure(sdp1);
+
+        for (const auto& linkInfo : interBridgeEndpoints1)
+        {
+            linkInfo.second.ptrLink->setLossRate(0.01);
+        }
+
+        utils::Time::nanoSleep(2 * utils::Time::sec);
+
+        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, true, true, true);
+        group.clients[1]->initiateCall(baseUrl2, conf2.getId(), false, true, true, true);
+        group.clients[2]->initiateCall(baseUrl2, conf2.getId(), false, true, true, true);
+
+        ASSERT_TRUE(group.connectAll(utils::Time::sec * 5));
+
+        make5secCallWithDefaultAudioProfile(group);
+
+        HttpGetRequest statsRequest((std::string(baseUrl) + "/stats").c_str());
+        statsRequest.awaitResponse(1500 * utils::Time::ms);
+        EXPECT_TRUE(statsRequest.isSuccess());
+        HttpGetRequest confRequest((std::string(baseUrl) + "/conferences").c_str());
+        confRequest.awaitResponse(500 * utils::Time::ms);
+        EXPECT_TRUE(confRequest.isSuccess());
+
+        bb1.remove(baseUrl);
+
+        utils::Time::nanoSleep(utils::Time::ms * 1000); // let pending packets be sent and received)
+
+        group.clients[0]->_transport->stop();
+        group.clients[1]->_transport->stop();
+        group.clients[2]->_transport->stop();
+
+        group.awaitPendingJobs(utils::Time::sec * 4);
+        finalizeSimulation();
+
+        logVideoSent("client1", *group.clients[0]);
+        logVideoSent("client2", *group.clients[1]);
+        logVideoSent("client3", *group.clients[2]);
+
+        const auto audioPacketSampleCount = codec::Opus::sampleRate / codec::Opus::packetsPerSecond;
+        {
+            auto audioCounters = group.clients[0]->_transport->getCumulativeAudioReceiveCounters();
+            EXPECT_EQ(audioCounters.lostPackets, 0);
+            const auto& rData1 = group.clients[0]->getAudioReceiveStats();
+            std::vector<double> allFreq;
+            EXPECT_EQ(rData1.size(), 2);
+
+            for (const auto& item : rData1)
+            {
+                if (group.clients[0]->isRemoteVideoSsrc(item.first))
+                {
+                    continue;
+                }
+
+                std::vector<double> freqVector;
+                std::vector<std::pair<uint64_t, double>> amplitudeProfile;
+                auto rec = item.second->getRecording();
+                analyzeRecording(rec, freqVector, amplitudeProfile, item.second->getLoggableId().c_str());
+                EXPECT_NEAR(rec.size(), 5 * codec::Opus::sampleRate, 3 * audioPacketSampleCount);
+                allFreq.insert(allFreq.begin(), freqVector.begin(), freqVector.end());
+
+                EXPECT_EQ(amplitudeProfile.size(), 2);
+                if (amplitudeProfile.size() > 1)
+                {
+                    EXPECT_NEAR(amplitudeProfile[1].second, 5725, 100);
+                }
+
+                // item.second->dumpPcmData();
+            }
+
+            std::sort(allFreq.begin(), allFreq.end());
+            ASSERT_GE(allFreq.size(), 2);
+            EXPECT_NEAR(allFreq[0], 1300.0, 25.0);
+            EXPECT_NEAR(allFreq[1], 2100.0, 25.0);
+
+            std::unordered_map<uint32_t, transport::ReportSummary> transportSummary2;
+            std::unordered_map<uint32_t, transport::ReportSummary> transportSummary3;
+            auto videoReceiveStats = group.clients[0]->_transport->getCumulativeVideoReceiveCounters();
+            group.clients[1]->_transport->getReportSummary(transportSummary2);
+            group.clients[2]->_transport->getReportSummary(transportSummary3);
+
+            logger::debug("client1 received video pkts %" PRIu64, "bbTest", videoReceiveStats.packets);
+            logTransportSummary("client2", group.clients[1]->_transport.get(), transportSummary2);
+            logTransportSummary("client3", group.clients[2]->_transport.get(), transportSummary3);
+
+            EXPECT_NEAR(videoReceiveStats.packets,
+                transportSummary2.begin()->second.packetsSent + transportSummary3.begin()->second.packetsSent,
+                25);
+        }
+        {
+            auto audioCounters = group.clients[1]->_transport->getCumulativeAudioReceiveCounters();
+            EXPECT_EQ(audioCounters.lostPackets, 0);
+
+            const auto& rData1 = group.clients[1]->getAudioReceiveStats();
+            std::vector<double> allFreq;
+            for (const auto& item : rData1)
+            {
+                std::vector<double> freqVector;
+                std::vector<std::pair<uint64_t, double>> amplitudeProfile;
+                auto rec = item.second->getRecording();
+                analyzeRecording(rec, freqVector, amplitudeProfile, item.second->getLoggableId().c_str());
+                EXPECT_NEAR(rec.size(), 5 * codec::Opus::sampleRate, 3 * audioPacketSampleCount);
+                EXPECT_EQ(freqVector.size(), 1);
+                allFreq.insert(allFreq.begin(), freqVector.begin(), freqVector.end());
+
+                EXPECT_EQ(amplitudeProfile.size(), 2);
+                if (amplitudeProfile.size() > 1)
+                {
+                    EXPECT_NEAR(amplitudeProfile[1].second, 5725, 100);
+                }
+
+                // item.second->dumpPcmData();
+            }
+
+            std::sort(allFreq.begin(), allFreq.end());
+            EXPECT_NEAR(allFreq[0], 600.0, 25.0);
+            EXPECT_NEAR(allFreq[1], 2100.0, 25.0);
+        }
+    });
+}
+
+#undef DEFINE_3_CLIENT_CONFERENCE

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -234,15 +234,15 @@ TEST_F(BarbellTest, packetLossViaBarbell)
             // have been ignored. So we might expect small number of videoCounters.lostPackets.
             if (videoCounters.lostPackets != 0)
             {
-                ASSERT_TRUE(stats.rcvPacketsMissing >= stats.rcvPacketsRecovered);
+                ASSERT_TRUE(stats.receiver.packetsMissing >= stats.receiver.packetsRecovered);
                 // Expect number of non-recovered packet to be smaller than half the loss rate.
-                ASSERT_TRUE(
-                    stats.rcvPacketsMissing - stats.rcvPacketsRecovered < stats.sndPacketsSent * PACKET_LOSS_RATE / 2);
+                ASSERT_TRUE(stats.receiver.packetsMissing - stats.receiver.packetsRecovered <
+                    stats.sender.packetsSent * PACKET_LOSS_RATE / 2);
             }
 
             // Assure that losses indeed happenned.
-            EXPECT_NE(stats.rcvPacketsMissing, 0);
-            EXPECT_NE(stats.rcvPacketsRecovered, 0);
+            EXPECT_NE(stats.receiver.packetsMissing, 0);
+            EXPECT_NE(stats.receiver.packetsRecovered, 0);
 
             const auto& rData1 = group.clients[0]->getAudioReceiveStats();
             std::vector<double> allFreq;
@@ -292,5 +292,3 @@ TEST_F(BarbellTest, packetLossViaBarbell)
         }
     });
 }
-
-#undef DEFINE_3_CLIENT_CONFERENCE

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -225,6 +225,11 @@ TEST_F(BarbellTest, packetLossViaBarbell)
 
         {
             auto videoCounters = group.clients[0]->_transport->getCumulativeVideoReceiveCounters();
+
+            // The worst case, we should loose about PACKET_LOSS_RATE (1%) * 5 sec * 30 fps around 15 frames.
+            // Sometimes videoCounters.lostPackets > 0 if I-frame is transmiited right after the "loss".
+            // But than, if we ask client->...->VideoMissingPacketsTracker.process() - should return 0 lost sequence
+            // numbers.
             EXPECT_EQ(videoCounters.lostPackets, 0);
 
             auto autioCounters = group.clients[0]->_transport->getCumulativeAudioReceiveCounters();

--- a/test/integration/BarbellTest.h
+++ b/test/integration/BarbellTest.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "IntegrationTest.h"
+
+struct BarbellTest : public IntegrationTest
+{
+    BarbellTest();
+    void SetUp() override;
+    void TearDown() override;
+};

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1756,9 +1756,9 @@ TEST_F(IntegrationTest, packetLossVideoRecoveredViaNack)
                 if (videoCounters.lostPackets != 0)
                 {
                     ASSERT_TRUE(stats.rcvPacketsMissing >= stats.rcvPacketsRecovered);
-                    // Expect number of non-recovered packet to be smaller than
-                    ASSERT_TRUE(
-                        stats.rcvPacketsMissing - stats.rcvPacketsRecovered < stats.sndPacketsSent * PACKET_LOSS_RATE);
+                    // Expect number of non-recovered packet to be smaller than half the loss rate.
+                    ASSERT_TRUE(stats.rcvPacketsMissing - stats.rcvPacketsRecovered <
+                        stats.sndPacketsSent * PACKET_LOSS_RATE / 2);
                 }
 
                 // Expect, "as sender" we received several NACK request from SFU, and we served them all.

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1711,9 +1711,6 @@ TEST_F(IntegrationTest, packetLossVideoRecoveredViaNack)
             linkInfo.second.ptrLink->setLossRate(0.01);
         }
 
-        ScopedFinalize finalize(std::bind(&IntegrationTest::finalizeSimulation, this));
-        startSimulation();
-
         const std::string baseUrl = "http://127.0.0.1:8080";
 
         GroupCall<SfuClient<ColibriChannel>> group(_instanceCounter,
@@ -1724,6 +1721,10 @@ TEST_F(IntegrationTest, packetLossVideoRecoveredViaNack)
             2);
 
         Conference conf;
+
+        ScopedFinalize finalize(std::bind(&IntegrationTest::finalizeSimulation, this));
+        startSimulation();
+
         group.startConference(conf, baseUrl + "/colibri");
 
         group.clients[0]->initiateCall(baseUrl, conf.getId(), true, true, true, true);

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1685,7 +1685,7 @@ TEST_F(IntegrationTest, detectIsPtt)
     });
 };
 
-TEST_F(IntegrationTest, packetLoss)
+TEST_F(IntegrationTest, whenPacketLossVideoIsResentAudioIsNot)
 {
     runTestInThread(_numWorkerThreads + 4, [this]() {
         _config.readFromString(R"({
@@ -1732,8 +1732,7 @@ TEST_F(IntegrationTest, packetLoss)
         {
             for (auto id : {0, 1})
             {
-                auto audioCounters =
-                    group.clients[id]->_transport->getAudioReceiveCounters(utils::Time::getAbsoluteTime());
+                auto audioCounters = group.clients[id]->_transport->getCumulativeAudioReceiveCounters();
                 EXPECT_NE(audioCounters.lostPackets, 0);
 
                 auto videoCounters = group.clients[id]->_transport->getCumulativeVideoReceiveCounters();

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1755,21 +1755,21 @@ TEST_F(IntegrationTest, packetLossVideoRecoveredViaNack)
                 // have been ignored. So we might expect small number of videoCounters.lostPackets.
                 if (videoCounters.lostPackets != 0)
                 {
-                    ASSERT_TRUE(stats.rcvPacketsMissing >= stats.rcvPacketsRecovered);
+                    ASSERT_TRUE(stats.receiver.packetsMissing >= stats.receiver.packetsRecovered);
                     // Expect number of non-recovered packet to be smaller than half the loss rate.
-                    ASSERT_TRUE(stats.rcvPacketsMissing - stats.rcvPacketsRecovered <
-                        stats.sndPacketsSent * PACKET_LOSS_RATE / 2);
+                    ASSERT_TRUE(stats.receiver.packetsMissing - stats.receiver.packetsRecovered <
+                        stats.sender.packetsSent * PACKET_LOSS_RATE / 2);
                 }
 
                 // Expect, "as sender" we received several NACK request from SFU, and we served them all.
-                EXPECT_NE(stats.sndNackRequestsReceived, 0);
-                EXPECT_NE(stats.sndPacketsMissingAsked, 0);
-                EXPECT_NE(stats.sndPacketsMissingSent, 0);
-                EXPECT_EQ(stats.sndPacketsMissingAsked, stats.sndPacketsMissingSent);
+                EXPECT_NE(stats.sender.nacksReceived, 0);
+                EXPECT_NE(stats.sender.retransmissionRequests, 0);
+                EXPECT_NE(stats.sender.retransmissions, 0);
+                EXPECT_EQ(stats.sender.retransmissionRequests, stats.sender.retransmissions);
 
-                EXPECT_EQ(stats.rcvNackRequestSent, 0); // Expected as it's is not implemented yet.
-                EXPECT_NE(stats.rcvPacketsMissing, 0);
-                EXPECT_NE(stats.rcvPacketsRecovered, 0);
+                EXPECT_EQ(stats.receiver.nackRequests, 0); // Expected as it's is not implemented yet.
+                EXPECT_NE(stats.receiver.packetsMissing, 0);
+                EXPECT_NE(stats.receiver.packetsRecovered, 0);
             }
         }
     });

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -73,7 +73,7 @@ void IntegrationTest::SetUp()
     }
 
 #if USE_FAKENETWORK
-    _clientsEndpointFacory =
+    _clientsEndpointFactory =
         std::shared_ptr<transport::EndpointFactory>(new emulator::FakeEndpointFactory(_internet->get(),
             [](std::shared_ptr<fakenet::NetworkLink>, const transport::SocketAddress& addr, const std::string& name) {
                 logger::info("Client %s endpoint uses address %s",
@@ -82,7 +82,7 @@ void IntegrationTest::SetUp()
                     addr.toString().c_str());
             }));
 #else
-    _clientsEndpointFacory = std::shared_ptr<transport::EndpointFactory>(new transport::EndpointFactoryImpl());
+    _clientsEndpointFactory = std::shared_ptr<transport::EndpointFactory>(new transport::EndpointFactoryImpl());
 #endif
 }
 
@@ -158,7 +158,7 @@ void IntegrationTest::initBridge(config::Config& config)
         interfaces,
         *_network,
         *_mainPoolAllocator,
-        _clientsEndpointFacory);
+        _clientsEndpointFactory);
 }
 
 using namespace emulator;

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -14,27 +14,6 @@
 #include <gtest/gtest.h>
 #include <mutex>
 
-#define DEFINE_3_CLIENT_CONFERENCE(TChannel, BASE_URL)                                                                 \
-    Conference conf;                                                                                                   \
-    conf.create(BASE_URL);                                                                                             \
-    EXPECT_TRUE(conf.isSuccess());                                                                                     \
-    utils::Time::rawNanoSleep(1 * utils::Time::sec);                                                                   \
-    SfuClient<TChannel> client1(++_instanceCounter,                                                                    \
-        *_mainPoolAllocator,                                                                                           \
-        _audioAllocator,                                                                                               \
-        *_transportFactory,                                                                                            \
-        *_sslDtls);                                                                                                    \
-    SfuClient<TChannel> client2(++_instanceCounter,                                                                    \
-        *_mainPoolAllocator,                                                                                           \
-        _audioAllocator,                                                                                               \
-        *_transportFactory,                                                                                            \
-        *_sslDtls);                                                                                                    \
-    SfuClient<TChannel> client3(++_instanceCounter,                                                                    \
-        *_mainPoolAllocator,                                                                                           \
-        _audioAllocator,                                                                                               \
-        *_transportFactory,                                                                                            \
-        *_sslDtls);
-
 struct IntegrationTest : public ::testing::Test
 {
     IntegrationTest();

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -37,7 +37,7 @@ struct IntegrationTest : public ::testing::Test
     std::unique_ptr<transport::TransportFactory> _transportFactory;
     std::shared_ptr<fakenet::InternetRunner> _internet;
     std::shared_ptr<transport::EndpointFactory> _bridgeEndpointFactory;
-    std::shared_ptr<transport::EndpointFactory> _clientsEndpointFacory;
+    std::shared_ptr<transport::EndpointFactory> _clientsEndpointFactory;
 
     uint32_t _instanceCounter;
     const size_t _numWorkerThreads;

--- a/test/integration/emulator/FakeEndpointFactory.cpp
+++ b/test/integration/emulator/FakeEndpointFactory.cpp
@@ -4,7 +4,11 @@
 
 namespace emulator
 {
-FakeEndpointFactory::FakeEndpointFactory(std::shared_ptr<fakenet::Gateway> network) : _network(network) {}
+FakeEndpointFactory::FakeEndpointFactory(std::shared_ptr<fakenet::Gateway> network, EndpointCallback callback)
+    : _network(network),
+      _callback(callback)
+{
+}
 
 transport::UdpEndpoint* FakeEndpointFactory::createUdpEndpoint(jobmanager::JobManager& jobManager,
     size_t maxSessionCount,
@@ -16,6 +20,8 @@ transport::UdpEndpoint* FakeEndpointFactory::createUdpEndpoint(jobmanager::JobMa
     auto endpoint =
         new emulator::FakeUdpEndpoint(jobManager, maxSessionCount, allocator, localPort, epoll, isShared, _network);
     _network->addLocal(static_cast<fakenet::NetworkNode*>(endpoint));
+
+    _callback(endpoint->getDownlink(), localPort, endpoint->getName());
 
     return static_cast<transport::UdpEndpoint*>(endpoint);
 }

--- a/test/integration/emulator/FakeEndpointFactory.h
+++ b/test/integration/emulator/FakeEndpointFactory.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "test/transport/FakeNetwork.h"
+#include "test/transport/NetworkLink.h"
 #include "transport/EndpointFactory.h"
+#include <functional>
 #include <memory>
 
 namespace jobmanager
@@ -23,8 +25,11 @@ namespace emulator
 
 class FakeEndpointFactory : public transport::EndpointFactory
 {
+    using EndpointCallback =
+        std::function<void(std::shared_ptr<fakenet::NetworkLink>, const transport::SocketAddress&, const std::string&)>;
+
 public:
-    FakeEndpointFactory(std::shared_ptr<fakenet::Gateway>);
+    FakeEndpointFactory(std::shared_ptr<fakenet::Gateway>, EndpointCallback);
 
     virtual transport::UdpEndpoint* createUdpEndpoint(jobmanager::JobManager& jobManager,
         size_t maxSessionCount,
@@ -35,5 +40,6 @@ public:
 
 private:
     std::shared_ptr<fakenet::Gateway> _network;
+    EndpointCallback _callback;
 };
 } // namespace emulator

--- a/test/integration/emulator/FakeUdpEndpoint.h
+++ b/test/integration/emulator/FakeUdpEndpoint.h
@@ -63,6 +63,7 @@ public:
         uint64_t timestamp) override;
     virtual bool hasIp(const transport::SocketAddress& target) override;
     virtual void process(uint64_t timestamp) override;
+    virtual std::shared_ptr<fakenet::NetworkLink> getDownlink() override { return _networkLink; }
 
     // Internal job interface.
     void internalUnregisterListener(IEvents* listener);
@@ -106,7 +107,7 @@ private:
     std::atomic<IEvents*> _defaultListener;
     std::shared_ptr<fakenet::Gateway> _network;
     memory::PacketPoolAllocator _networkLinkAllocator;
-    fakenet::NetworkLink _networkLink;
+    std::shared_ptr<fakenet::NetworkLink> _networkLink;
 
     struct RateMetrics
     {

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -693,11 +693,6 @@ public:
 
         _rtxStats.sndPacketsMissingAsked++;
 
-        if (cache == _videoCaches.end() || videoSource == _videoSources.end())
-        {
-            assert(false);
-        }
-
         if (videoSource->second->isKeyFrameRequested())
         {
             logger::info("Ignoring NACK for pre key frame packet %u, key frame at %u",
@@ -737,10 +732,7 @@ public:
         packet->setLength(cachedPacket->getLength() + sizeof(uint16_t));
 
         auto videoFeedbackSequenceCounterItr = _videoFeedbackSequenceCounter.find(ssrc);
-        if (videoFeedbackSequenceCounterItr == _videoFeedbackSequenceCounter.end())
-        {
-            assert(false);
-        }
+
         const auto sequenceCounter = videoFeedbackSequenceCounterItr->second;
 
         auto rtpHeader = rtp::RtpHeader::fromPacket(*packet);

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -351,6 +351,12 @@ public:
             }
 
             auto& inboundContext = it->second;
+
+            if (!inboundContext.videoMissingPacketsTracker)
+            {
+                inboundContext.videoMissingPacketsTracker = std::make_shared<bridge::VideoMissingPacketsTracker>(10);
+            }
+
             inboundContext.onRtpPacket(timestamp);
 
             if (!sender->unprotect(packet))

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -343,6 +343,7 @@ public:
             uint64_t timestamp)
         {
             auto rtpHeader = rtp::RtpHeader::fromPacket(packet);
+
             auto it = contexts.find(rtpHeader->ssrc.get());
             if (it == contexts.end())
             {
@@ -451,8 +452,12 @@ public:
                     if (numMissingSequenceNumbers)
                     {
                         logger::debug("Video missing packet tracker: %zu packets missing",
-                            "SfuClient",
+                            sender->getLoggableId().c_str(),
                             numMissingSequenceNumbers);
+                        for (size_t i = 0; i < numMissingSequenceNumbers; i++)
+                        {
+                            logger::debug("\n missing sequence number: %u", "SfuClient", missingSequenceNumbers[i]);
+                        }
                     }
                 }
             }

--- a/test/sctp/SctpEndpoint.cpp
+++ b/test/sctp/SctpEndpoint.cpp
@@ -41,7 +41,7 @@ SctpEndpoint::SctpEndpoint(uint16_t port,
     uint32_t mtu)
     : _loggableId("SctpEndpoint"),
       _port(std::make_unique<sctp::SctpServerPort>(_loggableId.getInstanceId(), this, this, port, config, timeSource)),
-      _sendQueue(bandwidthKpbs, std::max(bandwidthKpbs * 1000 / 4, mtu * 6u), mtu),
+      _sendQueue(_loggableId.c_str(), bandwidthKpbs, std::max(bandwidthKpbs * 1000 / 4, mtu * 6u), mtu),
       _streamId(0),
       _dataSizeReceived(0),
       _receivedMessageCount(0),

--- a/test/transport/FakeNetwork.cpp
+++ b/test/transport/FakeNetwork.cpp
@@ -240,4 +240,20 @@ void InternetRunner::internetThreadRun()
         }
     }
 }
+
+std::map<std::string, std::shared_ptr<NetworkLink>> getMapOfInternet(std::shared_ptr<Gateway> internet)
+{
+    std::map<std::string, std::shared_ptr<NetworkLink>> internetMap;
+    for (const auto& node : internet->getLocalNodes())
+    {
+        const auto downlink = node->getDownlink();
+        internetMap.emplace(downlink->getName(), downlink);
+    }
+    for (const auto& node : internet->getPublicNodes())
+    {
+        const auto downlink = node->getDownlink();
+        internetMap.emplace(downlink->getName(), downlink);
+    }
+    return internetMap;
+}
 } // namespace fakenet

--- a/test/transport/NetworkLink.h
+++ b/test/transport/NetworkLink.h
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <mutex>
 #include <queue>
+#include <string>
 #include <unistd.h>
 
 namespace memory
@@ -18,8 +19,9 @@ namespace fakenet
 class NetworkLink
 {
 public:
-    explicit NetworkLink(uint32_t bandwidthKbps, size_t bufferSize, size_t mtu)
-        : _releaseTime(0),
+    explicit NetworkLink(std::string name, uint32_t bandwidthKbps, size_t bufferSize, size_t mtu)
+        : _name(name),
+          _releaseTime(0),
           _bandwidthKbps(bandwidthKbps),
           _staticDelay(0),
           _mtu(mtu),
@@ -56,11 +58,14 @@ public:
     uint32_t getBandwidthKbps() const { return _bandwidthKbps; }
     void setBandwidthKbps(uint32_t bandwidth) { _bandwidthKbps = bandwidth; }
 
+    std::string getName() const { return _name; }
+
     static const int IPOVERHEAD = 20 + 14; // IP and DTLS header
 private:
     void addBurstDelay();
     memory::UniquePacket popDelayQueue(uint64_t timestamp);
 
+    std::string _name;
     std::queue<memory::UniquePacket> _queue;
     uint64_t _releaseTime;
     uint32_t _bandwidthKbps;


### PR DESCRIPTION
- Create an integration test that uses network simulation to control packet losses over the barbell connection;
- Add tracking of the missing video packets to the test client (SfuClient);
- Make EningeMixer to process missing video packets that came over barbell;
- Process NACK requests that comes via barbell;
- Fix the bug in the VideoForwarderRtxReceiveJob that kept received video packet on feedback ssrc context.