### PR TITLE
Fix segfault when ice.singlePort is 0

### DIFF
--- a/transport/TransportFactory.cpp
+++ b/transport/TransportFactory.cpp
@@ -512,6 +512,11 @@ public:
 
     void registerIceListener(Endpoint::IEvents& listener, const std::string& ufrag) override
     {
+        if (_sharedEndpoints.empty())
+        {
+            return;
+        }
+
         for (auto& endpoint : _sharedEndpoints[0])
         {
             endpoint->registerListener(ufrag, &listener);


### PR DESCRIPTION
Quick fix for segfault on SMB startup when ice.singlePort is set to 0 in config.json. No UDP probing candidates will be reported in this case as the implementation assumes there is at least 1 shared UDP endpoint.

Creating transport on private port is not affected: UDP endpoint is created on a random port from the udpPortRangeLow - udpPortRangeHigh as before.

RTC-13083

--

Fixes #193 