### PR TITLE
Fix broken deletion check

### DIFF
--- a/bridge/VideoStream.h
+++ b/bridge/VideoStream.h
@@ -35,10 +35,10 @@ struct VideoStream
     {
     }
 
-    std::string id;
-    std::string endpointId;
-    size_t endpointIdHash;
-    uint32_t localSsrc;
+    const std::string id;
+    const std::string endpointId;
+    const size_t endpointIdHash;
+    const uint32_t localSsrc;
     SimulcastStream simulcastStream;
     utils::Optional<SimulcastStream> secondarySimulcastStream;
     std::shared_ptr<transport::RtcTransport> transport;
@@ -50,7 +50,7 @@ struct VideoStream
 
     bool markedForDeletion;
     const bool ssrcRewrite;
-    bool isDtlsLocalEnabled;
+    const bool isDtlsLocalEnabled;
     bool isConfigured;
     const uint32_t idleTimeoutSeconds;
 };

--- a/bridge/VideoStream.h
+++ b/bridge/VideoStream.h
@@ -49,7 +49,7 @@ struct VideoStream
     SsrcWhitelist ssrcWhitelist;
 
     bool markedForDeletion;
-    bool ssrcRewrite;
+    const bool ssrcRewrite;
     bool isDtlsLocalEnabled;
     bool isConfigured;
     const uint32_t idleTimeoutSeconds;

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -1197,7 +1197,7 @@ void EngineMixer::checkPacketCounters(const uint64_t timestamp)
         for (auto& outboundContextEntry : videoStreamEntry.second->ssrcOutboundContexts)
         {
             auto& outboundContext = outboundContextEntry.second;
-            if (outboundContext.markedForDeletion)
+            if (!outboundContext.markedForDeletion)
             {
                 continue;
             }
@@ -1250,7 +1250,7 @@ void EngineMixer::checkPacketCounters(const uint64_t timestamp)
         for (auto& outboundContextEntry : recordingStreamEntry.second->ssrcOutboundContexts)
         {
             auto& outboundContext = outboundContextEntry.second;
-            if (outboundContext.markedForDeletion)
+            if (!outboundContext.markedForDeletion)
             {
                 continue;
             }

--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -1207,7 +1207,7 @@ void EngineMixer::checkRecordingPacketCounters(const uint64_t timestamp)
         {
             auto& outboundContext = outboundContextEntry.second;
             if (outboundContext.markedForDeletion &&
-                utils::Time::diffGT(outboundContext.lastSendTime, timestamp, utils::Time::sec * 300))
+                utils::Time::diffGT(outboundContext.lastSendTime, timestamp, utils::Time::sec * 30))
             {
                 logger::info("Removing marked and idle recording outbound context ssrc %u, rec endpointIdHash %lu",
                     _loggableId.c_str(),

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -391,6 +391,9 @@ private:
     void updateDirectorUplinkEstimates(const uint64_t engineIterationStartTimestamp);
     void processMissingPackets(const uint64_t timestamp);
     void checkPacketCounters(const uint64_t timestamp);
+    void checkInboundPacketCounters(const uint64_t timestamp);
+    void checkRecordingPacketCounters(const uint64_t timestamp);
+    void checkBarbellPacketCounters(const uint64_t timestamp);
     void checkIfRateControlIsNeeded(const uint64_t timestamp);
     bool isVideoInUse(const uint64_t timestamp, const uint64_t threshold) const;
     void markSsrcsInUse();

--- a/bridge/engine/EngineVideoStream.h
+++ b/bridge/engine/EngineVideoStream.h
@@ -76,20 +76,20 @@ struct EngineVideoStream
         return mainSsrc;
     }
 
-    std::string endpointId;
-    size_t endpointIdHash;
-    uint32_t localSsrc;
+    const std::string endpointId;
+    const size_t endpointIdHash;
+    const uint32_t localSsrc;
     SimulcastStream simulcastStream;
     utils::Optional<SimulcastStream> secondarySimulcastStream;
     concurrency::MpmcHashmap32<uint32_t, SsrcOutboundContext> ssrcOutboundContexts;
 
     transport::RtcTransport& transport;
 
-    bridge::RtpMap rtpMap;
-    bridge::RtpMap feedbackRtpMap;
+    const bridge::RtpMap rtpMap;
+    const bridge::RtpMap feedbackRtpMap;
 
     SsrcWhitelist ssrcWhitelist;
-    bool ssrcRewrite;
+    const bool ssrcRewrite;
 
     concurrency::MpmcQueue<SimulcastLevel> videoPinSsrcs;
     utils::Optional<SimulcastLevel> pinSsrc;

--- a/bridge/engine/SsrcOutboundContext.h
+++ b/bridge/engine/SsrcOutboundContext.h
@@ -36,8 +36,7 @@ public:
           lastRespondedNackTimestamp(0),
           originalSsrc(~0u),
           lastSendTime(utils::Time::getAbsoluteTime()),
-          markedForDeletion(false),
-          idle(false)
+          markedForDeletion(false)
     {
     }
 
@@ -101,16 +100,10 @@ public:
 
     /// ==== Accessed from Engine only!
     uint64_t lastSendTime;
-    void onRtpSent(const uint64_t timestamp)
-    {
-        lastSendTime = timestamp;
-        idle = false;
-    }
+    void onRtpSent(const uint64_t timestamp) { lastSendTime = timestamp; }
 
     // Stream owner is being removed. Stop outbound packets over this context
     bool markedForDeletion;
-    // Stream is temporarily idle and srtp encryption context is removed. It may be activated again.
-    bool idle;
 };
 
 } // namespace bridge


### PR DESCRIPTION
Outbound contexts should be deleted if they are markedForDeletion and become idle, not as soon as they become idle.

What happens now is that outboundContexts will be deleted when they are idle, even if they will resume later on. The SRTP context is then deleted and the receiving end will get SRTP unprotect errors.

This bug was introduced in PR #150 