### PR TITLE
mpmc mem footprint

### DIFF
--- a/concurrency/LockFreeList.cpp
+++ b/concurrency/LockFreeList.cpp
@@ -11,7 +11,7 @@ LockFreeList::LockFreeList() : _head(&_eol), _tail(&_eol), _count(0)
 }
 
 // Possible to push a list of items too
-void LockFreeList::push(ListItem* item)
+bool LockFreeList::push(ListItem* item)
 {
     ListItem* last = nullptr;
     const uint32_t version = _versionCounter.fetch_add(1);
@@ -57,7 +57,7 @@ void LockFreeList::push(ListItem* item)
     {
         // if we won this, the popper will have to move head to us
         _count.fetch_add(count, std::memory_order::memory_order_relaxed);
-        return;
+        return true;
     }
     else
     {
@@ -65,7 +65,7 @@ void LockFreeList::push(ListItem* item)
         // re-inserted at end popped empty, we must attach to head
         _head.store(itemNode);
         _count.fetch_add(count, std::memory_order::memory_order_relaxed);
-        return;
+        return true;
     }
 }
 

--- a/concurrency/LockFreeList.h
+++ b/concurrency/LockFreeList.h
@@ -32,7 +32,7 @@ public:
     LockFreeList();
     ~LockFreeList() = default;
 
-    void push(ListItem* item);
+    bool push(ListItem* item);
     bool pop(ListItem*& item);
 
     bool empty() const { return getPointer(_head.load()) == &_eol; }

--- a/memory/PoolAllocator.h
+++ b/memory/PoolAllocator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "concurrency/LockFreeList.h"
 #include "concurrency/WaitFreeStack.h"
 #include "logger/Logger.h"
 #include "memory/Allocator.h"

--- a/test/concurrency/MpscTest.cpp
+++ b/test/concurrency/MpscTest.cpp
@@ -79,21 +79,18 @@ void consumerRun(Q* queue, TransmissionReport reports[], bool validateSeqNo)
     int sleepCount = 0;
     for (;;)
     {
-        while (!queue->empty())
+        typename Q::value_type val;
+        while (queue->pop(val))
         {
-            typename Q::value_type val;
-            if (queue->pop(val))
+            ++reports[val.ssrc].received;
+            ++count;
+            if (validateSeqNo)
             {
-                ++reports[val.ssrc].received;
-                ++count;
-                if (validateSeqNo)
+                if (reports[val.ssrc].expSeqNo != val.seqNo)
                 {
-                    if (reports[val.ssrc].expSeqNo != val.seqNo)
-                    {
-                        ++reports[val.ssrc].disordered;
-                    }
-                    reports[val.ssrc].expSeqNo = val.seqNo + 1;
+                    ++reports[val.ssrc].disordered;
                 }
+                reports[val.ssrc].expSeqNo = val.seqNo + 1;
             }
         }
         if (queue->empty() && !consumerRunning)
@@ -114,7 +111,7 @@ void produceRun(uint32_t id, Q* queue, TransmissionReport reports[])
     int count = 0;
     while (producerRunning)
     {
-        for (int i = 0; i < 3000; ++i)
+        for (int i = 0; i < 5000; ++i)
         {
             if (queue->push(typename Q::value_type(id, count)))
             {


### PR DESCRIPTION
arbitrary queue size allowed, which helps reducing memory footprint
25% performance improvement due to
Fewer atomic operations.
read independant from write: less contention
Better layout of members
dispersed access pattern of the queue avoids cache line
contention on elements.
allow items without default constructor as items are created in
place when needed.