### PR TITLE
crashfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Debug/
 Release/
 *.xcodeproj/
 coverage/*
+git_version.*
+*/smb/test/include/TestConfig.h
+versioninfo.txt

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -29,7 +29,7 @@ node('be-integration') {
                 isReleaseBuild = true
             } else if (env.GIT_BRANCH ==~ /\d+\.\d+\.\d+/) {
                 version = "${env.GIT_BRANCH}-${currentBuild.number}"
-                isReleaseBuild = true
+                isReleaseBuild = !env.GIT_BRANCH.startsWith("0");
             }
 
             // Set the version env variable so that it's picked up by versioninfo.sh run as part of the build

--- a/test/transport/IceTest.cpp
+++ b/test/transport/IceTest.cpp
@@ -1592,13 +1592,13 @@ TEST_F(IceTest, udpTcpTimeout)
     endpoint2b.attach(sessions[1]);
 
     exchangeInfo(*sessions[0], *sessions[1]);
-    sessions[0]->addRemoteCandidate(ice::IceCandidate("werwe",
-                                        ice::IceComponent::RTP,
-                                        ice::TransportType::TCP,
-                                        12312,
-                                        endpoint2b._address,
-                                        ice::IceCandidate::Type::HOST,
-                                        ice::TcpType::PASSIVE),
+    sessions[0]->addRemoteTcpCandidate(ice::IceCandidate("werwe",
+                                           ice::IceComponent::RTP,
+                                           ice::TransportType::TCP,
+                                           12312,
+                                           endpoint2b._address,
+                                           ice::IceCandidate::Type::HOST,
+                                           ice::TcpType::PASSIVE),
         &endpoint1b);
     sessions[1]->addLocalTcpCandidate(ice::IceCandidate::Type::HOST,
         0,

--- a/test/transport/TransportIntegrationTest.cpp
+++ b/test/transport/TransportIntegrationTest.cpp
@@ -33,8 +33,6 @@ void TransportIntegrationTest::SetUp()
         "{\"ice.preferredIp\": \"127.0.0.1\", \"ice.singlePort\":10010, \"recording.singlePort\":0}";
     _config1.readFromString(configJson1);
     _config2.readFromString(configJson2);
-    std::vector<transport::SocketAddress> interfaces;
-    interfaces.push_back(transport::SocketAddress::parse(_config1.ice.preferredIp, 0));
 
     init(configJson1, configJson2);
 }

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -130,7 +130,7 @@ public:
     void setLocalCredentials(const std::pair<std::string, std::string>& credentials);
     IceCandidates getLocalCandidates() const;
     void addLocalCandidate(const IceCandidate& candidate);
-    void addLocalCandidate(const transport::SocketAddress& publicAddress, IceEndpoint* udpEndpoint);
+    void addLocalUdpCandidate(const transport::SocketAddress& publicAddress, IceEndpoint* udpEndpoint);
 
     void addLocalTcpCandidate(IceCandidate::Type type,
         int interfaceIndex,
@@ -139,7 +139,7 @@ public:
         TcpType tcpType);
 
     const IceCandidate& addRemoteCandidate(const IceCandidate& udpCandidate);
-    void addRemoteCandidate(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
+    void addRemoteTcpCandidate(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
 
     void setRemoteCredentials(const std::string& ufrag, const std::string& pwd);
     void setRemoteCredentials(const std::pair<std::string, std::string>& credentials);

--- a/utils/SocketAddress.h
+++ b/utils/SocketAddress.h
@@ -28,7 +28,7 @@ public:
     SocketAddress(const uint8_t* ipv6_networkOrder, uint16_t port, const char* nicName = nullptr);
     SocketAddress(const SocketAddress& other) : SocketAddress(&other._address.gen)
     {
-        memcpy(_nicName, other._nicName, NIC_NAME_MAX_SIZE);
+        std::memcpy(_nicName, other._nicName, NIC_NAME_MAX_SIZE);
     }
     SocketAddress(const SocketAddress& ip, uint16_t port) : SocketAddress(&ip._address.gen) { setPort(port); }
 


### PR DESCRIPTION
IceSession and transport keep the Tcp endpoints until the very end.
If new UDP PRFLX candidates show up after ICE connected, IceSession will be able to iterate through the endpoints to setup probe for the new candidate without crashing.