### PR TITLE
Auto detect audio ssrc if not set

### DIFF
--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -833,7 +833,12 @@ SsrcInboundContext* EngineMixer::emplaceInboundSsrcContext(const uint32_t ssrc,
     auto* audioStream = _engineAudioStreams.getItem(endpointIdHash);
     if (audioStream && audioStream->rtpMap.payloadType == payloadType)
     {
-        if (!audioStream->remoteSsrc.isSet() || audioStream->remoteSsrc.get() != ssrc)
+        if (!audioStream->remoteSsrc.isSet())
+        {
+            audioStream->remoteSsrc.set(ssrc);
+            logger::info("picking up inbound audio on ssrc %u automatically", _loggableId.c_str(), ssrc);
+        }
+        else if (audioStream->remoteSsrc.get() != ssrc)
         {
             return nullptr;
         }


### PR DESCRIPTION
Umony SDP does not have ssrc on SDP. Then we have we will auto configure it when we first see the ssrc