### PR TITLE
Limit forwarding to mid-quality when slids are being presented.

### DIFF
--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -289,7 +289,7 @@ EngineMixer::EngineMixer(const std::string& id,
       _probingVideoStreams(false),
       _minUplinkEstimate(0),
       _lastRecordingAckProcessed(utils::Time::getAbsoluteTime()),
-      _slidesPresent(0)
+      _slidesPresent(false)
 {
     assert(audioSsrcs.size() <= SsrcRewrite::ssrcArraySize);
     assert(videoSsrcs.size() <= SsrcRewrite::ssrcArraySize);

--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -357,6 +357,7 @@ private:
     uint32_t _minUplinkEstimate;
 
     uint64_t _lastRecordingAckProcessed;
+    bool _slidesPresent;
 
     uint32_t getMinRemoteClientDownlinkBandwidth() const;
     void reportMinRemoteClientDownlinkBandwidthToBarbells(const uint32_t minUplinkEstimate) const;

--- a/bridge/engine/EngineStreamDirector.h
+++ b/bridge/engine/EngineStreamDirector.h
@@ -475,7 +475,10 @@ public:
 
         const auto pinMapItr = _pinMap.find(toEndpointIdHash);
         const bool fromPinnedEndpoint = pinMapItr != _pinMap.end() && isSsrcFromParticipant(pinMapItr->second, ssrc);
-        const auto assignedQuality = (fromPinnedEndpoint ? viewer->pinQualityLevel : viewer->unpinQualityLevel);
+
+        // In case slides are used - limit video resolution to save CPU on recipients.
+        const auto assignedQuality =
+            (fromPinnedEndpoint && 0 == _slidesBitrateKbps) ? viewer->pinQualityLevel : viewer->unpinQualityLevel;
 
         size_t fromEndpointId = 0;
         const auto quality = getCurrentQualityAndEndpointId(ssrc, fromEndpointId);

--- a/test/bridge/EngineStreamDirectorTest.cpp
+++ b/test/bridge/EngineStreamDirectorTest.cpp
@@ -1071,16 +1071,18 @@ TEST_F(EngineStreamDirectorTest, highQualitySsrcDuringSlides_PinTarget_IsForward
     _engineStreamDirector->pin(2, 1);
     _engineStreamDirector->pin(3, 1);
 
+    _engineStreamDirector->setSlidesSsrcAndBitrate(14, 1000);
+
     // Though 1st pinned #2, it receives mid quality, since slides are present.
     EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(1, 11));
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(1, 9));
 
     // Though 2nd pinned #1, it receives mid quality, since slides are present.
-    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(2, 3));
+    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(2, 5));
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(2, 3));
 
     // Though 3rd pinned #1, it receives mid quality, since slides are present.
-    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(3, 3));
+    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(3, 5));
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(3, 3));
 }
 

--- a/test/bridge/EngineStreamDirectorTest.cpp
+++ b/test/bridge/EngineStreamDirectorTest.cpp
@@ -1056,15 +1056,6 @@ TEST_F(EngineStreamDirectorTest, highQualitySsrc_PinTarget_IsForwarded)
 
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(1, 11));
 }
-/*
-TEST_F(EngineStreamDirectorTest, contentTypeSlidesNotInLastNIsNotUsedWithoutRecordingStreams)
-{
-    _engineStreamDirector->addParticipant(1,
-        makeSimulcastStream(1, 2, bridge::SimulcastStream::VideoContentType::SLIDES));
-    _engineStreamDirector->setUplinkEstimateKbps(1, 100000, 5 * utils::Time::sec);
-    EXPECT_FALSE(_engineStreamDirector->isSsrcUsed(1, 1, true, false, 0));
-}
-*/
 
 TEST_F(EngineStreamDirectorTest, highQualitySsrcDuringSlides_PinTarget_IsForwardedAsUnpinned)
 {

--- a/test/bridge/EngineStreamDirectorTest.cpp
+++ b/test/bridge/EngineStreamDirectorTest.cpp
@@ -1056,6 +1056,42 @@ TEST_F(EngineStreamDirectorTest, highQualitySsrc_PinTarget_IsForwarded)
 
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(1, 11));
 }
+/*
+TEST_F(EngineStreamDirectorTest, contentTypeSlidesNotInLastNIsNotUsedWithoutRecordingStreams)
+{
+    _engineStreamDirector->addParticipant(1,
+        makeSimulcastStream(1, 2, bridge::SimulcastStream::VideoContentType::SLIDES));
+    _engineStreamDirector->setUplinkEstimateKbps(1, 100000, 5 * utils::Time::sec);
+    EXPECT_FALSE(_engineStreamDirector->isSsrcUsed(1, 1, true, false, 0));
+}
+*/
+
+TEST_F(EngineStreamDirectorTest, highQualitySsrcDuringSlides_PinTarget_IsForwardedAsUnpinned)
+{
+    addActiveVideoSender(1, 1);
+    addActiveVideoSender(2, 7);
+    addActiveVideoSender(3, 13);
+
+    _engineStreamDirector->addParticipant(4,
+        makeSimulcastStream(14, 15, bridge::SimulcastStream::VideoContentType::SLIDES));
+    _engineStreamDirector->setUplinkEstimateKbps(4, 100000, 5 * utils::Time::sec);
+
+    _engineStreamDirector->pin(1, 2);
+    _engineStreamDirector->pin(2, 1);
+    _engineStreamDirector->pin(3, 1);
+
+    // Though 1st pinned #2, it receives mid quality, since slides are present.
+    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(1, 11));
+    EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(1, 9));
+
+    // Though 2nd pinned #1, it receives mid quality, since slides are present.
+    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(2, 3));
+    EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(2, 3));
+
+    // Though 3rd pinned #1, it receives mid quality, since slides are present.
+    EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(3, 3));
+    EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(3, 3));
+}
 
 TEST_F(EngineStreamDirectorTest, lowQualitySsrc_HasNoPinTarget_UnderKbpsLimit_IsNotForwarded)
 {

--- a/test/transport/RecordingTransportTest.cpp
+++ b/test/transport/RecordingTransportTest.cpp
@@ -49,6 +49,7 @@ struct RecordingTransportTest : public testing::Test
 
     void TearDown() override
     {
+        _timers->stop();
         _jobManager->stop();
         _rtcePoll->stop();
         for (auto& wt : _workerThreads)

--- a/test/transport/RtcTransportTest.cpp
+++ b/test/transport/RtcTransportTest.cpp
@@ -297,6 +297,7 @@ struct RtcTransportTest : public testing::TestWithParam<std::tuple<uint32_t, boo
         _transportFactory.reset();
         _testPairs.clear();
         _network->stop();
+        _timers->stop();
         _jobManager->stop();
         for (auto& wt : _workerThreads)
         {

--- a/test/transport/SctpTest.cpp
+++ b/test/transport/SctpTest.cpp
@@ -289,6 +289,7 @@ struct SctpTransportTest : public ::testing::Test
         _testPairs.clear();
         _transportFactory.reset();
         _network->stop();
+        _timers->stop();
         _jobManager->stop();
 
         for (auto& wt : _workerThreads)

--- a/test/transport/TransportIntegrationTest.cpp
+++ b/test/transport/TransportIntegrationTest.cpp
@@ -84,6 +84,7 @@ void TransportIntegrationTest::TearDown()
     _transportFactory1.reset();
     _transportFactory2.reset();
     _network->stop();
+    _timers->stop();
     _jobManager->stop();
     for (auto& wt : _workerThreads)
     {


### PR DESCRIPTION
Add unit tests.