### PR TITLE
Publish smb as a scoped artifact

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -109,7 +109,7 @@ node('be-integration') {
                 sh "cp ../aws-linux/smb/smb ."
                 sh "cp ../aws-linux/smb/versioninfo.txt ."
                 writeJSON(file: 'package.json', json: [
-                    name: "smb-linux",
+                    name: "@symphony/smb-linux",
                     version: version,
                     description: "Symphony media bridge binaries for linux",
                     publishConfig: [
@@ -117,7 +117,7 @@ node('be-integration') {
                     ]
                 ])
                 withNvm("v16.16.0", "npmrcFile") {
-                    sh "npm publish"
+                    sh "npm publish --access public"
                 }
             }
         }


### PR DESCRIPTION
C9 SFU is a Node project, with a lot of public dependencies (resolved from https://registry.npmjs.org).
In the same time, it requires SFU, which is currently published to Symphony's Artifactory (also servers as NPM register) un-scoped.

Dependency resolution can only use multiple registries when dependencies are "scoped", thus it's necessary to publish SFU into our private registry as "scoped".