### PR TITLE
Feature/MEDIA-1774

### DIFF
--- a/bridge/ApiRequestHandler.cpp
+++ b/bridge/ApiRequestHandler.cpp
@@ -107,7 +107,7 @@ httpd::Response ApiRequestHandler::onRequest(const httpd::Request& request)
         RequestLogger requestLogger(request, _lastAutoRequestId);
         try
         {
-            auto token = utils::StringTokenizer::tokenize(request._url.c_str(), request._url.length(), "/?");
+            auto token = utils::StringTokenizer::tokenize(request._url.c_str(), request._url.length(), "/");
             if (utils::StringTokenizer::isEqual(token, "about") && token.next && request._method == httpd::Method::GET)
             {
                 return handleAbout(this, requestLogger, request, token);
@@ -118,18 +118,16 @@ httpd::Response ApiRequestHandler::onRequest(const httpd::Request& request)
             }
             else if (utils::StringTokenizer::isEqual(token, "conferences") && !token.next)
             {
-                return handleConferenceRequest(requestLogger, request);
-            }
-            else if (utils::StringTokenizer::isEqual(token, "conferences") && token.next && token.delimiter == '?')
-            {
-                token = utils::StringTokenizer::tokenize(token, '?');
-                const auto listType = token.str();
-                if (!token.next && listType == "brief")
+                if (request._params.empty())
+                {
+                    return handleConferenceRequest(requestLogger, request);
+                }
+                else if (request._params.find("brief") != request._params.end())
                 {
                     return fetchBriefConferenceList(this, requestLogger);
                 }
             }
-            else if (utils::StringTokenizer::isEqual(token, "conferences") && token.next && token.delimiter == '/')
+            else if (utils::StringTokenizer::isEqual(token, "conferences") && token.next)
             {
                 token = utils::StringTokenizer::tokenize(token, '/');
                 const auto conferenceId = token.str();

--- a/concurrency/MpmcPublish.h
+++ b/concurrency/MpmcPublish.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <atomic>
+#include <cassert>
+#include <iterator>
 
 namespace concurrency
 {
@@ -14,24 +16,15 @@ class MpmcPublish
     {
         Entry() : refCount(0) {}
 
-        std::atomic_uint32_t refCount;
+        std::atomic_uint32_t refCount; // 0 means free
         T value;
     };
 
-    static constexpr uint32_t indexBits = 16;
-    static constexpr uint32_t TOO_MANY_THREADS = 1 << (indexBits - 1);
-    static constexpr uint32_t indexMask = (1 << indexBits) - 1;
-
-    uint32_t indexOf(uint32_t cursor) const { return cursor & indexMask; }
-    uint32_t versionOf(uint32_t cursor) const { return cursor >> indexBits; }
-    uint32_t toCursor(uint32_t version, uint32_t index) const { return (version << indexBits) | 0x80000000 | index; }
-
 public:
     typedef T ValueType;
-    MpmcPublish() : _readCursor(0)
+    MpmcPublish() : _readPointer(nullptr)
     {
-        static_assert(MAX_THREADS > 0 && MAX_THREADS < TOO_MANY_THREADS,
-            "entries in MpmcPublish cannot exceed TOO_MANY_THREADS");
+        static_assert(MAX_THREADS > 2 && MAX_THREADS < 512, "entries must > 2 < 512 in MpmcPublish");
     }
 
     ~MpmcPublish() {}
@@ -39,57 +32,61 @@ public:
     // return false if empty
     bool read(T& target) const
     {
-        if (empty())
+        for (auto* cell = _readPointer.load(std::memory_order_consume); cell;
+             cell = _readPointer.load(std::memory_order_consume))
         {
-            return false;
-        }
-
-        for (;;)
-        {
-            const uint32_t readIndex = indexOf(_readCursor.load(std::memory_order::memory_order_consume));
-            Entry& cell = const_cast<Entry&>(_elements[readIndex]);
-            if (cell.refCount.fetch_add(1) < TOO_MANY_THREADS)
+            auto prevCount = cell->refCount.fetch_add(1);
+            if (prevCount > 0)
             {
-                target = cell.value;
-                cell.refCount.fetch_sub(1);
+                target = cell->value;
+                cell->refCount.fetch_sub(1);
                 return true;
             }
-            else
-            {
-                cell.refCount.fetch_sub(1);
-            }
+
+            cell->refCount.fetch_sub(1);
         }
+
+        return false;
     }
 
     // iterate until we find an idle slot to write into.
     // most reading threads will be locking the previous write pos
     bool write(const T& obj)
     {
-        uint32_t readCursor = _readCursor.load(std::memory_order::memory_order_relaxed);
-        const uint32_t readIndex = indexOf(readCursor);
-        const uint32_t version = versionOf(readCursor);
-        for (int i = 0; i < MAX_THREADS - 1; ++i)
+        auto readPointer = _readPointer.load(std::memory_order_consume);
+        const uint32_t offset = readPointer ? std::distance(&_elements[0], readPointer) + 1 : 0;
+        for (int i = 0; i < MAX_THREADS * 20; ++i)
         {
-            const auto index = (i + readIndex) % MAX_THREADS;
-            Entry& cell = _elements[index];
-            uint32_t expectedCount = 0;
-            if (cell.refCount.compare_exchange_strong(expectedCount, TOO_MANY_THREADS))
+            Entry& writeCell = _elements[(i + offset) % MAX_THREADS];
+            if (writeCell.refCount.fetch_add(1) == 0)
             {
-                cell.value = obj;
-                cell.refCount.fetch_sub(TOO_MANY_THREADS - 1); // make it readable before pointing readpointer to it
-                _readCursor.compare_exchange_strong(readCursor, toCursor(version + 1, index));
-                cell.refCount.fetch_sub(1);
+                // it is mine now
+                writeCell.value = obj;
+                if (!_readPointer.compare_exchange_strong(readPointer, &writeCell, std::memory_order_release))
+                {
+                    auto prevCount = writeCell.refCount.fetch_sub(1);
+                    assert(prevCount == 1);
+                    // ok, we lost race
+                }
+                else if (readPointer)
+                {
+                    readPointer->refCount.fetch_sub(1);
+                }
                 return true;
+            }
+            else
+            {
+                writeCell.refCount.fetch_sub(1);
             }
         }
 
-        return false;
+        return false; // failed to allocate write slot
     }
 
-    bool empty() const { return _readCursor.load(std::memory_order_consume) == 0; }
+    bool empty() const { return _readPointer.load(std::memory_order_consume) == nullptr; }
 
 private:
-    std::atomic_uint32_t _readCursor;
+    std::atomic<Entry*> _readPointer;
     Entry _elements[MAX_THREADS];
 };
 } // namespace concurrency

--- a/concurrency/MpmcPublish.h
+++ b/concurrency/MpmcPublish.h
@@ -35,7 +35,7 @@ public:
         for (auto* cell = _readPointer.load(std::memory_order_consume); cell;
              cell = _readPointer.load(std::memory_order_consume))
         {
-            auto prevCount = cell->refCount.fetch_add(1);
+            const auto prevCount = cell->refCount.fetch_add(1);
             if (prevCount > 0)
             {
                 target = cell->value;

--- a/httpd/Httpd.cpp
+++ b/httpd/Httpd.cpp
@@ -23,6 +23,21 @@ int32_t getHeaders(void* cls, MHD_ValueKind, const char* key, const char* value)
     return MHD_YES;
 }
 
+int32_t getParams(void* cls, MHD_ValueKind, const char* key, const char* value)
+{
+    auto request = reinterpret_cast<httpd::Request*>(cls);
+    if (value)
+    {
+        request->_params.emplace(key, value);
+    }
+    else
+    {
+        request->_params.emplace(key, std::string());
+    }
+
+    return MHD_YES;
+}
+
 int32_t addCorsHeaders(const httpd::Request& request, MHD_Response* response)
 {
     int32_t result = MHD_YES;
@@ -74,7 +89,7 @@ int32_t answerCallback(void* cls,
 {
     auto context = reinterpret_cast<Context*>(*conCls);
 
-    if (strncmp(method, "POST", 4) == 0 || strncmp(method, "PATCH", 5) == 0)
+    if (strncmp(method, "POST", 4) == 0 || strncmp(method, "PATCH", 5) == 0 || strncmp(method, "PUT", 3) == 0)
     {
         if (!context)
         {
@@ -127,6 +142,7 @@ int32_t answerCallback(void* cls,
 
     auto httpRequestHandler = reinterpret_cast<httpd::HttpRequestHandler*>(cls);
     MHD_get_connection_values(connection, MHD_HEADER_KIND, (MHD_KeyValueIterator)(&getHeaders), request);
+    MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, (MHD_KeyValueIterator)(&getParams), request);
     context->_response = new httpd::Response(httpRequestHandler->onRequest(*request));
 
     MHD_Response* mhdResponse;

--- a/httpd/Request.h
+++ b/httpd/Request.h
@@ -13,7 +13,8 @@ enum class Method
     POST,
     DELETE,
     PATCH,
-    OPTIONS
+    OPTIONS,
+    PUT
 };
 
 struct Request
@@ -39,6 +40,10 @@ struct Request
         else if (strncmp(methodString, "OPTIONS", 7) == 0)
         {
             _method = Method::OPTIONS;
+        }
+        else if (strncmp(methodString, "PUT", 3) == 0)
+        {
+            _method = Method::PUT;
         }
         else
         {
@@ -66,15 +71,40 @@ struct Request
         case Method::OPTIONS:
             _methodString = "OPTIONS";
             break;
+        case Method::PUT:
+            _methodString = "PUT";
+            break;
         default:
             assert(false);
         }
+    }
+
+    std::string paramsToString() const
+    {
+        if (_params.empty())
+        {
+            return "";
+        }
+
+        std::string r;
+        r.reserve(50);
+        r += "?";
+        for (auto& pair : _params)
+        {
+            if (r.size() > 1)
+            {
+                r += "&";
+            }
+            r += pair.first + (pair.second.empty() ? "" : "=" + pair.second);
+        }
+        return r;
     }
 
     Method _method;
     std::string _methodString;
     std::string _url;
     std::unordered_map<std::string, std::string> _headers;
+    std::unordered_map<std::string, std::string> _params;
     utils::StringBuilder<8192> _body;
 };
 

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1761,7 +1761,7 @@ TEST_F(IntegrationTest, confList)
         EXPECT_TRUE(confRequest);
 
         auto briefConfRequest = emulator::awaitResponse<HttpGetRequest>(_httpd,
-            std::string(baseUrl) + "/conferences?brief",
+            std::string(baseUrl) + "/conferences?brief=1",
             1500 * utils::Time::ms,
             responseBody);
         logger::info("%s", "test", responseBody.dump(3).c_str());

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1771,6 +1771,14 @@ TEST_F(IntegrationTest, confList)
         EXPECT_EQ(mixerJson["id"], conf.getId());
         EXPECT_EQ(mixerJson["usercount"], group.clients.size());
 
+        briefConfRequest = emulator::awaitResponse<HttpGetRequest>(_httpd,
+            std::string(baseUrl) + "/conferences?brief",
+            1500 * utils::Time::ms,
+            responseBody);
+        logger::info("%s", "test", responseBody.dump(3).c_str());
+        EXPECT_TRUE(briefConfRequest);
+        EXPECT_TRUE(responseBody.size() == 1);
+
         for (auto& ep : mixerJson["users"])
         {
             auto id = ep.get<std::string>();

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1771,14 +1771,6 @@ TEST_F(IntegrationTest, confList)
         EXPECT_EQ(mixerJson["id"], conf.getId());
         EXPECT_EQ(mixerJson["usercount"], group.clients.size());
 
-        briefConfRequest = emulator::awaitResponse<HttpGetRequest>(_httpd,
-            std::string(baseUrl) + "/conferences?brief",
-            1500 * utils::Time::ms,
-            responseBody);
-        logger::info("%s", "test", responseBody.dump(3).c_str());
-        EXPECT_TRUE(briefConfRequest);
-        EXPECT_TRUE(responseBody.size() == 1);
-
         for (auto& ep : mixerJson["users"])
         {
             auto id = ep.get<std::string>();
@@ -1787,6 +1779,14 @@ TEST_F(IntegrationTest, confList)
                           [&id](const std::unique_ptr<SfuClient<Channel>>& p) { return p->getEndpointId() == id; }),
                 group.clients.end());
         }
+
+        briefConfRequest = emulator::awaitResponse<HttpGetRequest>(_httpd,
+            std::string(baseUrl) + "/conferences?brief",
+            1500 * utils::Time::ms,
+            responseBody);
+        logger::info("%s", "test", responseBody.dump(3).c_str());
+        EXPECT_TRUE(briefConfRequest);
+        EXPECT_TRUE(responseBody.size() == 1);
 
         group.clients[0]->_transport->stop();
         group.clients[1]->_transport->stop();

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -1784,6 +1784,12 @@ TEST_F(IntegrationTest, confList)
             std::string(baseUrl) + "/conferences?brief",
             1500 * utils::Time::ms,
             responseBody);
+
+        briefConfRequest = emulator::awaitResponse<HttpGetRequest>(_httpd,
+            std::string(baseUrl) + "/conferences?brief=1&bread=true&butter",
+            1500 * utils::Time::ms,
+            responseBody);
+
         logger::info("%s", "test", responseBody.dump(3).c_str());
         EXPECT_TRUE(briefConfRequest);
         EXPECT_TRUE(responseBody.size() == 1);

--- a/test/integration/RealTimeTest.cpp
+++ b/test/integration/RealTimeTest.cpp
@@ -459,6 +459,26 @@ TEST_F(RealTimeTest, localVideoMeeting)
 
     makeCallWithDefaultAudioProfile(group, 20 * utils::Time::sec);
 
+    nlohmann::json responseBody;
+    auto briefConfRequest = emulator::awaitResponse<HttpGetRequest>(nullptr,
+        std::string(baseUrl) + "/conferences?brief=1",
+        1500 * utils::Time::ms,
+        responseBody);
+    logger::info("%s", "test", responseBody.dump(3).c_str());
+    EXPECT_TRUE(responseBody.size() == 1);
+    EXPECT_TRUE(briefConfRequest);
+    auto& mixerJson = responseBody[0];
+    EXPECT_EQ(mixerJson["id"], conf.getId());
+    EXPECT_EQ(mixerJson["usercount"], group.clients.size());
+
+    briefConfRequest = emulator::awaitResponse<HttpGetRequest>(nullptr,
+        std::string(baseUrl) + "/conferences?brief",
+        1500 * utils::Time::ms,
+        responseBody);
+    logger::info("%s", "test", responseBody.dump(3).c_str());
+    EXPECT_TRUE(briefConfRequest);
+    EXPECT_TRUE(responseBody.size() == 1);
+
     group.disconnectClients();
 
     for (auto& client : group.clients)

--- a/test/integration/emulator/Httpd.cpp
+++ b/test/integration/emulator/Httpd.cpp
@@ -37,12 +37,12 @@ httpd::Response HttpdFactory::sendRequest(httpd::Method method, const char* url,
     std::string fqUrl = url;
     if (utils::startsWith("http://", fqUrl))
     {
-        auto urlStart = fqUrl.find('/', 7);
-        auto paramStart = fqUrl.find('?', urlStart + 8);
+        const auto urlStart = fqUrl.find('/', 7);
+        const auto paramStart = fqUrl.find('?', urlStart + 2);
         if (paramStart != std::string::npos)
         {
             request._url = fqUrl.substr(urlStart, paramStart - urlStart);
-            auto params = fqUrl.substr(paramStart + 1);
+            const auto params = fqUrl.substr(paramStart + 1);
             for (auto keyValueToken = utils::StringTokenizer::tokenize(params.c_str(), params.size(), "&");
                  !keyValueToken.empty();
                  keyValueToken = utils::StringTokenizer::tokenize(keyValueToken, "&"))

--- a/test/integration/emulator/Httpd.cpp
+++ b/test/integration/emulator/Httpd.cpp
@@ -38,10 +38,34 @@ httpd::Response HttpdFactory::sendRequest(httpd::Method method, const char* url,
     if (utils::startsWith("http://", fqUrl))
     {
         auto urlStart = fqUrl.find('/', 7);
-        request._url = fqUrl.substr(urlStart);
+        auto paramStart = fqUrl.find('?', urlStart + 8);
+        if (paramStart != std::string::npos)
+        {
+            request._url = fqUrl.substr(urlStart, paramStart - urlStart);
+            auto params = fqUrl.substr(paramStart + 1);
+            for (auto keyValueToken = utils::StringTokenizer::tokenize(params.c_str(), params.size(), "&");
+                 !keyValueToken.empty();
+                 keyValueToken = utils::StringTokenizer::tokenize(keyValueToken, "&"))
+            {
+                auto paramSplit = utils::StringTokenizer::tokenize(keyValueToken.start, keyValueToken.length, "=");
+                if (!paramSplit.next)
+                {
+                    request._params.emplace(keyValueToken.str(), "");
+                }
+                else
+                {
+                    request._params.emplace(paramSplit.str(), utils::StringTokenizer::tokenize(paramSplit, '&').str());
+                }
+            }
+        }
+        else
+        {
+            request._url = fqUrl.substr(urlStart);
+        }
     }
     else
     {
+        assert(false);
         request._url = url;
     }
 

--- a/test/transport/RtcTransportTest.cpp
+++ b/test/transport/RtcTransportTest.cpp
@@ -489,13 +489,13 @@ TEST(TransportStats, MpmcPublish)
         uint32_t mem[20];
     };
 
-    const int THREAD_COUNT = 6;
+    const int READER_COUNT = 6;
     const int WRITER_COUNT = 2;
-    concurrency::MpmcPublish<InfoObject, THREAD_COUNT + WRITER_COUNT> board;
+    concurrency::MpmcPublish<InfoObject, READER_COUNT + WRITER_COUNT> board;
 
     board.write(InfoObject());
     std::atomic_bool running(true);
-    std::thread* threads[THREAD_COUNT];
+    std::thread* threads[READER_COUNT];
     std::thread* writers[WRITER_COUNT];
 
     for (int i = 0; i < WRITER_COUNT; ++i)
@@ -510,7 +510,7 @@ TEST(TransportStats, MpmcPublish)
         });
     }
 
-    for (int i = 0; i < THREAD_COUNT; ++i)
+    for (int i = 0; i < READER_COUNT; ++i)
     {
         threads[i] = new std::thread([&board, &running]() {
             InfoObject data;
@@ -523,7 +523,7 @@ TEST(TransportStats, MpmcPublish)
 
     utils::Time::uSleep(5000000);
     running = false;
-    for (int i = 0; i < THREAD_COUNT; ++i)
+    for (int i = 0; i < READER_COUNT; ++i)
     {
         threads[i]->join();
         delete threads[i];


### PR DESCRIPTION
Fix to have the get the short list of conference contents, confid and endpoint ids.
I also detected a flaky test MpmcPublish that could fail when run in tcheck. This was due to writer not finding an empty slot when tcheck paused all threads in reading and writing. This is a good test so I improved the implementation of MpmcPublish read/write will always succeed when the threads are at most as many as specified.