### PR TITLE
Add `Allocator.h`

### DIFF
--- a/bridge/MixerManager.cpp
+++ b/bridge/MixerManager.cpp
@@ -305,10 +305,15 @@ void MixerManager::engineMixerRemoved(EngineMixer& engineMixer)
     auto findResult = _mixers.find(mixerId);
     if (findResult != _mixers.end())
     {
+        logger::info("Finalizing EngineMixer %s", "MixerManager", mixerId.c_str());
         auto mixer = findResult->second;
         _mixers.erase(mixerId);
         mixer->stopTransports(); // this will stop new packets from coming in
         _backgroundJobQueue.addJob<bridge::FinalizeEngineMixerRemoval>(*this, mixer);
+    }
+    else
+    {
+        logger::error("EngineMixer %s not found", "MixerManager", mixerId.c_str());
     }
 }
 
@@ -322,6 +327,8 @@ void MixerManager::finalizeEngineMixerRemoval(const std::string& mixerId)
         _sendAllocator.logAllocatedElements();
         _audioAllocator.logAllocatedElements();
     }
+
+    logger::info("Mixer %s has been finalized", "MixerManager", mixerId.c_str());
 }
 
 void MixerManager::allocateAudioBuffer(EngineMixer& mixer, uint32_t ssrc)

--- a/concurrency/MpmcHashmap.h
+++ b/concurrency/MpmcHashmap.h
@@ -1,12 +1,11 @@
 #pragma once
 #include "LockFreeList.h"
 #include "memory/details.h"
+#include "utils/Allocator.h"
 #include "utils/StdExtensions.h"
 #include <algorithm>
 #include <atomic>
 #include <functional>
-#include <sys/mman.h>
-#include <unistd.h>
 #include <vector>
 
 namespace concurrency
@@ -181,16 +180,12 @@ public:
 
     explicit MpmcHashmap32(size_t maxElements) : _end(0), _capacity(maxElements), _index(maxElements * 4)
     {
-        void* mem = mmap(nullptr,
-            blockSizeFor(_capacity, sizeof(Entry)),
-            (PROT_READ | PROT_WRITE),
-            (MAP_PRIVATE | MAP_ANONYMOUS),
-            -1,
-            0);
+        void* mem = page_allocator::allocate(page_allocator::pageAlignedSpace(_capacity * sizeof(Entry)));
+
         _elements = reinterpret_cast<Entry*>(mem);
         assert(reinterpret_cast<intptr_t>(_elements) != -1);
         assert(reinterpret_cast<intptr_t>(&_elements[1]) != -1);
-        std::memset(mem, 0, blockSizeFor(_capacity, sizeof(Entry)));
+
         for (size_t i = 0; i < _capacity; ++i)
         {
             _elements[i].state = State::empty;
@@ -207,7 +202,8 @@ public:
                 _elements[i].~Entry();
             }
         }
-        munmap(_elements, blockSizeFor(_capacity, sizeof(Entry)));
+
+        page_allocator::free(_elements, page_allocator::pageAlignedSpace(_capacity * sizeof(Entry)));
     }
 
     template <typename... Args>
@@ -393,18 +389,6 @@ public:
     const PointerType getItem(const KeyT& key) const { return const_cast<MpmcHashmap32<KeyT, T>&>(*this).getItem(key); }
 
 private:
-    static size_t blockSizeFor(size_t count, size_t size)
-    {
-        const auto pageSize = getpagesize();
-        const auto used = (count * size);
-        const auto remaining = used % pageSize;
-        if (remaining != 0)
-        {
-            return used + (pageSize - remaining);
-        }
-        return used;
-    }
-
     Entry* _elements;
     std::atomic_uint32_t _end;
 

--- a/concurrency/MpmcHashmap.h
+++ b/concurrency/MpmcHashmap.h
@@ -180,7 +180,7 @@ public:
 
     explicit MpmcHashmap32(size_t maxElements) : _end(0), _capacity(maxElements), _index(maxElements * 4)
     {
-        void* mem = page_allocator::allocate(page_allocator::pageAlignedSpace(_capacity * sizeof(Entry)));
+        void* mem = memory::page::allocate(memory::page::alignedSpace(_capacity * sizeof(Entry)));
 
         _elements = reinterpret_cast<Entry*>(mem);
         assert(reinterpret_cast<intptr_t>(_elements) != -1);
@@ -203,7 +203,7 @@ public:
             }
         }
 
-        page_allocator::free(_elements, page_allocator::pageAlignedSpace(_capacity * sizeof(Entry)));
+        memory::page::free(_elements, memory::page::alignedSpace(_capacity * sizeof(Entry)));
     }
 
     template <typename... Args>

--- a/concurrency/MpmcQueue.h
+++ b/concurrency/MpmcQueue.h
@@ -26,7 +26,9 @@ class MpmcQueue
 
 public:
     typedef T value_type;
-    explicit MpmcQueue(uint32_t maxElements) : _maxElements(maxElements), _blockSize(page_allocator::pageAlignedSpace(maxElements * sizeof(Entry)))
+    explicit MpmcQueue(uint32_t maxElements)
+        : _maxElements(maxElements),
+          _blockSize(memory::page::alignedSpace(maxElements * sizeof(Entry)))
     {
         _readCursor = 0;
         _writeCursor = 0;
@@ -35,8 +37,7 @@ public:
         _cacheLineSeparator1[0] = 0;
         _cacheLineSeparator2[0] = 0;
 
-        _elements = reinterpret_cast<Entry*>(
-            page_allocator::allocate(_blockSize));
+        _elements = reinterpret_cast<Entry*>(memory::page::allocate(_blockSize));
 
         for (uint32_t i = 0; i < _maxElements; ++i)
         {
@@ -51,7 +52,7 @@ public:
             _elements[i].~Entry();
         }
 
-        page_allocator::free(_elements, _blockSize);
+        memory::page::free(_elements, _blockSize);
     }
 
     // return false if empty

--- a/memory/PoolAllocator.h
+++ b/memory/PoolAllocator.h
@@ -56,7 +56,7 @@ public:
         : _deleter(this),
           _name(std::move(name)),
           _elements(nullptr),
-          _size(page_allocator::pageAlignedSpace(elementCount * sizeof(Entry))),
+          _size(memory::page::alignedSpace(elementCount * sizeof(Entry))),
           _popIndex(0),
           _pushIndex(0),
           _originalElementCount(_size / sizeof(Entry)),
@@ -66,7 +66,7 @@ public:
         _cacheLineSeparator2[0] = 0;
         _cacheLineSeparator3[0] = 0;
 
-        _elements = reinterpret_cast<Entry*>(page_allocator::allocate(_size));
+        _elements = reinterpret_cast<Entry*>(memory::page::allocate(_size));
         assert(reinterpret_cast<intptr_t>(_elements) != -1);
 
         static_assert(sizeof(Entry) % alignof(std::max_align_t) == 0, "ELEMENT_SIZE must be multiple of alignment");
@@ -81,7 +81,7 @@ public:
     ~PoolAllocator()
     {
         logAllocatedElements();
-        page_allocator::free(_elements, _size);
+        memory::page::free(_elements, _size);
     }
 
     Deleter& getDeleter() { return _deleter; }

--- a/memory/RingAllocator.cpp
+++ b/memory/RingAllocator.cpp
@@ -26,8 +26,8 @@ const uint32_t FREE = 0xFFBBEEDD;
 } // namespace
 
 RingAllocator::RingAllocator(size_t size)
-    : _size(page_allocator::pageAlignedSpace(size)),
-      _area(reinterpret_cast<uint8_t*>(page_allocator::allocate(_size))),
+    : _size(memory::page::alignedSpace(size)),
+      _area(reinterpret_cast<uint8_t*>(memory::page::allocate(_size))),
       _head(0),
       _tail(0)
 {
@@ -35,7 +35,7 @@ RingAllocator::RingAllocator(size_t size)
 
 RingAllocator::~RingAllocator()
 {
-    page_allocator::free(_area, _size);
+    memory::page::free(_area, _size);
 }
 
 // allocates continuous block after tail of buffer.

--- a/memory/RingAllocator.h
+++ b/memory/RingAllocator.h
@@ -36,10 +36,10 @@ public:
     void free(void* data);
 
 private:
+    const size_t _size;
+    uint8_t* _area;
     uint32_t _head;
     uint32_t _tail;
-    uint8_t* _area;
-    const size_t _size;
 };
 
 } // namespace memory

--- a/memory/RingBuffer.h
+++ b/memory/RingBuffer.h
@@ -26,14 +26,14 @@ public:
           _reentrancyCount(0)
 #endif
     {
-        _size = page_allocator::pageAlignedSpace(S * sizeof(T));
-        _data = reinterpret_cast<T*>(page_allocator::allocate(_size));
+        _size = memory::page::alignedSpace(S * sizeof(T));
+        _data = reinterpret_cast<T*>(memory::page::allocate(_size));
 
         memset(_data, 0, _size);
         memset(_silenceBuffer, 0, silenceBufferSize * sizeof(T));
     }
 
-    ~RingBuffer() { page_allocator::free(_data, _size); }
+    ~RingBuffer() { memory::page::free(_data, _size); }
 
     /**
      * Reads size elements from the buffer to outData, but does not move the read head.

--- a/memory/RingBuffer.h
+++ b/memory/RingBuffer.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include "utils/Allocator.h"
 #include "utils/ScopedReentrancyBlocker.h"
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-#include <sys/mman.h>
-#include <unistd.h>
 
 namespace memory
 {
@@ -27,23 +26,14 @@ public:
           _reentrancyCount(0)
 #endif
     {
-        _size = S * sizeof(T);
-
-        const auto pageSize = getpagesize();
-        const auto remaining = _size % pageSize;
-        if (remaining != 0)
-        {
-            _size += (pageSize - remaining);
-        }
-        _data =
-            reinterpret_cast<T*>(mmap(nullptr, _size, (PROT_READ | PROT_WRITE), (MAP_PRIVATE | MAP_ANONYMOUS), -1, 0));
-        assert(reinterpret_cast<intptr_t>(_data) != -1);
+        _size = page_allocator::pageAlignedSpace(S * sizeof(T));
+        _data = reinterpret_cast<T*>(page_allocator::allocate(_size));
 
         memset(_data, 0, _size);
         memset(_silenceBuffer, 0, silenceBufferSize * sizeof(T));
     }
 
-    ~RingBuffer() { munmap(_data, _size); }
+    ~RingBuffer() { page_allocator::free(_data, _size); }
 
     /**
      * Reads size elements from the buffer to outData, but does not move the read head.

--- a/utils/Allocator.h
+++ b/utils/Allocator.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cassert>
+#include <sys/mman.h>
+#include <unistd.h>
+
+// set DISABLE_MMAP to disable direct page allocation mapping.
+// Disabling this can be use full to run tools to leak detection that can't track mmap, like heaptrack
+#if !defined(DISABLE_MMAP)
+#define DISABLE_MMAP 0
+#endif
+
+#if DISABLE_MMAP
+#include <stdlib.h>
+#include <string.h>
+#endif
+
+namespace page_allocator
+{
+
+inline size_t getPageSize()
+{
+    return sysconf(_SC_PAGE_SIZE);
+}
+
+inline void* allocate(size_t size)
+{
+    assert((size & ~(getPageSize() - 1)) == size);
+#if !DISABLE_MMAP
+    auto* const mem = mmap(nullptr, size, (PROT_READ | PROT_WRITE), (MAP_PRIVATE | MAP_ANONYMOUS), -1, 0);
+#else
+    auto* const mem = ::aligned_alloc(getPageSize(), size);
+    // initialize memory to zero to mimics behaviour of MAP_ANONYMOUS
+    ::memset(mem, 0, size);
+#endif
+    assert(mem && reinterpret_cast<intptr_t>(mem) != -1);
+    return mem;
+}
+
+inline void free(void* mem, size_t size)
+{
+    assert((size & ~(getPageSize() - 1)) == size);
+#if !DISABLE_MMAP
+    const int ret = munmap(mem, size);
+    (void)ret; // silence warning of not using variable on release builds
+    assert(ret == 0);
+#else
+    ::free(mem);
+#endif
+}
+
+inline size_t pageAlignedSpace(size_t space)
+{
+    const size_t pageSize = getPageSize();
+    return (space + pageSize - 1) & ~(pageSize - 1);
+}
+
+} // namespace page_allocator

--- a/utils/Allocator.h
+++ b/utils/Allocator.h
@@ -15,7 +15,10 @@
 #include <string.h>
 #endif
 
-namespace page_allocator
+namespace memory
+{
+
+namespace page
 {
 
 inline size_t getPageSize()
@@ -49,10 +52,11 @@ inline void free(void* mem, size_t size)
 #endif
 }
 
-inline size_t pageAlignedSpace(size_t space)
+inline size_t alignedSpace(size_t space)
 {
     const size_t pageSize = getPageSize();
     return (space + pageSize - 1) & ~(pageSize - 1);
 }
 
-} // namespace page_allocator
+} // namespace page
+} // namespace memory


### PR DESCRIPTION
The goal of this change is changing `mmap` to `aling_alloc` by a compile configuration so we can run tools to memory leak detection that does not support `mmap`, like heaptrack 