### PR TITLE
Publish linux binaries as npm package

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -113,10 +113,6 @@ node('be-integration') {
                     description: "Symphony media bridge binaries for linux",
                     publishConfig: [
                         registry: "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/"
-                    ],
-                    scripts: [
-                        build: "echo \"No build script provided\"",
-                        test: "echo \"No test script provided\""
                     ]
                 ])
                 withNvm("v16.16.0", "npmrcFile") {

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -3,8 +3,7 @@
 properties([
     buildDiscarder(logRotator(artifactNumToKeepStr: "15", numToKeepStr: "15")),
     parameters([
-        string(name: "ARTIFACTORY_CREDENTIALS_ID", defaultValue: "jenkins-artifactory-credentials", description: "Id of credentials for artifactory access for mt scripts"),
-
+        string(name: "ARTIFACTORY_CREDENTIALS_ID", defaultValue: "jenkins-artifactory-credentials", description: "Id of credentials for artifactory access for mt scripts")
     ])
 ])
 
@@ -106,7 +105,7 @@ node('be-integration') {
             sh "mkdir npm-publish"
             dir("npm-publish") {
                 sh "cp -R ../aws-linux/smb/libs ."
-                sh "cp -R ../aws-linux/smb/smb ."
+                sh "cp ../aws-linux/smb/smb ."
                 sh "cp ../aws-linux/smb/versioninfo.txt ."
                 writeJSON(file: 'package.json', json: [
                     name: "smb-linux",

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -4,6 +4,7 @@ properties([
     buildDiscarder(logRotator(artifactNumToKeepStr: "15", numToKeepStr: "15")),
     parameters([
         string(name: "ARTIFACTORY_CREDENTIALS_ID", defaultValue: "jenkins-artifactory-credentials", description: "Id of credentials for artifactory access for mt scripts"),
+
     ])
 ])
 
@@ -98,6 +99,30 @@ node('be-integration') {
         docker.image('gcr.io/sym-dev-rtc/buildsmb-el7:latest').inside {
             stage('Create archive') {
                 sh "zip -r ${baseName}-${version}.zip el7/smb/smb el7/smb/versioninfo.txt el7/smb/libs/ el8/smb/smb el8/smb/versioninfo.txt el8/smb/libs/ ubuntu-focal/smb/smb ubuntu-focal/smb/versioninfo.txt ubuntu-focal/smb/libs/ ubuntu-focal-deb/smb/*.tar.gz ubuntu-focal-deb/smb/*.deb aws-linux/smb/versioninfo.txt aws-linux/smb/libs/ aws-linux/smb/smb"
+            }
+        }
+
+        stage ("npm publish") {
+            sh "mkdir npm-publish"
+            dir("npm-publish") {
+                sh "cp -R ../aws-linux/smb/libs ."
+                sh "cp -R ../aws-linux/smb/smb ."
+                sh "cp ../aws-linux/smb/versioninfo.txt ."
+                writeJSON(file: 'package.json', json: [
+                    name: "smb-linux",
+                    version: version,
+                    description: "Symphony media bridge binaries for linux",
+                    publishConfig: [
+                        registry: "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/"
+                    ],
+                    scripts: [
+                        build: "echo \"No build script provided\"",
+                        test: "echo \"No test script provided\""
+                    ]
+                ])
+                withNvm("v16.16.0", "npmrcFile") {
+                    sh "npm publish"
+                }
             }
         }
 


### PR DESCRIPTION

Updated Jenkinsfile to bundle aws-linux binaries to a 'smb-linux' package which is published to symphony registry

This allows a node project to get binaries via npm with a reference like 
`"smb-linux": "0.0.2-7"` in package.json and outcome creates following file structure in node_modules:
<img width="514" alt="Screenshot 2022-11-21 at 14 13 24" src="https://user-images.githubusercontent.com/31619899/203070130-08937a17-d4f2-493b-a117-b4b5f9d8a4f3.png">

