### PR TITLE
Replace sprintf by snprintf

### DIFF
--- a/external/http.h
+++ b/external/http.h
@@ -402,7 +402,7 @@ http_t* http_get(char const* url, void* memctx)
         internal->request_header_large = (char*)HTTP_MALLOC(memctx, request_header_len + 1);
         request_header = internal->request_header_large;
     }
-    sprintf(request_header, "GET %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port);
+    snprintf(request_header, request_header_len + 1, "GET %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port);
 
     return &internal->http;
 }
@@ -441,7 +441,8 @@ http_t* http_post(char const* url, void const* data, size_t size, void* memctx)
         internal->request_header_large = (char*)HTTP_MALLOC(memctx, request_header_len + 1);
         request_header = internal->request_header_large;
     }
-    sprintf(request_header,
+    snprintf(request_header,
+        request_header_len + 1,
         "POST %s HTTP/1.0\r\nHost: %s:%s\r\nContent-Length: %d\r\n\r\n",
         resource,
         address,
@@ -489,7 +490,8 @@ http_t* http_patch(char const* url, void const* data, size_t size, void* memctx)
         internal->request_header_large = (char*)HTTP_MALLOC(memctx, request_header_len + 1);
         request_header = internal->request_header_large;
     }
-    sprintf(request_header,
+    snprintf(request_header,
+        request_header_len + 1,
         "PATCH %s HTTP/1.0\r\nHost: %s:%s\r\nContent-Length: %d\r\n\r\n",
         resource,
         address,
@@ -537,7 +539,7 @@ http_t* http_delete(char const* url, void* memctx)
         internal->request_header_large = (char*)HTTP_MALLOC(memctx, request_header_len + 1);
         request_header = internal->request_header_large;
     }
-    sprintf(request_header, "DELETE %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port);
+    snprintf(request_header, request_header_len, "DELETE %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port);
 
     return &internal->http;
 }

--- a/external/http.h
+++ b/external/http.h
@@ -539,7 +539,12 @@ http_t* http_delete(char const* url, void* memctx)
         internal->request_header_large = (char*)HTTP_MALLOC(memctx, request_header_len + 1);
         request_header = internal->request_header_large;
     }
-    snprintf(request_header, request_header_len, "DELETE %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port);
+    snprintf(request_header,
+        request_header_len + 1,
+        "DELETE %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n",
+        resource,
+        address,
+        port);
 
     return &internal->http;
 }

--- a/rtp/RtpHeader.cpp
+++ b/rtp/RtpHeader.cpp
@@ -2,6 +2,7 @@
 #include "logger/Logger.h"
 #include "utils/StringBuilder.h"
 #include "utils/Time.h"
+#include <array>
 
 namespace
 {
@@ -9,12 +10,12 @@ void logPacketError(void* p, const size_t len, const size_t baseHeaderLength)
 {
     logger::debug("RTP packet header invalid. Length %lu, baseHeaderLength %lu", "RtpHeader", len, baseHeaderLength);
     const auto pBytes = reinterpret_cast<uint8_t*>(p);
-    char byteString[4];
+    std::array<char, 4> byteString;
     utils::StringBuilder<256> loggerString;
     for (size_t i = 0; i < rtp::MIN_RTP_HEADER_SIZE; ++i)
     {
-        sprintf(byteString, "%02x ", pBytes[i]);
-        loggerString.append(byteString);
+        snprintf(byteString.data(), byteString.size(), "%02x ", pBytes[i]);
+        loggerString.append(byteString.data());
     }
 
     logger::debug("%s", "RtpHeader", loggerString.get());

--- a/test/integration/emulator/ApiChannel.cpp
+++ b/test/integration/emulator/ApiChannel.cpp
@@ -10,9 +10,10 @@ namespace
 std::string newGuuid()
 {
     utils::IdGenerator idGen;
-    char uuid[200];
+    std::string uuid(36, '\0');
 
-    sprintf(uuid,
+    snprintf(&uuid.front(), // + null terminator
+        uuid.size() + 1,
         "%08x-%04x-%04x-%04x-%012x",
         static_cast<uint32_t>(idGen.next() & 0xFFFFFFFFu),
         static_cast<uint32_t>(idGen.next() & 0xFFFFu),
@@ -26,9 +27,12 @@ std::string newGuuid()
 std::string newIdString()
 {
     utils::IdGenerator idGen;
-    char uuid[200];
+    std::string uuid(8, '\0');
 
-    sprintf(uuid, "%08u", static_cast<uint32_t>(idGen.next() & 0xFFFFFFFFu));
+    snprintf(&uuid.front(),
+        uuid.size() + 1, // + null terminator
+        "%08u",
+        static_cast<uint32_t>(idGen.next() & 0xFFFFFFFFu));
 
     return uuid;
 }
@@ -420,7 +424,7 @@ void ColibriChannel::create(const std::string& baseUrl,
     const uint32_t idleTimeout,
     const utils::Span<std::string> neighbours)
 {
-    // Colibry endpoints do not support idle timeouts.
+    // Colibri endpoints do not support idle timeouts.
     assert(0 == idleTimeout);
 
     _conferenceId = conferenceId;


### PR DESCRIPTION
Replace `sprintf` by `snprintf` as `sprintf` is considered unsafe and has been deprecated in MacOX.sdk 