### PR TITLE
Improve load tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,6 +588,8 @@ set(TEST_FILES
     test/utils/FunctionTest.cpp)
 
 set(LOAD_TEST_FILES
+    test/integration/IntegrationTest.cpp
+    test/integration/IntegrationTest.h
     test/integration/RealTimeTest.cpp
     test/integration/RealTimeTest.h
     test/integration/LoadTestConfig.h

--- a/test/integration/BarbellTest.cpp
+++ b/test/integration/BarbellTest.cpp
@@ -354,7 +354,7 @@ TEST_F(BarbellTest, simpleBarbell)
         size_t freqId = 0;
         for (auto id : {0, 1})
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true);
             EXPECT_EQ(data.dominantFrequencies.size(), 2);
             EXPECT_NEAR(data.dominantFrequencies[0], expectedFrequencies[freqId][0], 25.0);
             EXPECT_NEAR(data.dominantFrequencies[1], expectedFrequencies[freqId++][1], 25.0);
@@ -496,7 +496,7 @@ TEST_F(BarbellTest, barbellAfterClients)
         size_t freqId = 0;
         for (auto id : {0, 1})
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true);
             EXPECT_EQ(data.dominantFrequencies.size(), 1);
             EXPECT_EQ(data.amplitudeProfile.size(), 2);
             if (data.amplitudeProfile.size() > 1)
@@ -626,7 +626,7 @@ TEST_F(BarbellTest, barbellNeighbours)
         const size_t expectedFreqCount[] = {2, 1, 1};
         for (size_t id = 0; id < 3; ++id)
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, 0);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true, 0);
             EXPECT_EQ(data.dominantFrequencies.size(), expectedFreqCount[id]);
 
             std::unordered_map<uint32_t, transport::ReportSummary> transportSummary;

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -462,7 +462,8 @@ TEST_F(IntegrationTest, plain)
         size_t freqId = 0;
         for (auto id : {0, 1, 2})
         {
-            const auto data = analyzeRecording<SfuClient<ColibriChannel>>(group.clients[id].get(), 5, 2 == id ? 2 : 0);
+            const auto data =
+                analyzeRecording<SfuClient<ColibriChannel>>(group.clients[id].get(), 5, true, 2 == id ? 2 : 0);
             EXPECT_EQ(data.dominantFrequencies.size(), 2);
             EXPECT_NEAR(data.dominantFrequencies[0], expectedFrequencies[freqId][0], 25.0);
             EXPECT_NEAR(data.dominantFrequencies[1], expectedFrequencies[freqId++][1], 25.0);
@@ -551,7 +552,7 @@ TEST_F(IntegrationTest, twoClientsAudioOnly)
         size_t freqId = 0;
         for (auto id : {0, 1})
         {
-            const auto data = analyzeRecording<SfuClient<ColibriChannel>>(group.clients[id].get(), 5);
+            const auto data = analyzeRecording<SfuClient<ColibriChannel>>(group.clients[id].get(), 5, true);
             EXPECT_EQ(data.dominantFrequencies.size(), 1);
             EXPECT_EQ(data.amplitudeProfile.size(), 2);
             if (data.amplitudeProfile.size() > 1)
@@ -883,7 +884,7 @@ TEST_F(IntegrationTest, plainNewApi)
         size_t freqId = 0;
         for (auto id : {0, 1, 2})
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, 2 == id ? 2 : 0);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true, 2 == id ? 2 : 0);
             EXPECT_EQ(data.dominantFrequencies.size(), 2);
             EXPECT_NEAR(data.dominantFrequencies[0], expectedFrequencies[freqId][0], 25.0);
             EXPECT_NEAR(data.dominantFrequencies[1], expectedFrequencies[freqId++][1], 25.0);
@@ -974,7 +975,7 @@ TEST_F(IntegrationTest, ptime10)
         size_t freqId = 0;
         for (auto id : {0, 1, 2})
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, 2 == id ? 2 : 0);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true, 2 == id ? 2 : 0);
             EXPECT_EQ(data.dominantFrequencies.size(), 2);
             EXPECT_NEAR(data.dominantFrequencies[0], expectedFrequencies[freqId][0], 25.0);
             EXPECT_NEAR(data.dominantFrequencies[1], expectedFrequencies[freqId++][1], 25.0);
@@ -1420,7 +1421,7 @@ TEST_F(IntegrationTest, conferencePort)
         size_t freqId = 0;
         for (auto id : {0, 1, 2})
         {
-            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, 2 == id ? 2 : 0);
+            const auto data = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true, 2 == id ? 2 : 0);
             EXPECT_EQ(data.dominantFrequencies.size(), 2);
             EXPECT_NEAR(data.dominantFrequencies[0], expectedFrequencies[freqId][0], 25.0);
             EXPECT_NEAR(data.dominantFrequencies[1], expectedFrequencies[freqId++][1], 25.0);
@@ -1513,7 +1514,7 @@ TEST_F(IntegrationTest, neighbours)
         AudioAnalysisData results[4];
         for (size_t id = 0; id < 4; ++id)
         {
-            results[id] = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, chMixed[id]);
+            results[id] = analyzeRecording<SfuClient<Channel>>(group.clients[id].get(), 5, true, chMixed[id]);
 
             std::unordered_map<uint32_t, transport::ReportSummary> transportSummary;
             std::string clientName = "client_" + std::to_string(id);

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -98,6 +98,7 @@ struct IntegrationTest : public ::testing::Test
         std::vector<double> dominantFrequencies;
         std::vector<std::pair<uint64_t, double>> amplitudeProfile;
         size_t audioSsrcCount = 0;
+        std::map<double, size_t> receivedBytes;
     };
 
     IntegrationTest();
@@ -152,6 +153,7 @@ public:
     template <typename TClient>
     static IntegrationTest::AudioAnalysisData analyzeRecording(TClient* client,
         double expectedDurationSeconds,
+        bool checkAmplitudeProfile = true,
         size_t mixedAudioSources = 0,
         bool dumpPcmData = false);
 

--- a/test/integration/RealTimeTest.h
+++ b/test/integration/RealTimeTest.h
@@ -68,8 +68,12 @@ public:
         const char* baseUrl,
         const std::string& endpointId);
 
+public:
+    static const double frequencies[];
+
 protected:
     void initLocalTransports();
+    void smbMegaHootTest(const size_t numSpeakers);
 
 protected:
     const uint32_t _clientsConnectionTimeout;
@@ -79,16 +83,3 @@ protected:
 private:
     size_t getNumWorkerThreads() const;
 };
-
-namespace
-{
-class ScopedFinalize
-{
-public:
-    explicit ScopedFinalize(std::function<void()> finalizeMethod) : _method(finalizeMethod) {}
-    ~ScopedFinalize() { _method(); }
-
-private:
-    std::function<void()> _method;
-};
-} // namespace

--- a/test/integration/emulator/AudioSource.h
+++ b/test/integration/emulator/AudioSource.h
@@ -50,7 +50,7 @@ private:
     uint32_t _ptime;
     IsPttState _isPtt;
     bool _useAudioLevel;
-    Audio _fakeAudio;
+    Audio _emulatedAudioType;
 };
 
 } // namespace emulator

--- a/test/integration/emulator/SfuClient.h
+++ b/test/integration/emulator/SfuClient.h
@@ -116,7 +116,7 @@ public:
           _loggableId("client", id),
           _recordingActive(true),
           _ptime(ptime),
-          _audioType(Audio::None),
+          _sendAudioType(Audio::None),
           _expectedReceiveAudioType(Audio::None)
     {
     }
@@ -157,7 +157,7 @@ public:
         uint32_t idleTimeout = 0)
     {
         utils::Span<std::string> noNeighbours;
-        _audioType = audio;
+        _sendAudioType = audio;
         _channel.create(baseUrl,
             conferenceId,
             initiator,
@@ -178,7 +178,7 @@ public:
         const utils::Span<std::string>& neighbours,
         uint32_t idleTimeout = 0)
     {
-        _audioType = audio;
+        _sendAudioType = audio;
         _channel.create(baseUrl,
             conferenceId,
             initiator,
@@ -208,7 +208,7 @@ public:
 
         if (_channel.isAudioOffered())
         {
-            _audioSource = std::make_unique<emulator::AudioSource>(_allocator, _idGenerator.next(), _audioType);
+            _audioSource = std::make_unique<emulator::AudioSource>(_allocator, _idGenerator.next(), _sendAudioType);
             _transport->setAudioPayloadType(111, codec::Opus::sampleRate);
         }
 
@@ -705,7 +705,7 @@ public:
                         rtpHeader->ssrc.get(),
                         rtpMap,
                         sender,
-                        _expectedReceiveAudioType == Audio::None ? _audioType : _expectedReceiveAudioType,
+                        _expectedReceiveAudioType == Audio::None ? _sendAudioType : _expectedReceiveAudioType,
                         timestamp));
                 it = _audioReceivers.find(rtpHeader->ssrc.get());
             }
@@ -1003,7 +1003,7 @@ private:
     std::unique_ptr<webrtc::WebRtcDataStream> _dataStream;
     size_t _instanceId;
     RtxStats _rtxStats;
-    Audio _audioType;
+    Audio _sendAudioType;
     Audio _expectedReceiveAudioType;
 };
 

--- a/transport/UdpEndpointImpl.cpp
+++ b/transport/UdpEndpointImpl.cpp
@@ -30,7 +30,7 @@ UdpEndpointImpl::UdpEndpointImpl(jobmanager::JobManager& jobManager,
     : BaseUdpEndpoint("UdpEndpoint", jobManager, maxSessionCount, allocator, localPort, epoll, isShared),
       _iceListeners(maxSessionCount * 2),
       _dtlsListeners(maxSessionCount * 2),
-      _iceResponseListeners(maxSessionCount * 4)
+      _iceResponseListeners(maxSessionCount * 16)
 {
 }
 


### PR DESCRIPTION
- switch from 'fake' to 'opus' for generated audio. Should not load much, since we'll use not more than 5 producers;
- add analysis: frequencies are analyzed and matched against known producers. Amplitude analysis is off;
- add five jump starters for test: 'DISABLED_smbMegaHoot_1' to DISABLED_smbMegaHoot_5' ('DISABLED_smbMegaHoot' is the same as 'DISABLED_smbMegaHoot_1);
- add logging to see what was sent and received.