### PR TITLE
Fix EngineStreamDirector

### DIFF
--- a/bridge/engine/DiscardReceivedVideoPacketJob.cpp
+++ b/bridge/engine/DiscardReceivedVideoPacketJob.cpp
@@ -9,11 +9,13 @@ namespace bridge
 
 DiscardReceivedVideoPacketJob::DiscardReceivedVideoPacketJob(memory::UniquePacket packet,
     transport::RtcTransport* sender,
-    bridge::SsrcInboundContext& ssrcContext)
+    bridge::SsrcInboundContext& ssrcContext,
+    const uint32_t extendedSequenceNumber)
     : CountedJob(sender->getJobCounter()),
       _packet(std::move(packet)),
       _sender(sender),
-      _ssrcContext(ssrcContext)
+      _ssrcContext(ssrcContext),
+      _extendedSequenceNumber(extendedSequenceNumber)
 {
     assert(_packet);
     assert(_packet->getLength() > 0);
@@ -34,6 +36,7 @@ void DiscardReceivedVideoPacketJob::run()
     {
         uint32_t extSeqno = 0;
         _ssrcContext.videoMissingPacketsTracker->onPacketArrived(rtpHeader->sequenceNumber, extSeqno);
+        _ssrcContext.lastReceivedExtendedSequenceNumber = _extendedSequenceNumber;
     }
 }
 

--- a/bridge/engine/DiscardReceivedVideoPacketJob.cpp
+++ b/bridge/engine/DiscardReceivedVideoPacketJob.cpp
@@ -32,11 +32,11 @@ void DiscardReceivedVideoPacketJob::run()
         return;
     }
 
+    _ssrcContext.lastReceivedExtendedSequenceNumber = _extendedSequenceNumber;
     if (_ssrcContext.videoMissingPacketsTracker)
     {
         uint32_t extSeqno = 0;
         _ssrcContext.videoMissingPacketsTracker->onPacketArrived(rtpHeader->sequenceNumber, extSeqno);
-        _ssrcContext.lastReceivedExtendedSequenceNumber = _extendedSequenceNumber;
     }
 }
 

--- a/bridge/engine/DiscardReceivedVideoPacketJob.h
+++ b/bridge/engine/DiscardReceivedVideoPacketJob.h
@@ -18,7 +18,8 @@ class DiscardReceivedVideoPacketJob : public jobmanager::CountedJob
 public:
     DiscardReceivedVideoPacketJob(memory::UniquePacket packet,
         transport::RtcTransport* sender,
-        bridge::SsrcInboundContext& ssrcContext);
+        bridge::SsrcInboundContext& ssrcContext,
+        const uint32_t extendedSequenceNumber);
 
     void run() override;
 
@@ -26,6 +27,7 @@ private:
     memory::UniquePacket _packet;
     transport::RtcTransport* _sender;
     bridge::SsrcInboundContext& _ssrcContext;
+    const uint32_t _extendedSequenceNumber;
 };
 
 } // namespace bridge

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -1416,7 +1416,10 @@ void EngineMixer::onVideoRtpPacketReceived(SsrcInboundContext& ssrcContext,
 
     if (!mustBeForwardedOnBarbells && !ssrcContext.isSsrcUsed.load())
     {
-        sender->getJobQueue().addJob<bridge::DiscardReceivedVideoPacketJob>(std::move(packet), sender, ssrcContext);
+        sender->getJobQueue().addJob<bridge::DiscardReceivedVideoPacketJob>(std::move(packet),
+            sender,
+            ssrcContext,
+            extendedSequenceNumber);
         return;
     }
 

--- a/bridge/engine/EngineStreamDirector.cpp
+++ b/bridge/engine/EngineStreamDirector.cpp
@@ -3,11 +3,11 @@
 namespace bridge
 {
 constexpr EngineStreamDirector::ConfigRow EngineStreamDirector::configLadder[6] = {
-    // BaseRate, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
+    // BaseRate = 0, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
     {2500 - 500, highQuality, midQuality, 500, 2500, 6500},
     {500 - 500, midQuality, midQuality, 500, 500, 4500},
     {500 - 100, midQuality, lowQuality, 100, 500, 1300},
     {100 - 100, lowQuality, lowQuality, 100, 100, 900},
-    {100, lowQuality, dropQuality, 0, 100, 200},
+    {100, lowQuality, dropQuality, 0, 100, 100},
     {0, dropQuality, dropQuality, 0, 0, 0}};
 } // namespace bridge

--- a/bridge/engine/EngineStreamDirector.cpp
+++ b/bridge/engine/EngineStreamDirector.cpp
@@ -3,7 +3,7 @@
 namespace bridge
 {
 constexpr EngineStreamDirector::ConfigRow EngineStreamDirector::configLadder[6] = {
-    // BaseRate = 0, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
+    // BaseRate, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
     {2500 - 500, highQuality, midQuality, 500, 2500, 6500},
     {500 - 500, midQuality, midQuality, 500, 500, 4500},
     {500 - 100, midQuality, lowQuality, 100, 500, 1300},

--- a/bridge/engine/EngineStreamDirector.cpp
+++ b/bridge/engine/EngineStreamDirector.cpp
@@ -4,10 +4,10 @@ namespace bridge
 {
 constexpr EngineStreamDirector::ConfigRow EngineStreamDirector::configLadder[6] = {
     // BaseRate = 0, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
-    {2500 - 500, highQuality, midQuality, 500, 2500, 6000},
-    {500 - 500, midQuality, midQuality, 500, 500, 4000},
-    {500 - 100, midQuality, lowQuality, 100, 500, 1200},
-    {100 - 100, lowQuality, lowQuality, 100, 100, 800},
-    {100, lowQuality, dropQuality, 0, 100, 100},
+    {2500 - 500, highQuality, midQuality, 500, 2500, 6500},
+    {500 - 500, midQuality, midQuality, 500, 500, 4500},
+    {500 - 100, midQuality, lowQuality, 100, 500, 1300},
+    {100 - 100, lowQuality, lowQuality, 100, 100, 900},
+    {100, lowQuality, dropQuality, 0, 100, 200},
     {0, dropQuality, dropQuality, 0, 0, 0}};
 } // namespace bridge

--- a/bridge/engine/EngineStreamDirector.h
+++ b/bridge/engine/EngineStreamDirector.h
@@ -936,10 +936,11 @@ private:
         bool sendingVideo = participantStreams.primary.isSendingVideo() ||
             (participantStreams.secondary.isSet() && participantStreams.secondary.get().isSendingVideo());
 
-        // The value of maxReceivingVideoStreams dictates avaible bitrate distribution, but if we are
-        // the only one, or the very first participant sending video, it'll be 0. Since we want to initialize
-        // wanted pinned/unpinned qualities anyway, it's important we assure it's set to 1, to conform
-        // with the configLadder table assumption that at least one stream is present.
+        // We need to divide available bitrate (minus bitrate for slides, if present) to "maxReceivingVideoStreams".
+        // "maxReceivingVideoStreams" can be 0, if we are the only one sending video, or the very first one
+        // - in that case quality limits will be initially overestimated (but would be peridically updated with each
+        // uplink estimation anyway). To lookup "configLadder" we need at least one stream, thus capping to 1 from
+        // below.
         const auto maxReceivingVideoStreams =
             std::max(1ul, std::min(_lowQualitySsrcs.size(), (unsigned long)_lastN) - (sendingVideo ? 1 : 0));
 

--- a/bridge/engine/EngineStreamDirector.h
+++ b/bridge/engine/EngineStreamDirector.h
@@ -269,7 +269,7 @@ public:
             std::max(uplinkEstimateKbps, participantStream.defaultLevelBandwidthLimit);
 
         size_t pinnedQuality, unpinnedQuality;
-        getVideoQualityLimits(participantStream, pinnedQuality, unpinnedQuality);
+        getVideoQualityLimits(endpointIdHash, participantStream, pinnedQuality, unpinnedQuality);
 
         participantStream.desiredHighestEstimatedPinnedLevel = pinnedQuality;
         participantStream.desiredUnpinnedLevel = unpinnedQuality;
@@ -926,23 +926,24 @@ private:
         return (numRecordingStreams != 0 && isContentSlides(ssrc, senderEndpointIdHash));
     }
 
-    inline void getVideoQualityLimits(const ParticipantStreams& participantStreams,
+    inline void getVideoQualityLimits(const size_t endpointIdHash,
+        const ParticipantStreams& participantStreams,
         size_t& outPinnedQuality,
         size_t& outUnpinnedQuality) const
     {
         outPinnedQuality = dropQuality;
         outUnpinnedQuality = dropQuality;
 
+        // We need to divide available bitrate (minus bitrate for slides, if present) to "maxReceivingVideoStreams".
+        // "maxReceivingVideoStreams" can be 0, if we are the only one sending video, or the very first one in that case
+        // quality limits will be initially overestimated (but would be peridically updated with each uplink estimation
+        // anyway). To lookup "configLadder" we need at least one stream, thus capping to 1 from below.
+
         bool sendingVideo = participantStreams.primary.isSendingVideo() ||
             (participantStreams.secondary.isSet() && participantStreams.secondary.get().isSendingVideo());
 
-        // We need to divide available bitrate (minus bitrate for slides, if present) to "maxReceivingVideoStreams".
-        // "maxReceivingVideoStreams" can be 0, if we are the only one sending video, or the very first one
-        // - in that case quality limits will be initially overestimated (but would be peridically updated with each
-        // uplink estimation anyway). To lookup "configLadder" we need at least one stream, thus capping to 1 from
-        // below.
-        const auto maxReceivingVideoStreams =
-            std::max(1ul, std::min(_lowQualitySsrcs.size(), (unsigned long)_lastN) - (sendingVideo ? 1 : 0));
+        const auto maxReceivingVideoStreams = std::max(1ul,
+            std::min(std::max(1ul, _lowQualitySsrcs.size()), (unsigned long)_lastN) - (sendingVideo ? 1 : 0));
 
         int bestConfigId = 0;
         unsigned long bestConfigCost = 0;
@@ -971,13 +972,15 @@ private:
         outPinnedQuality = configLadder[bestConfigId].PinnedQuality;
         outUnpinnedQuality = configLadder[bestConfigId].UnpinnedQuality;
 
-        DIRECTOR_LOG("VQ pinned: %c, unpinned %c, max streams %ld, estimated uplink %d, reserve for slides: %d",
+        DIRECTOR_LOG("VQ pinned: %c, unpinned %c, max streams %ld, estimated uplink %d, reserve for slides: %d "
+                     "(endpoint %zu)",
             _loggableId.c_str(),
             (char)outPinnedQuality + '0',
             (char)outUnpinnedQuality + '0',
             maxReceivingVideoStreams,
             estimatedUplinkBandwidth,
-            _slidesBitrateKbps);
+            _slidesBitrateKbps,
+            endpointIdHash);
     }
 };
 

--- a/bridge/engine/VideoMissingPacketsTracker.h
+++ b/bridge/engine/VideoMissingPacketsTracker.h
@@ -62,7 +62,11 @@ public:
 #endif
 
         auto missingPacketsItr = _missingPackets.find(sequenceNumber);
-        if (missingPacketsItr == _missingPackets.end() || missingPacketsItr->second._arrived)
+        if (missingPacketsItr == _missingPackets.end())
+        {
+            return false;
+        }
+        else if (missingPacketsItr->second._arrived)
         {
 #if DEBUG_MISSING_PACKETS_TRACKER
             logger::debug("Late packet arrived seq %u already removed", _loggableId.c_str(), sequenceNumber);

--- a/test/bridge/EngineStreamDirectorTest.cpp
+++ b/test/bridge/EngineStreamDirectorTest.cpp
@@ -624,8 +624,8 @@ TEST_F(EngineStreamDirectorTest, bandwidthEstimationAllNeededQualityLevelsAreUse
     _engineStreamDirector->setUplinkEstimateKbps(3, 2000, 61 * utils::Time::sec);
 
     // Low estimate
-    _engineStreamDirector->setUplinkEstimateKbps(4, 1, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(4, 1, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 101, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 101, 61 * utils::Time::sec);
 
     // Used by 4
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(1, 1, true, 0));

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -469,12 +469,14 @@ public:
             }
 
             inboundContext.onRtpPacketReceived(timestamp);
+#if 0
             logger::debug("%s received ssrc %u, seq %u, extseq %u",
                 _loggableId.c_str(),
                 sender->getLoggableId().c_str(),
                 inboundContext.ssrc,
                 rtpHeader->sequenceNumber.get(),
                 inboundContext.lastReceivedExtendedSequenceNumber);
+#endif
 
             if (!sender->unprotect(packet))
             {


### PR DESCRIPTION
- always initialize retval outPinnedQUality and outUnpinnedQuality;
- take into account if the participant sends video itself (thus maxReceivingVideoStreams will be less);
- make maxReceivingVideoStreams range limited by 1 from the lower end to ensure correct bitrate calculation using configLadder.

Issue: https://github.com/finos/SymphonyMediaBridge/issues/189