### PR TITLE
Add CheckGit.cmake to write git revision into the generated header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.6.2)
 project(smb)
 
+include(version/CheckGit.cmake)
+CheckGitSetup()
+
 option(ENABLE_LEGACY_API "ENABLE_LEGACY_API" OFF)
 option(ENABLE_LIBATOMIC "ENABLE_LIBATOMIC" OFF)
 option(ENABLE_ALLOCATOR_METRICS "Force enable the allocator metrics. It will be active by default in DEBUG" OFF)
@@ -425,7 +428,7 @@ add_executable(smb
         ${FILES}
         main.cpp)
 
-target_link_libraries(smb Threads::Threads ${THIRD_PARTY_LIBS})
+target_link_libraries(smb Threads::Threads ${THIRD_PARTY_LIBS} git_version)
 
 ##################
 # Test framework
@@ -592,7 +595,7 @@ target_include_directories(UnitTest PRIVATE ${CMAKE_TEST_INCLUDE} "test/include"
 # Copy test Data
 file(COPY "${CMAKE_SOURCE_DIR}/test/resources" DESTINATION "${CMAKE_TEST_DIRECTORY}")
 
-target_link_libraries(UnitTest gtest gmock ${THIRD_PARTY_LIBS})
+target_link_libraries(UnitTest gtest gmock ${THIRD_PARTY_LIBS} git_version)
 
 add_test(AllUnitTests UnitTest)
 

--- a/bridge/endpointActions/About.cpp
+++ b/bridge/endpointActions/About.cpp
@@ -1,5 +1,6 @@
 #include "ApiActions.h"
 #include "bridge/RequestLogger.h"
+#include "generated/git_version.h"
 #include "utils/StringTokenizer.h"
 
 namespace bridge
@@ -12,7 +13,8 @@ httpd::Response handleAbout(ActionContext* context,
     const auto nextToken = ::utils::StringTokenizer::tokenize(token.next, token.remainingLength, '/');
     if (utils::StringTokenizer::isEqual(nextToken, "version"))
     {
-        httpd::Response response(httpd::StatusCode::OK, "{}");
+        std::string versionString = "{\"revision\":\"" + std::string(kGitHash) + "\"}";
+        httpd::Response response(httpd::StatusCode::OK, versionString);
         response._headers["Content-type"] = "text/json";
         return response;
     }

--- a/bridge/endpointActions/About.cpp
+++ b/bridge/endpointActions/About.cpp
@@ -1,6 +1,6 @@
 #include "ApiActions.h"
 #include "bridge/RequestLogger.h"
-#include "generated/git_version.h"
+#include "git_version.h"
 #include "utils/StringTokenizer.h"
 
 namespace bridge

--- a/version/CheckGit.cmake
+++ b/version/CheckGit.cmake
@@ -1,0 +1,81 @@
+set(CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
+if (NOT DEFINED pre_configure_dir)
+    set(pre_configure_dir ${CMAKE_CURRENT_LIST_DIR})
+endif ()
+
+if (NOT DEFINED post_configure_dir)
+    set(post_configure_dir ${CMAKE_BINARY_DIR}/generated)
+endif ()
+
+set(pre_configure_file ${pre_configure_dir}/git_version.cpp.in)
+set(post_configure_file ${post_configure_dir}/git_version.cpp)
+
+function(CheckGitWrite git_hash)
+    file(WRITE ${CMAKE_BINARY_DIR}/git-state.txt ${git_hash})
+endfunction()
+
+function(CheckGitRead git_hash)
+    if (EXISTS ${CMAKE_BINARY_DIR}/git-state.txt)
+        file(STRINGS ${CMAKE_BINARY_DIR}/git-state.txt CONTENT)
+        LIST(GET CONTENT 0 var)
+
+        set(${git_hash} ${var} PARENT_SCOPE)
+    endif ()
+endfunction()
+
+function(CheckGitVersion)
+    # Get the latest abbreviated commit hash of the working branch
+    execute_process(
+        COMMAND git log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+    CheckGitRead(GIT_HASH_CACHE)
+    if (NOT EXISTS ${post_configure_dir})
+        file(MAKE_DIRECTORY ${post_configure_dir})
+    endif ()
+
+    if (NOT EXISTS ${post_configure_dir}/git_version.h)
+        file(COPY ${pre_configure_dir}/git_version.h DESTINATION ${post_configure_dir})
+    endif()
+
+    if (NOT DEFINED GIT_HASH_CACHE)
+        set(GIT_HASH_CACHE "INVALID")
+    endif ()
+
+    # Only update the git_version.cpp if the hash has changed. This will
+    # prevent us from rebuilding the project more than we need to.
+    if (NOT ${GIT_HASH} STREQUAL ${GIT_HASH_CACHE} OR NOT EXISTS ${post_configure_file})
+        # Set che GIT_HASH_CACHE variable the next build won't have
+        # to regenerate the source file.
+        CheckGitWrite(${GIT_HASH})
+
+        configure_file(${pre_configure_file} ${post_configure_file} @ONLY)
+    endif ()
+
+endfunction()
+
+function(CheckGitSetup)
+
+    add_custom_target(AlwaysCheckGit COMMAND ${CMAKE_COMMAND}
+        -DRUN_CHECK_GIT_VERSION=1
+        -Dpre_configure_dir=${pre_configure_dir}
+        -Dpost_configure_file=${post_configure_dir}
+        -DGIT_HASH_CACHE=${GIT_HASH_CACHE}
+        -P ${CURRENT_LIST_DIR}/CheckGit.cmake
+        BYPRODUCTS ${post_configure_file}
+        )
+
+    add_library(git_version ${CMAKE_BINARY_DIR}/generated/git_version.cpp)
+    target_include_directories(git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
+    add_dependencies(git_version AlwaysCheckGit)
+
+    CheckGitVersion()
+endfunction()
+
+# This is used to run this function from an external cmake process.
+if (RUN_CHECK_GIT_VERSION)
+    CheckGitVersion()
+endif ()

--- a/version/git_version.cpp.in
+++ b/version/git_version.cpp.in
@@ -1,0 +1,2 @@
+#include "git_version.h"
+const char *kGitHash = "@GIT_HASH@";

--- a/version/git_version.h
+++ b/version/git_version.h
@@ -1,0 +1,6 @@
+#ifndef GIT_VERSION_H
+#define GIT_VERSION_H
+
+extern const char* kGitHash;
+
+#endif // GIT_VERSION_H


### PR DESCRIPTION
- Add CheckGit.cmake to write git revision into the generated header file;
- update "About/version" endpoint action to return {"revision":"<short git revision>"}