### PR TITLE
SRTP with SDES keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ elseif(UNIX)
 
     set(CMAKE_INSTALL_RPATH "./libs")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++abi -lrt")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -lc++abi -lrt")
 
 # std::filesystem requires c++fs library before CLANG 9.1
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9_1)
@@ -78,6 +78,7 @@ find_package(OpenSSL REQUIRED)
 find_package(Srtp2 REQUIRED)
 find_package(Opus REQUIRED)
 find_package(LibMicrohttpd REQUIRED)
+link_directories(/usr/local/lib)
 
 include_directories(.)
 include_directories(external)
@@ -388,6 +389,8 @@ set(FILES
         transport/dtls/SslDtls.cpp
         transport/dtls/SslDtls.h
         transport/dtls/SslWriteBioListener.h
+        transport/dtls/SrtpProfiles.h
+        transport/dtls/SrtpProfiles.cpp
         transport/ice/IceCandidate.cpp
         transport/ice/IceCandidate.h
         transport/ice/IceComponent.h
@@ -558,6 +561,7 @@ set(TEST_FILES
     test/integration/BarbellTest.h
     test/integration/ConfIntegrationTest.cpp
     test/integration/IceTransportTest.cpp
+    test/integration/SrtpIntegrationTest.cpp
     
 #    test/integration/MixerTimeoutTest.cpp
 #    test/integration/StatsTest.cpp

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Symphony Media Bridge (SMB) is a media server application that handles audio
 In RTC conferencing systems, when more than two participants are in a conference there is usually a media server component involved. Each participant in the conference will send their audio and video streams to the media server. The media server is then responsible for sending the correct media streams to each receiving participant.
 
 Conferencing media servers are typically divided into two categories, multipoint conference units (MCU) and selective forwarding units (SFU).
- MCUs decode, mix and transcode media streams delivering a single or a few output streams to each receiver. SFUs do not decode or transcode media streams from participants, but forwards a selection of the incoming media streams to each receiver in some intelligent way. Not all incoming streams are forwarded, but typically more than one stream to each receiver.
+MCUs decode, mix and transcode media streams delivering a single or a few output streams to each receiver. SFUs do not decode or transcode media streams from participants, but forwards a selection of the incoming media streams to each receiver in some intelligent way. Not all incoming streams are forwarded, but typically more than one stream to each receiver.
 
 SMB is an SFU at its core, but has some hybrid MCU like solutions. Video streams are forwarded and not transcoded, but participants can request a mixed, transcoded audio stream instead of forwarded streams. SMB can also be run in a mode where multiple streams are forwarded, but the contents of each stream can vary between different participants in the conference. This allows for larger conferences than SFUs can typically handle.
 
@@ -15,18 +15,20 @@ Written as a high performance native application with efficient resource managem
 
 ## Documentation
 
-- [Wiki](https://github.com/finos/SymphonyMediaBridge/wiki)
-- [Usage example](https://github.com/finos/SymphonyMediaBridge/tree/master/examples)
+-   [Wiki](https://github.com/finos/SymphonyMediaBridge/wiki)
+-   [Usage example](https://github.com/finos/SymphonyMediaBridge/tree/master/examples)
+-   [HTTP API documentation](https://github.com/finos/SymphonyMediaBridge/tree/master/doc/READMEapi.md)
 
 ## Installing
 
 The Supported platforms for the release builds are
-- Ubuntu Server 20.04 LTS
-- Ubuntu Server 21.10
+
+-   Ubuntu Server 20.04 LTS
+-   Ubuntu Server 21.10
 
 The following additional dependencies have to be installed:
 
-```apt-get install libc++-dev libc++abi-dev libsrtp2-1 libmicrohttpd12 libopus0```
+`apt-get install libc++-dev libc++abi-dev libsrtp2-1 libmicrohttpd12 libopus0`
 
 ### Alternative 1. Installing the .deb package
 
@@ -34,23 +36,23 @@ The following additional dependencies have to be installed:
 
 #### 2. Install
 
-```dpkg -i finos-rtc-smb_<version>.deb```
+`dpkg -i finos-rtc-smb_<version>.deb`
 
 #### 3. Start with the default empty config file
 
-```smb /etc/finos-rtc-smb/config.json```
+`smb /etc/finos-rtc-smb/config.json`
 
-### Alternative 2. Download the .tar.gz file 
+### Alternative 2. Download the .tar.gz file
 
 #### 1. Download and extract the .tar.gz file from a release
 
 #### 2. Add realtime priority capabilities to the smb binary
 
-```setcap CAP_SYS_NICE+ep smb```
+`setcap CAP_SYS_NICE+ep smb`
 
 #### 3. Start with the default empty config file
 
-```./smb config.json```
+`./smb config.json`
 
 ## Development setup
 
@@ -60,36 +62,37 @@ The Symphony Media Bridge is a cmake based project that can be built and run for
 
 #### 1. Install the required dependencies
 
-```apt-get install cmake llvm clang lldb libc++-dev libc++abi-dev libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev libunwind-13-dev```
+`apt-get install cmake llvm clang lldb libc++-dev libc++abi-dev libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev libunwind-13-dev`
 
 #### 2. Set Clang as compiler
 
-```export CC=clang && export CXX=clang++```
+`export CC=clang && export CXX=clang++`
 
 #### 3. Generate the Makefile
 
-```cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .```
+`cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .`
 
 ### Building for MacOSX
 
 #### 1. Install the required dependencies using brew
 
-```brew install cmake srtp openssl@1.1 libmicrohttpd opus```
+`brew install cmake srtp openssl@1.1 libmicrohttpd opus`
 
 #### 2.1 Generate the Makefile
 
-```cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .```
+`cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .`
 
 #### 2.2 Alternatively generate Xcode project files
 
-```cmake -G "Xcode" .```
+`cmake -G "Xcode" .`
 
 ### Running the application
 
-``` ./smb config.json ```
+`./smb config.json`
 
 ### Running the local test suite
-```./UnitTest```
+
+`./UnitTest`
 
 ## Contributing
 
@@ -102,8 +105,7 @@ The Symphony Media Bridge is a cmake based project that can be built and run for
 
 _NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS OR who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the FINOS Clabot tool (or [EasyCLA](https://github.com/finos/community/blob/master/governance/Software-Projects/EasyCLA.md)). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
 
-*Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@finos.org](mailto:help@finos.org)*
-
+_Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@finos.org](mailto:help@finos.org)_
 
 ## License
 

--- a/api/AllocateEndpoint.h
+++ b/api/AllocateEndpoint.h
@@ -18,8 +18,8 @@ struct AllocateEndpoint
         bool ice;
         utils::Optional<bool> iceControlling;
 
-        bool dtls = false;
-        bool sdes = false;
+        bool dtls;
+        bool sdes;
     };
 
     struct Audio

--- a/api/AllocateEndpoint.h
+++ b/api/AllocateEndpoint.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "api/RtcDescriptors.h"
+#include "transport/dtls/SrtpProfiles.h"
 #include "utils/Optional.h"
 #include <cstdint>
 #include <string>
@@ -11,12 +13,13 @@ struct AllocateEndpoint
 {
     struct Transport
     {
-        Transport() : ice(false), dtls(false) {}
+        Transport() : ice(false), dtls(false), sdes(false) {}
 
         bool ice;
         utils::Optional<bool> iceControlling;
 
-        bool dtls;
+        bool dtls = false;
+        bool sdes = false;
     };
 
     struct Audio

--- a/api/Generator.cpp
+++ b/api/Generator.cpp
@@ -3,6 +3,7 @@
 #include "api/ConferenceEndpoint.h"
 #include "api/EndpointDescription.h"
 #include "api/utils.h"
+#include "utils/Base64.h"
 
 namespace
 {
@@ -57,6 +58,17 @@ nlohmann::json generateTransport(const api::Transport& transport)
         dtlsJson["hash"] = dtls.hash;
         dtlsJson["setup"] = dtls.setup;
         transportJson["dtls"] = dtlsJson;
+    }
+    if (!transport.sdesKeys.empty())
+    {
+        transportJson["sdes"] = nlohmann::json::array();
+        for (auto sdesKey : transport.sdesKeys)
+        {
+            nlohmann::json sdesJson;
+            sdesJson["key"] = utils::Base64::encode(sdesKey.keySalt, sdesKey.getLength());
+            sdesJson["profile"] = api::utils::toString(sdesKey.profile);
+            transportJson["sdes"].push_back(sdesJson);
+        }
     }
 
     if (transport.connection.isSet())

--- a/api/Parser.cpp
+++ b/api/Parser.cpp
@@ -2,6 +2,7 @@
 #include "api/ConferenceEndpoint.h"
 #include "api/utils.h"
 #include "utils/Base64.h"
+#include "utils/Format.h"
 
 namespace
 {
@@ -128,7 +129,10 @@ api::AllocateEndpoint::Transport parseAllocateEndpointTransport(const nlohmann::
     api::AllocateEndpoint::Transport transport;
     setIfExists(transport.ice, data, "ice");
     setIfExists(transport.iceControlling, data, "ice-controlling");
+
     setIfExists(transport.dtls, data, "dtls");
+    setIfExists(transport.sdes, data, "sdes");
+
     return transport;
 }
 
@@ -177,6 +181,20 @@ api::Transport parsePatchEndpointTransport(const nlohmann::json& data)
         dtls.hash = dtlsJson["hash"].get<std::string>();
         dtls.setup = dtlsJson["setup"].get<std::string>();
         transport.dtls.set(dtls);
+    }
+    else if (data.find("sdes") != data.end())
+    {
+        const auto& sdesJson = data["sdes"];
+        srtp::AesKey aesKey;
+        const size_t decodedLength =
+            utils::Base64::decode(sdesJson["key"].get<std::string>().c_str(), aesKey.keySalt, sizeof(aesKey.keySalt));
+        aesKey.profile = api::utils::stringToSrtpProfile(sdesJson["profile"].get<std::string>());
+        if (decodedLength != aesKey.getLength())
+        {
+            throw nlohmann::detail::other_error::create(-1,
+                utils::format("SDES key invalid length. EndpointConfigure"));
+        }
+        transport.sdesKeys.push_back(aesKey);
     }
 
     if (data.find("connection") != data.end())

--- a/api/Parser.h
+++ b/api/Parser.h
@@ -7,6 +7,7 @@
 #include "api/EndpointDescription.h"
 #include "api/Recording.h"
 #include "nlohmann/json.hpp"
+#include "transport/dtls/SrtpProfiles.h"
 
 namespace api
 {

--- a/api/RtcDescriptors.cpp
+++ b/api/RtcDescriptors.cpp
@@ -1,7 +1,23 @@
 #include "RtcDescriptors.h"
+#include "api/utils.h"
 
 namespace api
 {
 const char* VideoStream::slidesContent = "slides";
 const char* VideoStream::videoContent = "video";
+
+utils::EnumRef<SrtpMode> srtpModes[] = {{"DISABLED", SrtpMode::Disabled},
+    {"DTLS", SrtpMode::DTLS},
+    {"SDES", SrtpMode::SDES}};
+
+SrtpMode stringToSrtpMode(const std::string& s)
+{
+    return fromString(s, srtpModes);
+}
+
+std::string toString(SrtpMode mode)
+{
+    return toString(mode, srtpModes);
+}
+
 } // namespace api

--- a/api/RtcDescriptors.h
+++ b/api/RtcDescriptors.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "api/SimulcastGroup.h"
+#include "transport/dtls/SrtpProfiles.h"
 #include "utils/Optional.h"
 #include <cstdint>
 #include <string>
@@ -8,6 +9,16 @@
 
 namespace api
 {
+
+enum SrtpMode
+{
+    Disabled = 0,
+    DTLS,
+    SDES
+};
+
+SrtpMode stringToSrtpMode(const std::string& s);
+std::string toString(SrtpMode mode);
 
 struct Candidate
 {
@@ -52,6 +63,23 @@ struct Transport
     utils::Optional<Ice> ice;
     utils::Optional<Dtls> dtls;
     utils::Optional<Connection> connection;
+    std::vector<srtp::AesKey> sdesKeys;
+
+    srtp::Mode getSrtpMode() const
+    {
+        if (dtls.isSet())
+        {
+            return srtp::Mode::DTLS;
+        }
+        else if (!sdesKeys.empty())
+        {
+            return srtp::Mode::SDES;
+        }
+        else
+        {
+            return srtp::Mode::NULL_CIPHER;
+        }
+    }
 };
 
 struct VideoStream

--- a/api/utils.cpp
+++ b/api/utils.cpp
@@ -5,76 +5,60 @@ namespace api
 namespace utils
 {
 
-const char* toString(const ice::IceSession::State state)
+api::utils::EnumRef<ice::IceSession::State> iceStates[] = {{"unknown", ice::IceSession::State::LAST},
+    {"IDLE", ice::IceSession::State::IDLE},
+    {"GATHERING", ice::IceSession::State::GATHERING},
+    {"READY", ice::IceSession::State::READY},
+    {"CONNECTING", ice::IceSession::State::CONNECTING},
+    {"CONNECTED", ice::IceSession::State::CONNECTED},
+    {"FAILED", ice::IceSession::State::FAILED}};
+
+const char* toString(ice::IceSession::State state)
 {
-    switch (state)
-    {
-    case ice::IceSession::State::IDLE:
-        return "IDLE";
-    case ice::IceSession::State::GATHERING:
-        return "GATHERING";
-    case ice::IceSession::State::READY:
-        return "READY";
-    case ice::IceSession::State::CONNECTING:
-        return "CONNECTING";
-    case ice::IceSession::State::CONNECTED:
-        return "CONNECTED";
-    case ice::IceSession::State::FAILED:
-        return "FAILED";
-    default:
-        return "unknown";
-    }
+    return toString(state, iceStates);
 }
 
-const ice::IceSession::State stringToIceState(const std::string& state)
+ice::IceSession::State stringToIceState(const std::string& state)
 {
-    if (state == "IDLE")
-        return ice::IceSession::State::IDLE;
-    if (state == "GATHERING")
-        return ice::IceSession::State::GATHERING;
-    if (state == "READY")
-        return ice::IceSession::State::READY;
-    if (state == "CONNECTING")
-        return ice::IceSession::State::CONNECTING;
-    if (state == "CONNECTED")
-        return ice::IceSession::State::CONNECTED;
-    if (state == "FAILED")
-        return ice::IceSession::State::FAILED;
-    return ice::IceSession::State::LAST;
+    return fromString(state, iceStates);
 }
 
-const char* toString(const transport::SrtpClient::State state)
+api::utils::EnumRef<transport::SrtpClient::State> dtlsStates[] = {{"unknown", transport::SrtpClient::State::LAST},
+    {"IDLE", transport::SrtpClient::State::IDLE},
+    {"READY", transport::SrtpClient::State::READY},
+    {"CONNECTED", transport::SrtpClient::State::CONNECTED},
+    {"CONNECTING", transport::SrtpClient::State::CONNECTING},
+    {"FAILED", transport::SrtpClient::State::FAILED}};
+
+const char* toString(transport::SrtpClient::State state)
 {
-    switch (state)
-    {
-    case transport::SrtpClient::State::IDLE:
-        return "IDLE";
-    case transport::SrtpClient::State::READY:
-        return "READY";
-    case transport::SrtpClient::State::CONNECTED:
-        return "CONNECTED";
-    case transport::SrtpClient::State::CONNECTING:
-        return "CONNECTING";
-    case transport::SrtpClient::State::FAILED:
-        return "FAILED";
-    default:
-        return "unknown";
-    }
+    return toString(state, dtlsStates);
 }
 
-const transport::SrtpClient::State stringToDtlsState(const std::string& state)
+transport::SrtpClient::State stringToDtlsState(const std::string& state)
 {
-    if (state == "IDLE")
-        return transport::SrtpClient::State::IDLE;
-    if (state == "READY")
-        return transport::SrtpClient::State::READY;
-    if (state == "CONNECTED")
-        return transport::SrtpClient::State::CONNECTED;
-    if (state == "CONNECTING")
-        return transport::SrtpClient::State::CONNECTING;
-    if (state == "FAILED")
-        return transport::SrtpClient::State::FAILED;
-    return transport::SrtpClient::State::LAST;
+    return fromString(state, dtlsStates);
 }
+
+api::utils::EnumRef<srtp::Profile> sdesProfiles[] = {{"", srtp::Profile::NULL_CIPHER},
+    {"AES_128_CM_HMAC_SHA1_80", srtp::Profile::AES128_CM_SHA1_80},
+    {"AES_128_CM_HMAC_SHA1_32", srtp::Profile::AES128_CM_SHA1_32},
+    {"AES_256_CM_HMAC_SHA1_80", srtp::Profile::AES_256_CM_SHA1_80},
+    {"AES_256_CM_HMAC_SHA1_32", srtp::Profile::AES_256_CM_SHA1_32},
+    {"AES_192_CM_HMAC_SHA1_80", srtp::Profile::AES_192_CM_SHA1_80},
+    {"AES_192_CM_HMAC_SHA1_32", srtp::Profile::AES_192_CM_SHA1_32},
+    {"AEAD_AES_128_GCM", srtp::Profile::AEAD_AES_128_GCM},
+    {"AEAD_AES_256_GCM", srtp::Profile::AEAD_AES_256_GCM}};
+
+const char* toString(srtp::Profile profile)
+{
+    return toString(profile, sdesProfiles);
+}
+
+srtp::Profile stringToSrtpProfile(const std::string& profile)
+{
+    return fromString(profile, sdesProfiles);
+}
+
 } // namespace utils
 } // namespace api

--- a/api/utils.h
+++ b/api/utils.h
@@ -6,9 +6,46 @@ namespace api
 {
 namespace utils
 {
-const char* toString(const ice::IceSession::State state);
-const ice::IceSession::State stringToIceState(const std::string& state);
-const char* toString(const transport::SrtpClient::State state);
-const transport::SrtpClient::State stringToDtlsState(const std::string& state);
+const char* toString(ice::IceSession::State state);
+ice::IceSession::State stringToIceState(const std::string& state);
+const char* toString(transport::SrtpClient::State state);
+transport::SrtpClient::State stringToDtlsState(const std::string& state);
+const char* toString(srtp::Profile profile);
+srtp::Profile stringToSrtpProfile(const std::string& profile);
+
+template <typename T>
+struct EnumRef
+{
+    const char* name;
+    T value;
+};
+
+// make sure dictionary contains default / null value at position 0
+template <typename T, size_t N>
+T fromString(const std::string& name, const EnumRef<T> (&dictionary)[N])
+{
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (name == dictionary[i].name)
+        {
+            return dictionary[i].value;
+        }
+    }
+    return dictionary[0].value;
+}
+
+template <typename T, size_t N>
+const char* toString(T enumValue, const EnumRef<T> (&dictionary)[N])
+{
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (enumValue == dictionary[i].value)
+        {
+            return dictionary[i].name;
+        }
+    }
+    return dictionary[0].name;
+}
+
 } // namespace utils
 } // namespace api

--- a/bridge/ApiRequestHandler.cpp
+++ b/bridge/ApiRequestHandler.cpp
@@ -78,6 +78,10 @@ httpd::Response ApiRequestHandler::handleEndpointRequest(RequestLogger& requestL
     {
         return processEndpointPostRequest(this, requestLogger, request, conferenceId, endpointId);
     }
+    else if (request._method == httpd::Method::PUT)
+    {
+        return processEndpointPutRequest(this, requestLogger, request, conferenceId, endpointId);
+    }
     else if (request._method == httpd::Method::DELETE)
     {
         return expireEndpoint(this, requestLogger, conferenceId, endpointId);

--- a/bridge/AudioStream.h
+++ b/bridge/AudioStream.h
@@ -19,7 +19,6 @@ struct AudioStream
         std::shared_ptr<transport::RtcTransport>& transport,
         const bool audioMixed,
         bool ssrcRewrite,
-        bool isDtlsLocalEnabled,
         utils::Optional<uint32_t> idleTimeout)
         : id(id),
           endpointId(endpointId),
@@ -29,9 +28,9 @@ struct AudioStream
           audioMixed(audioMixed),
           markedForDeletion(false),
           ssrcRewrite(ssrcRewrite),
-          isDtlsLocalEnabled(isDtlsLocalEnabled),
           isConfigured(false),
-          idleTimeoutSeconds(idleTimeout.isSet() ? idleTimeout.get() : 0)
+          idleTimeoutSeconds(idleTimeout.isSet() ? idleTimeout.get() : 0),
+          srtpMode(srtp::Mode::UNDEFINED)
     {
     }
 
@@ -48,10 +47,10 @@ struct AudioStream
 
     bool markedForDeletion;
     bool ssrcRewrite;
-    bool isDtlsLocalEnabled;
     bool isConfigured;
     const uint32_t idleTimeoutSeconds;
     std::vector<uint32_t> neighbours;
+    srtp::Mode srtpMode; // decided on configure
 };
 
 } // namespace bridge

--- a/bridge/LegacyApiRequestHandler.h
+++ b/bridge/LegacyApiRequestHandler.h
@@ -53,6 +53,7 @@ private:
         const std::string& conferenceId,
         const bool useBundling,
         RequestLogger& requestLogger,
+        bool enableDtls,
         Mixer& mixer);
 
     bool allocateChannel(const std::string& contentName,

--- a/bridge/Mixer.cpp
+++ b/bridge/Mixer.cpp
@@ -321,7 +321,6 @@ bool Mixer::addAudioStream(std::string& outId,
     const utils::Optional<ice::IceRole>& iceRole,
     const bool audioMixed,
     bool rewriteSsrcs,
-    bool isDtlsEnabled,
     utils::Optional<uint32_t> idleTimeoutSeconds)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
@@ -351,7 +350,6 @@ bool Mixer::addAudioStream(std::string& outId,
             transport,
             audioMixed,
             rewriteSsrcs,
-            isDtlsEnabled,
             idleTimeoutSeconds));
 
     if (!streamItr.second)
@@ -390,7 +388,6 @@ bool Mixer::addVideoStream(std::string& outId,
     const std::string& endpointId,
     const utils::Optional<ice::IceRole>& iceRole,
     bool rewriteSsrcs,
-    bool isDtlsEnabled,
     utils::Optional<uint32_t> idleTimeoutSeconds)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
@@ -419,7 +416,6 @@ bool Mixer::addVideoStream(std::string& outId,
             _ssrcGenerator.next(),
             transport,
             rewriteSsrcs,
-            isDtlsEnabled,
             idleTimeoutSeconds));
 
     if (!emplaceResult.second)
@@ -468,7 +464,6 @@ bool Mixer::addBundledAudioStream(std::string& outId,
             transportItr->second._transport,
             audioMixed,
             ssrcRewrite,
-            true,
             idleTimeoutSeconds));
 
     if (!streamItr.second)
@@ -515,7 +510,6 @@ bool Mixer::addBundledVideoStream(std::string& outId,
             _ssrcGenerator.next(),
             transportItr->second._transport,
             ssrcRewrite,
-            true,
             idleTimeoutSeconds));
 
     if (!streamItr.second)
@@ -1033,9 +1027,14 @@ bool Mixer::getTransportBundleDescription(const std::string& endpointId, Transpo
     auto bundleTransport = bundleTransportItr->second._transport.get();
     assert(bundleTransport);
 
+    std::vector<srtp::AesKey> sdesKeys;
+    bundleTransport->getSdesKeys(sdesKeys);
+
     outTransportDescription = TransportDescription(bundleTransport->getLocalCandidates(),
         bundleTransport->getLocalCredentials(),
-        bundleTransport->isDtlsClient());
+        bundleTransport->isDtlsClient(),
+        sdesKeys,
+        bundleTransportItr->second.srtpMode);
 
     return true;
 }
@@ -1055,7 +1054,9 @@ bool Mixer::getBarbellTransportDescription(const std::string& barbellId, Transpo
 
     outTransportDescription = TransportDescription(bundleTransport->getLocalCandidates(),
         bundleTransport->getLocalCredentials(),
-        bundleTransport->isDtlsClient());
+        bundleTransport->isDtlsClient(),
+        std::vector<srtp::AesKey>(),
+        srtp::Mode::DTLS);
 
     return true;
 }
@@ -1076,40 +1077,32 @@ bool Mixer::getAudioStreamTransportDescription(const std::string& endpointId,
         return false;
     }
 
-    const bool isAudioConfigured = audioStreamItr->second->isConfigured;
-    const bool isDtlsEnabled =
-        (isAudioConfigured ? transport->isDtlsEnabled() : audioStreamItr->second->isDtlsLocalEnabled);
+    std::vector<srtp::AesKey> sdesKeys;
+    transport->getSdesKeys(sdesKeys);
 
-    if (transport->isIceEnabled() && isDtlsEnabled)
+    if (transport->isIceEnabled())
     {
         outTransportDescription = TransportDescription(transport->getLocalCandidates(),
             transport->getLocalCredentials(),
-            transport->isDtlsClient());
+            transport->isDtlsClient(),
+            sdesKeys,
+            audioStreamItr->second->srtpMode);
     }
-    else if (!transport->isIceEnabled() && isDtlsEnabled)
+    else if (!transport->isIceEnabled())
     {
         if (!_config.ice.publicIpv4.get().empty())
         {
             auto publicPort = transport::SocketAddress::parse(_config.ice.publicIpv4);
             publicPort.setPort(transport->getLocalRtpPort().getPort());
-            outTransportDescription = TransportDescription(publicPort, transport->isDtlsClient());
+            outTransportDescription =
+                TransportDescription(publicPort, transport->isDtlsClient(), sdesKeys, audioStreamItr->second->srtpMode);
         }
         else
         {
-            outTransportDescription = TransportDescription(transport->getLocalRtpPort(), transport->isDtlsClient());
-        }
-    }
-    else if (!transport->isIceEnabled() && !isDtlsEnabled)
-    {
-        if (!_config.ice.publicIpv4.get().empty())
-        {
-            auto publicPort = transport::SocketAddress::parse(_config.ice.publicIpv4);
-            publicPort.setPort(transport->getLocalRtpPort().getPort());
-            outTransportDescription = TransportDescription(publicPort);
-        }
-        else
-        {
-            outTransportDescription = TransportDescription(transport->getLocalRtpPort());
+            outTransportDescription = TransportDescription(transport->getLocalRtpPort(),
+                transport->isDtlsClient(),
+                sdesKeys,
+                audioStreamItr->second->srtpMode);
         }
     }
 
@@ -1126,29 +1119,29 @@ bool Mixer::getVideoStreamTransportDescription(const std::string& endpointId,
         return false;
     }
 
-    auto transport = videoStreamItr->second->transport.get();
-    if (!transport)
+    auto& videoStream = *videoStreamItr->second;
+    if (!videoStream.transport)
     {
         return false;
     }
 
-    const bool isVideoConfigured = videoStreamItr->second->isConfigured;
-    const bool isDtlsEnabled =
-        (isVideoConfigured ? transport->isDtlsEnabled() : videoStreamItr->second->isDtlsLocalEnabled);
+    std::vector<srtp::AesKey> sdesKeys;
+    videoStream.transport->getSdesKeys(sdesKeys);
 
-    if (transport->isIceEnabled() && isDtlsEnabled)
+    if (videoStream.transport->isIceEnabled())
     {
-        outTransportDescription = TransportDescription(transport->getLocalCandidates(),
-            transport->getLocalCredentials(),
-            transport->isDtlsClient());
+        outTransportDescription = TransportDescription(videoStream.transport->getLocalCandidates(),
+            videoStream.transport->getLocalCredentials(),
+            videoStream.transport->isDtlsClient(),
+            sdesKeys,
+            videoStream.srtpMode);
     }
-    else if (!transport->isIceEnabled() && isDtlsEnabled)
+    else
     {
-        outTransportDescription = TransportDescription(transport->getLocalRtpPort(), transport->isDtlsClient());
-    }
-    else if (!transport->isIceEnabled() && !isDtlsEnabled)
-    {
-        outTransportDescription = TransportDescription(transport->getLocalRtpPort());
+        outTransportDescription = TransportDescription(videoStream.transport->getLocalRtpPort(),
+            videoStream.transport->isDtlsClient(),
+            sdesKeys,
+            videoStream.srtpMode);
     }
 
     return true;
@@ -1473,7 +1466,21 @@ bool Mixer::configureAudioStreamTransportDtls(const std::string& endpointId,
     {
         return false;
     }
-    audioStreamItr->second->transport->setRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    audioStreamItr->second->srtpMode = srtp::Mode::DTLS;
+    audioStreamItr->second->transport->asyncSetRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    return true;
+}
+
+bool Mixer::configureAudioStreamTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey)
+{
+    std::lock_guard<std::mutex> locker(_configurationLock);
+    auto audioStreamIt = _audioStreams.find(endpointId);
+    if (audioStreamIt == _audioStreams.end())
+    {
+        return false;
+    }
+    audioStreamIt->second->srtpMode = srtp::Mode::SDES;
+    audioStreamIt->second->transport->asyncSetRemoteSdesKey(remoteKey);
     return true;
 }
 
@@ -1488,11 +1495,25 @@ bool Mixer::configureVideoStreamTransportDtls(const std::string& endpointId,
     {
         return false;
     }
-    videoStreamItr->second->transport->setRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    videoStreamItr->second->srtpMode = srtp::Mode::DTLS;
+    videoStreamItr->second->transport->asyncSetRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
     return true;
 }
 
-bool Mixer::configureAudioStreamTransportDisableDtls(const std::string& endpointId)
+bool Mixer::configureVideoStreamTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey)
+{
+    std::lock_guard<std::mutex> locker(_configurationLock);
+    auto videoStreamIt = _videoStreams.find(endpointId);
+    if (videoStreamIt == _videoStreams.end())
+    {
+        return false;
+    }
+    videoStreamIt->second->srtpMode = srtp::Mode::SDES;
+    videoStreamIt->second->transport->asyncSetRemoteSdesKey(remoteKey);
+    return true;
+}
+
+bool Mixer::configureAudioStreamTransportDisableSrtp(const std::string& endpointId)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
     auto audioStreamItr = _audioStreams.find(endpointId);
@@ -1500,11 +1521,12 @@ bool Mixer::configureAudioStreamTransportDisableDtls(const std::string& endpoint
     {
         return false;
     }
-    audioStreamItr->second->transport->disableDtls();
+    audioStreamItr->second->transport->asyncDisableSrtp();
+    audioStreamItr->second->srtpMode = srtp::Mode::NULL_CIPHER;
     return true;
 }
 
-bool Mixer::configureVideoStreamTransportDisableDtls(const std::string& endpointId)
+bool Mixer::configureVideoStreamTransportDisableSrtp(const std::string& endpointId)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
     auto videoStreamItr = _videoStreams.find(endpointId);
@@ -1512,7 +1534,7 @@ bool Mixer::configureVideoStreamTransportDisableDtls(const std::string& endpoint
     {
         return false;
     }
-    videoStreamItr->second->transport->disableDtls();
+    videoStreamItr->second->transport->asyncDisableSrtp();
     return true;
 }
 
@@ -1537,13 +1559,28 @@ bool Mixer::configureBundleTransportDtls(const std::string& endpointId,
     const bool isDtlsClient)
 {
     std::lock_guard<std::mutex> locker(_configurationLock);
-    auto transportItr = _bundleTransports.find(endpointId);
-    if (transportItr == _bundleTransports.end())
+    auto transportIt = _bundleTransports.find(endpointId);
+    if (transportIt == _bundleTransports.end())
     {
         return false;
     }
 
-    transportItr->second._transport->setRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    transportIt->second.srtpMode = srtp::Mode::DTLS;
+    transportIt->second._transport->asyncSetRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    return true;
+}
+
+bool Mixer::configureBundleTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey)
+{
+    std::lock_guard<std::mutex> locker(_configurationLock);
+    auto bundleIt = _bundleTransports.find(endpointId);
+    if (bundleIt == _bundleTransports.end())
+    {
+        return false;
+    }
+
+    bundleIt->second.srtpMode = srtp::Mode::SDES;
+    bundleIt->second._transport->asyncSetRemoteSdesKey(remoteKey);
     return true;
 }
 
@@ -2289,7 +2326,7 @@ bool Mixer::configureBarbellTransport(const std::string& barbellId,
     }
 
     barbellItr->second->transport->setRemoteIce(credentials, candidates, _engineMixer->getAudioAllocator());
-    barbellItr->second->transport->setRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
+    barbellItr->second->transport->asyncSetRemoteDtlsFingerprint(fingerprintType, fingerprintHash, isDtlsClient);
     barbellItr->second->transport->setSctp(5000, 5000);
     return true;
 }

--- a/bridge/Mixer.h
+++ b/bridge/Mixer.h
@@ -107,13 +107,11 @@ public:
         const utils::Optional<ice::IceRole>& iceRole,
         const bool audioMixed,
         bool rewriteSsrcs,
-        bool isDtlsEnabled,
         utils::Optional<uint32_t> idleTimeoutSeconds = utils::Optional<uint32_t>());
     bool addVideoStream(std::string& outId,
         const std::string& endpointId,
         const utils::Optional<ice::IceRole>& iceRole,
         bool rewriteSsrcs,
-        bool isDtlsEnabled,
         utils::Optional<uint32_t> idleTimeoutSeconds = utils::Optional<uint32_t>());
     void allocateAudioBuffer(uint32_t ssrc);
 
@@ -182,14 +180,15 @@ public:
         const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool isDtlsClient);
+    bool configureAudioStreamTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey);
+    bool configureAudioStreamTransportDisableSrtp(const std::string& endpointId);
 
     bool configureVideoStreamTransportDtls(const std::string& endpointId,
         const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool isDtlsClient);
-
-    bool configureAudioStreamTransportDisableDtls(const std::string& endpointId);
-    bool configureVideoStreamTransportDisableDtls(const std::string& endpointId);
+    bool configureVideoStreamTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey);
+    bool configureVideoStreamTransportDisableSrtp(const std::string& endpointId);
 
     bool configureBundleTransportIce(const std::string& endpointId,
         const std::pair<std::string, std::string>& credentials,
@@ -199,6 +198,7 @@ public:
         const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool isDtlsClient);
+    bool configureBundleTransportSdes(const std::string& endpointId, const srtp::AesKey& remoteKey);
 
     bool configureBarbellTransport(const std::string& barbellId,
         const std::pair<std::string, std::string>& credentials,
@@ -299,6 +299,7 @@ private:
     {
         explicit BundleTransport(const std::shared_ptr<transport::RtcTransport>& transport) : _transport(transport) {}
         std::shared_ptr<transport::RtcTransport> _transport;
+        srtp::Mode srtpMode;
     };
 
     const config::Config& _config;

--- a/bridge/TransportDescription.h
+++ b/bridge/TransportDescription.h
@@ -25,23 +25,41 @@ struct TransportDescription
 
     TransportDescription(const std::vector<ice::IceCandidate>& iceCandidates,
         const std::pair<std::string, std::string>& iceCredentials,
-        const bool isDtlsClient)
+        const bool isDtlsClient,
+        const std::vector<srtp::AesKey>& sdesKeys,
+        srtp::Mode srtpMode)
         : ice(Ice{iceCandidates, iceCredentials}),
-          dtls(Dtls{isDtlsClient})
+          dtls(Dtls{isDtlsClient}),
+          sdesKeys(sdesKeys),
+          srtpMode(srtpMode)
     {
     }
 
-    TransportDescription(const transport::SocketAddress& localPeer, const bool isDtlsClient)
+    TransportDescription(const transport::SocketAddress& localPeer,
+        const bool isDtlsClient,
+        const std::vector<srtp::AesKey>& sdesKeys,
+        srtp::Mode srtpMode)
         : localPeer(localPeer),
-          dtls(Dtls{isDtlsClient})
+          dtls(Dtls{isDtlsClient}),
+          sdesKeys(sdesKeys),
+          srtpMode(srtpMode)
     {
     }
 
-    TransportDescription(const transport::SocketAddress& localPeer) : localPeer(localPeer) {}
+    TransportDescription(const transport::SocketAddress& localPeer,
+        const std::vector<srtp::AesKey>& sdesKeys,
+        srtp::Mode srtpMode)
+        : localPeer(localPeer),
+          sdesKeys(sdesKeys),
+          srtpMode(srtpMode)
+    {
+    }
 
     utils::Optional<Ice> ice;
     utils::Optional<transport::SocketAddress> localPeer;
-    utils::Optional<Dtls> dtls;
+    Dtls dtls;
+    std::vector<srtp::AesKey> sdesKeys;
+    srtp::Mode srtpMode;
 };
 
 } // namespace bridge

--- a/bridge/VideoStream.h
+++ b/bridge/VideoStream.h
@@ -19,7 +19,6 @@ struct VideoStream
         const uint32_t localSsrc,
         std::shared_ptr<transport::RtcTransport>& transport,
         bool ssrcRewrite,
-        bool isDtlsLocalEnabled,
         utils::Optional<uint32_t> idleTimeout)
         : id(id),
           endpointId(endpointId),
@@ -29,7 +28,7 @@ struct VideoStream
           transport(transport),
           markedForDeletion(false),
           ssrcRewrite(ssrcRewrite),
-          isDtlsLocalEnabled(isDtlsLocalEnabled),
+          srtpMode(srtp::Mode::UNDEFINED),
           isConfigured(false),
           idleTimeoutSeconds(idleTimeout.isSet() ? idleTimeout.get() : 0)
     {
@@ -50,7 +49,7 @@ struct VideoStream
 
     bool markedForDeletion;
     const bool ssrcRewrite;
-    const bool isDtlsLocalEnabled;
+    srtp::Mode srtpMode;
     bool isConfigured;
     const uint32_t idleTimeoutSeconds;
 };

--- a/bridge/endpointActions/ApiActions.h
+++ b/bridge/endpointActions/ApiActions.h
@@ -24,6 +24,12 @@ httpd::Response processEndpointPostRequest(ActionContext* context,
     const std::string& conferenceId,
     const std::string& endpointId);
 
+httpd::Response processEndpointPutRequest(ActionContext* context,
+    RequestLogger& requestLogger,
+    const httpd::Request& request,
+    const std::string& conferenceId,
+    const std::string& endpointId);
+
 httpd::Response getConferenceInfo(ActionContext*,
     RequestLogger&,
     const httpd::Request&,
@@ -41,6 +47,12 @@ httpd::Response handleAbout(ActionContext*,
 httpd::Response processBarbellAction(ActionContext*,
     RequestLogger&,
     const httpd::Request&,
+    const std::string& conferenceId,
+    const std::string& barbellId);
+
+httpd::Response processBarbellPutAction(ActionContext* context,
+    RequestLogger& requestLogger,
+    const httpd::Request& request,
     const std::string& conferenceId,
     const std::string& barbellId);
 

--- a/doc/api/READMEapi.md
+++ b/doc/api/READMEapi.md
@@ -1,0 +1,903 @@
+# API description
+
+This document lists SMB supported requests and responses in a pseudo request example form. Types are either specified in the document or implicit from the example value.
+
+## Allocate conference
+
+Allocate a new conference resource, responds with conference id for the allocated resource.
+
+Normally, SMB will use a shared UDP port for all conferences that all clients connect to. It will then de-multiplex using ICE ufrag and source IP:port. By setting global-port to false, conference will allocate its own port for the conference. All clients will connect to that port instead, for this conference. If global-port is not set, it will default to true.
+
+```json
+POST /conferences/
+{
+    "last-n": Integer,
+    "global-port": Boolean
+}
+```
+
+```json
+200 OK
+{
+    "id": String
+}
+```
+
+## Allocate endpoint with bundled transport
+
+Allocate a new endpoint with endpoint id {endpointId} in the conference {conferenceId}. Responds with information used to construct an SDP offer.
+
+The idleTimeout is optional timeout in seconds. If no packets have been received during this period, the endpoint will be removed.
+
+Relay-type is how SMB will relay the incoming packets. For audio it may be mixed into 1 ssrc. It may be forwarded from the sender by preserving the original ssrc (forwarder). The preferred mode is ssrc-rewrite. SMB will then relay the packets by mapping the ssrcs to a fixed set of outbound ssrcs. This allows fewer ssrcs to be negotiated and will cause fewer streams to be forwarded. It also prevents re-negotiations that would otherwise happen when people join and leave the conference as ssrcs would be added and removed at that time. Clients are also likely to be limited in how many audio sinks and video sinks they can handle. With ssrc-rewrite the conference can be very large.
+
+**Note** that both DTLS and SDES can be enabled in the allocate request. DTLS and SDES will be prepared and put in offer. The configure request will decide which SRTP mode will be used. DTLS is a requirement for data channel as SCTP is enveloped in DTLS messages.
+**Note** that ICE is mandatory for bundled transport.
+
+```json
+POST /conferences/{conferenceId}/{endpointId}
+{
+    "action": "allocate",
+    "bundle-transport": {
+        "ice-controlling": Boolean,
+        "ice": true,
+        "dtls": boolean,
+        "sdes": boolean
+        },
+    "audio": {
+        "relay-type": ["forwarder | mixed | ssrc-rewrite"]
+        },
+    "video": {
+        "relay-type": "forwarder | ssrc-rewrite"
+        },
+    "data": {},
+    "idleTimeout": <90> // seconds
+}
+```
+
+```json
+200 OK
+{
+    "bundle-transport": {
+        "dtls": {
+            "setup": "actpass",
+            "type": "sha-256",
+            "hash": String
+        },
+        "sdes":[ // omitted if dtls is used
+            {
+                "profile": "AES_128_CM_HMAC_SHA1_80",
+                "key": "SGVsbG8gYmFzZTY0IHdvcmxkIQ=="
+            },
+            {
+                "profile": "AES_256_CM_HMAC_SHA1_80",
+                "key" : "SGVsbG8gYmFzZTY0IHdvcmxkIQ=="
+            }],
+        "ice": {
+            "ufrag": String,
+            "pwd": String,
+            "candidates": [
+                {
+                    "foundation": String,
+                    "component": Integer,
+                    "protocol": String,
+                    "priority": Long,
+                    "ip": String,
+                    "port": Integer,
+                    "type": String,
+                    "generation": Integer,
+                    "network": Integer
+                }
+            ]
+        }
+    },
+    "audio": {
+        "payload-type": {
+            "id": 111,
+            "parameters": {
+                "minptime": "10",
+                "useinbandfec": "1"
+            },
+            "rtcp-fbs": [],
+            "name": "opus",
+            "clockrate": 48000,
+            "channels": 2
+        },
+        "ssrcs": [int, int],
+        "rtp-hdrexts": [
+            {
+                "id": 1,
+                "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+            },
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
+        ]
+    },
+    "video": {
+        "payload-types": [
+            {
+                "id": 100,
+                "parameters": {},
+                "rtcp-fbs": [
+                    {
+                        "type": "goog-remb"
+                    },
+                    {
+                        "type": "nack"
+                    },
+                    {
+                        "type": "nack",
+                        "subtype": "pli"
+                    }
+                ],
+                "name": "VP8",
+                "clockrate": 90000
+            },
+            {
+                "id": 96,
+                "parameters": {
+                    "apt": "100"
+                },
+                "rtcp-fbs": [],
+                "name": "rtx",
+                "clockrate": 90000
+            }
+        ],
+        "streams": [
+            {
+                "sources": [
+                    {
+                        "main": Integer,
+                        "feedback": Integer
+                    }
+                ],
+                "id": "Nuxr31v1qPvNIGkNDBvEar2FX298cQHO6jmi",
+                "content": "video|slides|local"
+            }
+        ],
+        "rtp-hdrexts": [
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            },
+            {
+                "id": 4,
+                "uri": "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+            }
+        ]
+    },
+    "data": {
+        "port": 5000
+    }
+}
+```
+
+_SRTP profiles_
+
+```
+AES_128_CM_HMAC_SHA1_80
+AES_128_CM_HMAC_SHA1_32
+AES_192_CM_HMAC_SHA1_80
+AES_192_CM_HMAC_SHA1_32
+AES_256_CM_HMAC_SHA1_80
+AES_256_CM_HMAC_SHA1_32
+AEAD_AES_128_GCM
+AEAD_AES_256_GCM
+```
+
+### Allocate endpoint without bundle transport
+
+You can allocate and endpoint with separate transport for audio and video. This means there will be multiple ports used and any ICE and DTLS will be established independently.
+ICE is optional and if disabled, a fixed port will be allocated and configured public IP will be presented.
+DTLS and SDES are also optional and thus the encryption can be disabled altogether
+
+```json
+POST /conferences/{conferenceId}/{endpointId}
+{
+    "action": "allocate",
+    "audio": {
+        "relay-type": [
+            "forwarder | mixed | ssrc-rewrite"
+        ],
+        "transport": {
+            "ice": false,
+            "dtls": false,
+            "sdes": true
+        },
+    },
+    "data": {},
+    "idleTimeout": <90> // seconds
+}
+```
+
+```json
+200 OK
+{
+    "audio": {
+        "payload-type": {
+            "id": 111,
+            "parameters": {
+                "minptime": "10",
+                "useinbandfec": "1"
+            },
+            "rtcp-fbs": [],
+            "name": "opus",
+            "clockrate": 48000,
+            "channels": 2
+        },
+        "ssrcs": [int, int
+        ],
+        "rtp-hdrexts": [
+            {
+                "id": 1,
+                "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+            },
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
+        ]
+        "transport": {
+            "sdes": [
+                {
+                    "profile": "AES_128_CM_HMAC_SHA1_80",
+                    "key": "SGVsbG8gYmFzZTY0IHdvcmxkIQ=="
+                },
+                {
+                    "profile": "AES_256_CM_HMAC_SHA1_80",
+                    "key": "SGVsbG8gYmFzZTY0IHdvcmxkIQ=="
+                }
+            ],
+            "connection":{
+                "port":32467,
+                "ip":"203.14.54.111"
+            }
+        },
+    }
+}
+```
+
+## Configure endpoint
+
+Configure endpoint id {endpointId} in the conference {conferenceId} based on information from the initial SDP answer from the endpoint.
+
+```json
+PUT /conferences/{conferenceId}/{endpointId}
+{
+    "action": "configure",
+    "bundle-transport": {
+        "dtls": {
+            "setup": [
+                "active | passive"
+            ],
+            "type": String,
+            "hash": String
+        },
+        "sdes":{ // omit if dtls is used
+            "profile": "AES_128_CM_HMAC_SHA1_80",
+            "key": "SGVsbG8gYmFzZTY0IHdvcmxkIQ=="
+        },
+        "ice": {
+            "ufrag": String,
+            "pwd": String,
+            "candidates": [
+                {
+                    "foundation": String,
+                    "component": Integer,
+                    "protocol": String,
+                    "priority": Long,
+                    "ip": String,
+                    "port": Integer,
+                    "type": String,
+                    "generation": Integer,
+                    "network": Integer
+                }
+            ]
+        }
+    },
+    "audio": {
+        "payload-type": {
+            "id": 111,
+            "parameters": {
+                "minptime": "10",
+                "useinbandfec": "1"
+            },
+            "rtcp-fbs": [],
+            "name": "opus",
+            "clockrate": 48000,
+            "channels": 2
+        },
+        "ssrcs": [Integer, ...],
+        "rtp-hdrexts": [
+            {
+                "id": 1,
+                "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+            },
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
+        ]
+    },
+    "video": {
+        "payload-types": [
+            {
+                "id": 100,
+                "parameters": {},
+                "rtcp-fbs": [
+                    {
+                        "type": "goog-remb"
+                    },
+                    {
+                        "type": "nack"
+                    },
+                    {
+                        "type": "nack",
+                        "subtype": "pli"
+                    }
+                ],
+                "name": "VP8",
+                "clockrate": 90000
+            },
+            {
+                "id": 96,
+                "parameters": {
+                    "apt": "100"
+                },
+                "rtcp-fbs": [],
+                "name": "rtx",
+                "clockrate": 90000
+            }
+        ],
+        "streams": [
+            {
+                "sources": [
+                    {
+                        "main": 1234,
+                        "feedback": 4321
+                    }
+                ],
+                "id": "Nuxr31v1qPvNIGkNDBvEar2FX298cQHO6jmi",
+                "content": "video|slides|local"
+            }
+        ],
+        "rtp-hdrexts": [
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            },
+            {
+                "id": 4,
+                "uri": "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+            }
+        ]
+    },
+    "data": {
+        "port": 5000
+    },
+    "neighbours": {
+        "groups": [
+            "group1",
+            "12345"
+        ]
+    }
+}
+```
+
+```json
+200 OK
+{
+    // same body as for allocate
+}
+```
+
+## Reconfigure endpoint
+
+Reconfigure endpoint id {endpointId} in the conference {conferenceId} adding or removing ssrcs sent from that endpoint.
+
+```json
+PUT /conferences/{conferenceId}/{endpointId}
+{
+    "action": "reconfigure",
+    "audio": {
+        "ssrcs": [Integer...]
+    },
+    "video": {
+        "streams": [
+            {
+                "sources": [
+                    {
+                        "main": 1234,
+                        "feedback": 4321
+                    }
+                ],
+                "id": "Nuxr31v1qPvNIGkNDBvEar2FX298cQHO6jmi",
+                "content": "video|slides|local"
+            }
+        ],
+    }
+}
+```
+
+```json
+200 OK
+```
+
+## Remove endpoint
+
+Delete an endpoint id {endpointId} in the conference {conferenceId}.
+
+```json
+DELETE /conferences/{conferenceId}/{endpointId}
+```
+
+```json
+200 OK
+```
+
+_Deprecated API_
+
+```json
+POST /conferences/{conferenceId}/{endpointId}
+{
+"action": "expire"
+}
+```
+
+```json
+200 OK
+```
+
+## Allocate barbell leg
+
+A 2-way barbell leg can be setup between two SMBs. This can be used to create larger conference or multi location conference to facilitate lower delay on average. There is an allocation step, and a configuration step in the same manner as for channels. There is a small difference between endpoint allocation when it comes to video. An endpoint will only receive a selected video stream per participant and an rtc feedback stream in addition to that. The barbell endpoint can receive multicast and RTX for the participants. The dominant speaker may send low, medium and high res video streams. The others may send medium and low resolution to allow the receiving SMB to select lower resolution in case the clients' downlinks are limited.
+
+**Barbells have mandatory DTLS based SRTP**
+
+Allocate a {barbell port} in the conference {conferenceId}.
+
+```json
+POST /barbell/{conferenceId}/{barbellId}
+{
+    "action": "allocate",
+    "bundle-transport": {
+        "ice-controlling": Boolean
+    }
+}
+```
+
+```json
+200 OK
+{
+    "bundle-transport": {
+        "dtls": {
+            "setup": "actpass",
+            "type": "sha-256",
+            "hash": String
+        },
+        "ice": {
+            "ufrag": String,
+            "pwd": String,
+            "candidates": [
+                {
+                    "foundation": String,
+                    "component": Integer,
+                    "protocol": String,
+                    "priority": Long,
+                    "ip": String,
+                    "port": Integer,
+                    "type": String,
+                    "generation": Integer,
+                    "network": Integer
+                }
+            ]
+        }
+    },
+    "audio": {
+        "payload-type": {
+            "id": 111,
+            "parameters": {
+                "minptime": "10",
+                "useinbandfec": "1"
+            },
+            "rtcp-fbs": [],
+            "name": "opus",
+            "clockrate": 48000,
+            "channels": 2
+        },
+        "ssrcs": [Integer, ...],
+        "rtp-hdrexts": [
+            {
+                "id": 1,
+                "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+            },
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
+        ]
+    },
+    "video": {
+        "payload-types": [
+            {
+                "id": 100,
+                "parameters": {},
+                "rtcp-fbs": [
+                    {
+                        "type": "goog-remb"
+                    },
+                    {
+                        "type": "nack"
+                    },
+                    {
+                        "type": "nack",
+                        "subtype": "pli"
+                    }
+                ],
+                "name": "VP8",
+                "clockrate": 90000
+            },
+            {
+                "id": 96,
+                "parameters": {
+                    "apt": "100"
+                },
+                "rtcp-fbs": [],
+                "name": "rtx",
+                "clockrate": 90000
+            }
+        ],
+        "streams": [
+            {
+                "sources": [
+                    {
+                        "main": 1234,
+                        "feedback": 4321
+                    }
+                ],
+                "id": "Nuxr31v1qPvNIGkNDBvEar2FX298cQHO6jmi",
+                "content": "video|slides|local"
+            }
+        ],
+        "rtp-hdrexts": [
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            },
+            {
+                "id": 4,
+                "uri": "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+            }
+        ]
+    },
+    "data": {
+        "port": 5000
+    }
+}
+```
+
+## Remove Barbell
+
+Remove {barbellId} from the conference {conferenceId}.
+
+```json
+DELETE /barbell/{conferenceId}/{barbellId}
+```
+
+```json
+200 OK
+```
+
+## Configure barbell
+
+Configure barbell {barbellId} in the conference {conferenceId} based on information from the initial SDP answer from the barbell allocation.
+
+```json
+PUT /barbell/{conferenceId}/{barbellId}
+{
+    "action": "configure",
+    "bundle-transport": {
+        "dtls": {
+            "setup": "active | passive",
+            "type": String,
+            "hash": String
+        },
+        "ice": {
+            "ufrag": String,
+            "pwd": String,
+            "candidates": [
+                {
+                    "foundation": String,
+                    "component": Integer,
+                    "protocol": String,
+                    "priority": Long,
+                    "ip": String,
+                    "port": Integer,
+                    "type": String,
+                    "generation": Integer,
+                    "network": Integer
+                }
+            ]
+        }
+    },
+    "audio": {
+        "payload-type": {
+            "id": 111,
+            "parameters": {
+                "minptime": "10",
+                "useinbandfec": "1"
+            },
+            "rtcp-fbs": [],
+            "name": "opus",
+            "clockrate": 48000,
+            "channels": 2
+        },
+        "ssrcs": [Integer,...],
+        "rtp-hdrexts": [
+            {
+                "id": 1,
+                "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+            },
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
+        ]
+    },
+    "video": {
+        "payload-types": [
+            {
+                "id": 100,
+                "parameters": {},
+                "rtcp-fbs": [
+                    {
+                        "type": "goog-remb"
+                    },
+                    {
+                        "type": "nack"
+                    },
+                    {
+                        "type": "nack",
+                        "subtype": "pli"
+                    }
+                ],
+                "name": "VP8",
+                "clockrate": 90000
+            },
+            {
+                "id": 96,
+                "parameters": {
+                    "apt": "100"
+                },
+                "rtcp-fbs": [],
+                "name": "rtx",
+                "clockrate": 90000
+            }
+        ],
+        "streams": [
+            {
+                "sources": [
+                    {
+                        "main": 1234,
+                        "feedback": 4321
+                    }
+                ],
+                "id": "Nuxr31v1qPvNIGkNDBvEar2FX298cQHO6jmi",
+                "content": "video|slides|local"
+            }
+        ],
+        "rtp-hdrexts": [
+            {
+                "id": 3,
+                "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            },
+            {
+                "id": 4,
+                "uri": "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+            }
+        ]
+    },
+    "data": {
+        "port": 5000
+    }
+}
+```
+
+```json
+200 OK
+```
+
+## Monitor Conferences
+
+### Get Conference List
+
+You can use the following url to get a json array of currently instantiated conferenceIds.
+
+```json
+GET /conferences
+```
+
+```json
+200 OK
+["9465082961911005170","9465082961917344970"]
+```
+
+### Get Users List
+
+Use this URL to retrieve a full list of conference ids and user ids in all conferences.
+
+```json
+GET /conferences?brief
+```
+
+```json
+200 OK
+[
+    {
+        "id": "9465082961911005170",
+        "usercount": 3,
+        "users": [
+            "fc2bdae4-d490-5613-6055-00009dbc0e97",
+            "af3928b1-bfd5-3f7a-7e57-000011448e16",
+            "296098e6-f455-978b-283a-0000e806f078"
+        ]
+    }
+]
+```
+
+### Get Detailed info
+
+Retrieves the list of participants' endpoints in the conference {conferenceId}. Responds with basic information for each endpoint, such as: presence of audio and video streams, "Active Speaker" flag, use of recording, whether bundled transport is in use, ICE and DTLS status.
+
+```json
+GET /conferences/{conferenceId}
+```
+
+```json
+200 OK
+[
+    {
+        "dtlsState": string ,
+        "iceState": string ,
+        "id": string ,
+        "isActiveTalker": bool,
+        "isDominantSpeaker": bool,
+        "ActiveTalker": optional, present only when 'isActiveTalker' is 'true'
+    {
+            "noiseLevel": integer
+    "ptt": bool
+    "score": integer
+        }
+    },
+    {
+    ...
+    },
+    ...
+]
+```
+
+_DTLS States_
+
+-   "IDLE"
+-   "READY"
+-   "CONNECTING"
+-   "CONNECTED"
+-   "FAILED"
+
+_ICE States_
+
+-   "IDLE"
+-   "GATHERING"
+-   "READY"
+-   "CONNECTING"
+-   "CONNECTED"
+-   "FAILED"
+
+### Retrieve Metrics
+
+SMB produces useful metrics about the CPU and network load. Bit rates are in kbps. Below is a list of a few selected metrics that need more detailed description.
+
+-   **inbound_audio_streams** is number of streams with apparent RTP activity.
+-   **inbound_video_streams** is number of streams with apparent activity. Note that clients may send 3 streams each to SMB.
+-   **bwe_download_hist** is histogram of number of calls that falls into estimated bandwidth buckets for the clients´ bandwidth when sending to SMB. The buckets are: [125, 250, 500, 1000, 2000, 4000, 8000, 16000, 32000, >32000] kbps.
+-   **loss_download_hist** is histogram for number of calls with certain average loss rate when sending to SMB. The buckets are [0,1,2,4,8, 100] percent.
+-   **loss_upload_hist** histogram works the same but is based on loss reports from the clients.
+-   **rtt_download_hist** is a histogram for number of calls with specific RTT. The buckets are: [0.1, 0.2, 0.4, 0.8, 1.6, >1.6] seconds.
+-   **pacing_queue** is a queue used to pace video packets to adapt rate to the client`s receive bandwidth. This avoids choking the network and packets can be dropped in SMB instead of causing high latency towards client. If this runs high it means clients have network trouble and video will not be of good quality.
+-   **rtx_pacing_queue** is a parallell pacing queue that allows video RTX requests to be prioritized.
+
+```json
+GET /stats
+```
+
+```json
+{
+    "audiochannels": 0,
+    "bit_rate_download": 0,
+    "bit_rate_upload": 0,
+    "bwe_download_hist": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "conferences": 0,
+    "cpu_engine": 0.0,
+    "cpu_manager": 0.0,
+    "cpu_rtce": 0.0,
+    "cpu_usage": 0.006067961165048544,
+    "cpu_workers": 0.0027739251040221915,
+    "current_timestamp": 66218305,
+    "engine_slips": 1,
+    "http_tcp_connections": 1,
+    "inbound_audio_ext_streams": 0,
+    "inbound_audio_streams": 0,
+    "inbound_video_streams": 0,
+    "job_queue": 0,
+    "largestConference": 0,
+    "loss_download": 0.0,
+    "loss_download_hist": [0, 0, 0, 0, 0, 0],
+    "loss_upload": 0.0,
+    "loss_upload_hist": [0, 0, 0, 0, 0, 0],
+    "opus_decode_packet_rate": 0.0,
+    "outbound_audio_streams": 0,
+    "outbound_video_streams": 0,
+    "pacing_queue": 0,
+    "packet_rate_download": 0,
+    "packet_rate_upload": 0,
+    "participants": 0,
+    "receive_pool": 32768,
+    "rtc_tcp4_connections": 0,
+    "rtc_tcp6_connections": 0,
+    "rtt_download_hist": [0, 0, 0, 0, 0, 0],
+    "rtx_pacing_queue": 0,
+    "send_pool": 131072,
+    "shared_udp_end_drops": 0,
+    "shared_udp_receive_rate": 0,
+    "shared_udp_send_queue": 0,
+    "shared_udp_send_rate": 0,
+    "threads": 20,
+    "total_memory": 1622616,
+    "total_tcp_connections": 1,
+    "total_udp_connections": 4,
+    "used_memory": 336120,
+    "videochannels": 0
+}
+```
+
+## ICE probe endpoint
+
+ICE can be used to assess RTT to a mediabridge. For this purpose, there is a static ICE endpoint that can be used to measure RTT but cannot be used to establish media sessions. Use the following endpoint to get the info needed to setup such an ICE connection.
+
+```json
+GET /ice-candidates
+```
+
+```json
+200 OK
+{
+    "candidates": [
+        {
+            "component": 1,
+            "foundation": "870038700640",
+            "generation": 0,
+            "ip": "10.0.1.90",
+            "network": 1,
+            "port": 10000,
+            "priority": 142541055,
+            "protocol": "udp",
+            "type": "host"
+        },
+        {
+            "component": 1,
+            "foundation": "535128690992",
+            "generation": 0,
+            "ip": "82.29.139.91",
+            "network": 1,
+            "port": 10000,
+            "priority": 142540799,
+            "protocol": "udp",
+            "type": "srflx"
+        }
+    ],
+    "pwd": "QKvUzTxXHaa4RqzS0QBLFGoJ",
+    "ufrag": "y2uBVS3RATC4Sd"
+}
+```

--- a/docker/ubuntu-focal-deb/Dockerfile
+++ b/docker/ubuntu-focal-deb/Dockerfile
@@ -4,4 +4,4 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update
 
-RUN apt-get -y install llvm git wget cmake libc++-dev libc++abi-dev clang libtool lcov libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev zip
+RUN apt-get -y install llvm git wget cmake libc++-dev libc++abi-dev clang lld libtool lcov libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev zip

--- a/test/bridge/DummyRtcTransport.h
+++ b/test/bridge/DummyRtcTransport.h
@@ -33,12 +33,12 @@ public:
     }
     void addRemoteIceCandidate(const ice::IceCandidate& candidate) override {}
 
-    void setRemoteDtlsFingerprint(const std::string& fingerprintType,
+    void asyncSetRemoteDtlsFingerprint(const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool dtlsClientSide) override
     {
     }
-    void disableDtls() override{};
+    void asyncDisableSrtp() override{};
     transport::SocketAddress getLocalRtpPort() const override { return transport::SocketAddress(); }
     void setSctp(uint16_t localPort, uint16_t remotePort) override {}
     void connectSctp() override {}
@@ -49,7 +49,7 @@ public:
     void setAbsSendTimeExtensionId(uint8_t extensionId) override {}
     bool start() override { return true; }
     bool isIceEnabled() const override { return true; }
-    bool isDtlsEnabled() const override { return true; }
+
     void connect() override {}
     void runTick(uint64_t timestamp) override {}
     jobmanager::JobQueue& getJobQueue() override { return _jobQueue; }
@@ -106,6 +106,8 @@ public:
     const char* getTag() const override { return nullptr; };
 
     uint64_t getLastReceivedPacketTimestamp() const override { return 0; }
+    void getSdesKeys(std::vector<srtp::AesKey>& sdesKeys) const override {}
+    void asyncSetRemoteSdesKey(const srtp::AesKey& key) override {}
 
     logger::LoggableId _loggableId;
     size_t _endpointIdHash;

--- a/test/include/mocks/RtcTransportMock.h
+++ b/test/include/mocks/RtcTransportMock.h
@@ -28,11 +28,11 @@ class RtcTransportMock : public TransportMock<transport::RtcTransport>
     MOCK_METHOD(void, addRemoteIceCandidate, (const ice::IceCandidate& candidate), (override));
 
     MOCK_METHOD(void,
-        setRemoteDtlsFingerprint,
+        asyncSetRemoteDtlsFingerprint,
         (const std::string& fingerprintType, const std::string& fingerprintHash, const bool dtlsClientSide),
         (override));
 
-    MOCK_METHOD(void, disableDtls, (), (override));
+    MOCK_METHOD(void, asyncDisableSrtp, (), (override));
     MOCK_METHOD(transport::SocketAddress, getLocalRtpPort, (), (const override));
     MOCK_METHOD(void, setSctp, (uint16_t localPort, uint16_t remotePort), (override));
     MOCK_METHOD(void, connectSctp, (), (override));
@@ -89,6 +89,9 @@ class RtcTransportMock : public TransportMock<transport::RtcTransport>
         (override));
 
     MOCK_METHOD(uint16_t, allocateOutboundSctpStream, (), (override));
+
+    MOCK_METHOD(void, getSdesKeys, (std::vector<srtp::AesKey> & sdesKeys), (const override));
+    MOCK_METHOD(void, asyncSetRemoteSdesKey, (const srtp::AesKey& key), (override));
 };
 
 } // namespace test

--- a/test/integration/ConfIntegrationTest.cpp
+++ b/test/integration/ConfIntegrationTest.cpp
@@ -61,10 +61,12 @@ TEST_F(IntegrationTest, plain)
         startSimulation();
 
         group.startConference(conf, baseUrl + "/colibri");
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false);
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -157,8 +159,11 @@ TEST_F(IntegrationTest, twoClientsAudioOnly)
 
         group.startConference(conf, baseUrl + "/colibri");
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, false, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, true);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).withOpus();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -233,10 +238,14 @@ TEST_F(IntegrationTest, audioOnlyNoPadding)
         group.startConference(conf, baseUrl + "/colibri");
 
         printf("T%" PRIu64 " calling\n", (utils::Time::rawAbsoluteTime() / utils::Time::ms) & 0xFFFF);
+
+        CallConfigBuilder callConfig(conf.getId());
+        callConfig.withOpus().mixed().url(baseUrl);
+
         // Audio only for all three participants.
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, false, false);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, false);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, false);
+        group.clients[0]->initiateCall(callConfig.build());
+        group.clients[1]->joinCall(callConfig.build());
+        group.clients[2]->joinCall(callConfig.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -291,16 +300,13 @@ TEST_F(IntegrationTest, paddingOffWhenRtxNotProvided)
 
         using RtpVideoReceiver = typename SfuClient<ColibriChannel>::RtpVideoReceiver;
 
-        AnswerOptions answerOptionNoRtx;
-        answerOptionNoRtx.rtxDisabled = true;
-
-        group.clients[0]->_channel.setAnswerOptions(answerOptionNoRtx);
-        group.clients[1]->_channel.setAnswerOptions(answerOptionNoRtx);
+        emulator::CallConfigBuilder config(conf.getId());
+        config.withOpus().withVideo().disableRtx().url(baseUrl);
 
         // Audio only for all three participants.
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        group.clients[0]->initiateCall(config.build());
+        group.clients[1]->joinCall(config.build());
+        group.clients[2]->joinCall(config.enableRtx().build());
 
         auto connectResult = group.connectAll(utils::Time::sec * _clientsConnectionTimeout);
         EXPECT_TRUE(connectResult);
@@ -407,9 +413,12 @@ TEST_F(IntegrationTest, videoOffPaddingOff)
 
         group.startConference(conf, baseUrl + "/colibri");
 
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
         // Audio only for all three participants.
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
         // Client 3 will join after client 2, which produce video, will leave.
 
         if (!group.connectAll(utils::Time::sec * _clientsConnectionTimeout))
@@ -449,7 +458,7 @@ TEST_F(IntegrationTest, videoOffPaddingOff)
         }
 
         group.add(_httpd);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        group.clients[2]->joinCall(cfg.build());
         ASSERT_TRUE(group.connectSingle(2, utils::Time::sec * 4));
 
         group.clients[2]->_audioSource->setFrequency(2100);
@@ -507,9 +516,12 @@ TEST_F(IntegrationTest, plainNewApi)
 
         group.startConference(conf, baseUrl);
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -598,10 +610,12 @@ TEST_F(IntegrationTest, ptime10)
         startSimulation();
 
         group.startConference(conf, baseUrl);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false);
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -684,9 +698,12 @@ TEST_F(IntegrationTest, detectIsPtt)
 
         group.startConference(conf, baseUrl);
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.build());
 
         auto connectResult = group.connectAll(utils::Time::sec * _clientsConnectionTimeout);
         ASSERT_TRUE(connectResult);
@@ -860,8 +877,11 @@ TEST_F(IntegrationTest, packetLossVideoRecoveredViaNack)
 
         group.startConference(conf, baseUrl + "/colibri");
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -949,9 +969,12 @@ TEST_F(IntegrationTest, endpointAutoRemove)
         Conference conf(_httpd);
         group.startConference(conf, baseUrl + "/colibri");
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true, 0);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true, 10);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true, 10);
+        CallConfigBuilder cfgBuilder(conf.getId());
+        cfgBuilder.url(baseUrl).withOpus().withVideo();
+
+        group.clients[0]->initiateCall(cfgBuilder.build());
+        group.clients[1]->joinCall(cfgBuilder.idleTimeout(10).build());
+        group.clients[2]->joinCall(cfgBuilder.idleTimeout(10).build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -1065,9 +1088,12 @@ TEST_F(IntegrationTest, conferencePort)
 
         group.startConference(conf, baseUrl, false);
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -1160,12 +1186,17 @@ TEST_F(IntegrationTest, neighbours)
         group.startConference(conf, baseUrl);
 
         std::string neighbours[] = {"gid1"};
-        utils::Span<std::string> span(neighbours);
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall2(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true, span);
-        group.clients[2]->initiateCall2(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true, span);
 
-        group.clients[3]->initiateCall2(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false, span);
+        CallConfigBuilder cfgBuilder(conf.getId());
+        cfgBuilder.url(baseUrl).withOpus().withVideo();
+
+        CallConfigBuilder cfgNeighbours(cfgBuilder);
+        cfgNeighbours.neighbours(utils::Span<std::string>(neighbours));
+
+        group.clients[0]->initiateCall(cfgBuilder.build());
+        group.clients[1]->joinCall(cfgNeighbours.build());
+        group.clients[2]->joinCall(cfgNeighbours.build());
+        group.clients[3]->joinCall(cfgNeighbours.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -1259,8 +1290,11 @@ TEST_F(IntegrationTest, endpointMessage)
 
         group.startConference(conf, baseUrl);
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -1330,9 +1364,12 @@ TEST_F(IntegrationTest, noAudioLevelExt)
 
         group.startConference(conf, baseUrl);
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, false, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, true);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).withOpus();
+
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
         group.clients[2]->_audioSource->setUseAudioLevel(false);
@@ -1402,10 +1439,12 @@ TEST_F(IntegrationTest, confList)
         startSimulation();
 
         group.startConference(conf, baseUrl);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).av();
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, true, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, true, false);
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.mixed().build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
 
@@ -1531,10 +1570,12 @@ TEST_F(IntegrationTest, opusDecodeRate)
         startSimulation();
 
         group.startConference(conf, baseUrl);
+        CallConfigBuilder cfg(conf.getId());
+        cfg.url(baseUrl).withOpus();
 
-        group.clients[0]->initiateCall(baseUrl, conf.getId(), true, emulator::Audio::Opus, false, true);
-        group.clients[1]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, true);
-        group.clients[2]->initiateCall(baseUrl, conf.getId(), false, emulator::Audio::Opus, false, true);
+        group.clients[0]->initiateCall(cfg.build());
+        group.clients[1]->joinCall(cfg.build());
+        group.clients[2]->joinCall(cfg.build());
 
         ASSERT_TRUE(group.connectAll(utils::Time::sec * _clientsConnectionTimeout));
         group.clients[0]->_audioSource->setUseAudioLevel(false);

--- a/test/integration/emulator/CallConfigBuilder.h
+++ b/test/integration/emulator/CallConfigBuilder.h
@@ -1,0 +1,145 @@
+#pragma once
+#include "api/RtcDescriptors.h"
+#include "test/integration/emulator/AudioSource.h"
+#include "utils/Span.h"
+#include "utils/Time.h"
+#include <vector>
+
+namespace emulator
+{
+struct CallConfig
+{
+    std::string conferenceId;
+    std::string baseUrl;
+    bool dtls = true;
+    bool sdes = false;
+    std::vector<std::string> neighbours;
+    Audio audio = Audio::None;
+    bool video = false;
+    std::string relayType = "ssrc-rewrite";
+    bool rtx = true;
+    uint32_t idleTimeout = 0;
+    uint64_t ipv6CandidateDelay = 0;
+
+    bool hasAudio() const { return audio != Audio::None; }
+};
+
+class CallConfigBuilder
+{
+public:
+    CallConfigBuilder(std::string conferenceId) { _config.conferenceId = conferenceId; }
+
+    CallConfigBuilder& room(const std::string id)
+    {
+        _config.conferenceId = id;
+        return *this;
+    }
+
+    CallConfigBuilder& url(const std::string url)
+    {
+        _config.baseUrl = url;
+        return *this;
+    }
+
+    CallConfigBuilder& disableDtls()
+    {
+        _config.dtls = false;
+        return *this;
+    }
+
+    CallConfigBuilder& sdes()
+    {
+        _config.sdes = true;
+        return *this;
+    }
+
+    CallConfigBuilder& neighbours(const std::vector<std::string>& n)
+    {
+        _config.neighbours.clear();
+        _config.neighbours = n;
+        return *this;
+    }
+
+    CallConfigBuilder& neighbours(const utils::Span<std::string>& groups)
+    {
+        _config.neighbours.clear();
+        for (auto n : groups)
+        {
+            _config.neighbours.push_back(n);
+        }
+        return *this;
+    }
+
+    CallConfigBuilder& av()
+    {
+        _config.audio = Audio::Opus;
+        _config.video = true;
+        return *this;
+    }
+
+    CallConfigBuilder& withAudio()
+    {
+        _config.audio = Audio::Fake;
+        return *this;
+    }
+
+    CallConfigBuilder& withOpus()
+    {
+        _config.audio = Audio::Opus;
+        return *this;
+    }
+
+    CallConfigBuilder& muted()
+    {
+        _config.audio = Audio::Muted;
+        return *this;
+    }
+
+    CallConfigBuilder& withVideo()
+    {
+        _config.video = true;
+        return *this;
+    }
+
+    CallConfigBuilder& noVideo()
+    {
+        _config.video = false;
+        return *this;
+    }
+
+    CallConfigBuilder& disableRtx()
+    {
+        _config.rtx = false;
+        return *this;
+    }
+
+    CallConfigBuilder& enableRtx()
+    {
+        _config.rtx = true;
+        return *this;
+    }
+
+    CallConfigBuilder& mixed()
+    {
+        _config.relayType = "mixed";
+        return *this;
+    }
+
+    CallConfigBuilder& idleTimeout(uint32_t seconds)
+    {
+        _config.idleTimeout = seconds;
+        return *this;
+    }
+
+    CallConfigBuilder& delayIpv6(uint32_t ms)
+    {
+        _config.ipv6CandidateDelay = ms * utils::Time::ms;
+        return *this;
+    }
+
+    CallConfig build() const { return _config; }
+
+private:
+    CallConfig _config;
+};
+} // namespace emulator

--- a/test/transport/RtcTransportTest.cpp
+++ b/test/transport/RtcTransportTest.cpp
@@ -103,8 +103,8 @@ struct ClientPair : public transport::DataReceiver, public transport::DecryptedP
             _transport2->setRemotePeer(_transport1->getLocalRtpPort());
         }
 
-        _transport1->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
-        _transport2->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
+        _transport1->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
+        _transport2->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
         _transport1->setAbsSendTimeExtensionId(3); // from FakeVideoSource
         _transport2->setAbsSendTimeExtensionId(3);
         _transport1->setAudioPayloadType(_media2.audio.getPayloadType(), 16000);

--- a/test/transport/SctpTest.cpp
+++ b/test/transport/SctpTest.cpp
@@ -84,8 +84,8 @@ struct ClientPair : public transport::DataReceiver
         _transport1->setRemotePeer(_transport2->getLocalRtpPort());
         _transport2->setRemotePeer(_transport1->getLocalRtpPort());
 
-        _transport1->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
-        _transport2->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
+        _transport1->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
+        _transport2->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
 
         _transport1->setSctp(5000, 5001);
         _transport2->setSctp(5001, 5000);

--- a/test/transport/SrtpTest.cpp
+++ b/test/transport/SrtpTest.cpp
@@ -3,6 +3,7 @@
 #include "rtp/RtpHeader.h"
 #include "transport/dtls/DtlsMessageListener.h"
 #include "transport/dtls/SrtpClientFactory.h"
+#include "transport/dtls/SrtpProfiles.h"
 #include "transport/dtls/SslDtls.h"
 #include "transport/dtls/SslWriteBioListener.h"
 #include "utils/Time.h"
@@ -69,9 +70,6 @@ struct SrtpTest : public ::testing::Test, public transport::SrtpClient::IEvents
         _ep1 = std::make_unique<FakeSrtpEndpoint>(*_srtp1, *_srtp2, _allocator);
         _ep2 = std::make_unique<FakeSrtpEndpoint>(*_srtp2, *_srtp1, _allocator);
 
-        _srtp1->setRemoteDtlsFingerprint("sha-256", _dtls->getLocalFingerprint(), true);
-        _srtp2->setRemoteDtlsFingerprint("sha-256", _dtls->getLocalFingerprint(), false);
-
         auto header = rtp::RtpHeader::create(_audioPacket);
         auto payload = header->getPayload();
         for (size_t i = 0; i < _audioPacket.getLength() - header->headerLength(); ++i)
@@ -80,9 +78,25 @@ struct SrtpTest : public ::testing::Test, public transport::SrtpClient::IEvents
         }
     }
 
+    void setupDtls()
+    {
+        _srtp1->setRemoteDtlsFingerprint("sha-256", _dtls->getLocalFingerprint(), true);
+        _srtp2->setRemoteDtlsFingerprint("sha-256", _dtls->getLocalFingerprint(), false);
+    }
+
+    void setupSdes(srtp::Profile profile)
+    {
+        srtp::AesKey key1;
+        srtp::AesKey key2;
+        _srtp1->getLocalKey(profile, key1);
+        _srtp2->getLocalKey(profile, key2);
+        _srtp1->setRemoteKey(key2);
+        _srtp2->setRemoteKey(key1);
+    }
+
     void connect()
     {
-        for (int i = 0; i < 500 && !(_srtp1->isDtlsConnected() && _srtp2->isDtlsConnected()); ++i)
+        for (int i = 0; i < 500 && !(_srtp1->isConnected() && _srtp2->isConnected()); ++i)
         {
             _srtp1->processTimeout();
             _srtp2->processTimeout();
@@ -110,6 +124,22 @@ struct SrtpTest : public ::testing::Test, public transport::SrtpClient::IEvents
         return true;
     }
 
+    bool isAudioPayloadValid(memory::Packet& newPacket) const
+    {
+        auto header = rtp::RtpHeader::fromPacket(_audioPacket);
+        auto payload = header->getPayload();
+
+        auto newPayload = rtp::RtpHeader::fromPacket(newPacket)->getPayload();
+        for (size_t i = 0; i < _audioPacket.getLength() - header->headerLength(); ++i)
+        {
+            if (payload[i] != newPayload[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     std::unique_ptr<transport::SrtpClientFactory> _factory;
     std::unique_ptr<transport::SslDtls> _dtls;
     memory::PacketPoolAllocator _allocator;
@@ -122,6 +152,7 @@ struct SrtpTest : public ::testing::Test, public transport::SrtpClient::IEvents
 
 TEST_F(SrtpTest, seqSkip)
 {
+    setupDtls();
     connect();
 
     uint16_t seqStart = 65530;
@@ -165,6 +196,7 @@ TEST_F(SrtpTest, seqSkip)
 
 TEST_F(SrtpTest, seqDuplicate)
 {
+    setupDtls();
     connect();
 
     auto packet = memory::makeUniquePacket(_allocator, _audioPacket);
@@ -183,6 +215,7 @@ TEST_F(SrtpTest, seqDuplicate)
 
 TEST_F(SrtpTest, sendOutOfOrder)
 {
+    setupDtls();
     connect();
 
     for (int i = 0; i < 50; ++i)
@@ -222,4 +255,25 @@ TEST_F(SrtpTest, sendOutOfOrder)
 
         EXPECT_TRUE(_srtp2->unprotect(*packet));
     }
+}
+
+TEST_F(SrtpTest, sdesSimple)
+{
+    setupSdes(srtp::Profile::AES128_CM_SHA1_80);
+
+    EXPECT_TRUE(_srtp1->isConnected());
+    EXPECT_TRUE(_srtp2->isConnected());
+    auto packet = memory::makeUniquePacket(_allocator, _audioPacket);
+    auto header = rtp::RtpHeader::fromPacket(*packet);
+    header->ssrc = 4321;
+    header->timestamp = 1234;
+    header->sequenceNumber = 5678;
+
+    size_t dataLen = packet->getLength();
+    EXPECT_TRUE(_srtp1->protect(*packet));
+    EXPECT_FALSE(isAudioPayloadValid(*packet));
+    EXPECT_GT(packet->getLength(), dataLen);
+    EXPECT_TRUE(_srtp2->unprotect(*packet));
+    EXPECT_EQ(dataLen, packet->getLength());
+    EXPECT_TRUE(isAudioPayloadValid(*packet));
 }

--- a/test/transport/TransportIntegrationTest.cpp
+++ b/test/transport/TransportIntegrationTest.cpp
@@ -140,7 +140,7 @@ TransportClientPair::TransportClientPair(transport::TransportFactory& transportF
     }
 
     _transport1->setRemoteIce(_transport2->getLocalCredentials(), candidates2, _audioAllocator);
-    _transport1->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
+    _transport1->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), true);
 }
 
 void TransportClientPair::stop()
@@ -188,7 +188,7 @@ int64_t TransportClientPair::tryConnect(const uint64_t timestamp, const transpor
     }
 
     _transport2->setRemoteIce(_transport1->getLocalCredentials(), _candidates1, _audioAllocator);
-    _transport2->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
+    _transport2->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
     _transport2->connect();
     _connectStart = 0;
     return utils::Time::sec;
@@ -209,7 +209,7 @@ int64_t TransportClientPair::tryConnect(const uint64_t timestamp,
     }
 
     _transport2->setRemoteIce(transport1IceCredentials, _candidates1, _audioAllocator);
-    _transport2->setRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
+    _transport2->asyncSetRemoteDtlsFingerprint("sha-256", sslDtls.getLocalFingerprint(), false);
     _transport2->connect();
     _connectStart = 0;
     return utils::Time::sec;

--- a/test/utils/Base64Test.cpp
+++ b/test/utils/Base64Test.cpp
@@ -4,15 +4,8 @@
 TEST(Base64, encode)
 {
     std::string text = "Hello base64 world!";
-    uint8_t result[utils::Base64::encodeLength(text)];
+    std::string strResult = utils::Base64::encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
 
-    utils::Base64::encode(text, result, 28);
-
-    std::string strResult;
-    for (const auto& value : result)
-    {
-        strResult += (char)value;
-    }
     EXPECT_STREQ(strResult.c_str(), "SGVsbG8gYmFzZTY0IHdvcmxkIQ==");
 }
 
@@ -21,7 +14,8 @@ TEST(Base64, decode)
     std::string encoded = "SGVsbG8gYmFzZTY0IHdvcmxkIQ==";
     uint8_t result[utils::Base64::decodeLength(encoded)];
 
-    utils::Base64::decode(encoded, result, 19);
+    auto s = utils::Base64::decode(encoded, result, 19);
+    EXPECT_EQ(s, 19);
 
     std::string strResult;
     for (const auto& value : result)
@@ -38,7 +32,8 @@ TEST(Base64, decodeSaltExample)
 
     uint8_t result[utils::Base64::decodeLength(encoded)];
 
-    utils::Base64::decode(encoded, result, 12);
+    auto s = utils::Base64::decode(encoded, result, 12);
+    EXPECT_EQ(s, 12);
 
     std::string strResult;
     for (const auto& value : result)
@@ -46,4 +41,19 @@ TEST(Base64, decodeSaltExample)
         strResult += (char)value;
     }
     EXPECT_STREQ(strResult.c_str(), "Quid pro quo");
+}
+
+TEST(Base64, transcodeTest)
+{
+    uint8_t data[4096];
+    for (size_t i = 0; i < sizeof(data); ++i)
+    {
+        data[i] = i;
+    }
+
+    std::string encoded = utils::Base64::encode(data, 4096);
+    uint8_t decoded[4096];
+    utils::Base64::decode(encoded, decoded, sizeof(decoded));
+
+    EXPECT_EQ(0, std::memcmp(data, decoded, sizeof(decoded)));
 }

--- a/transport/RtcTransport.h
+++ b/transport/RtcTransport.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dtls/SrtpProfiles.h"
 #include "jobmanager/JobManager.h"
 #include "memory/AudioPacketPoolAllocator.h"
 #include "memory/PacketPoolAllocator.h"
@@ -63,10 +64,10 @@ public:
         const ice::IceCandidates& candidates,
         memory::AudioPacketPoolAllocator& allocator) = 0;
     virtual void addRemoteIceCandidate(const ice::IceCandidate& candidate) = 0;
-    virtual void setRemoteDtlsFingerprint(const std::string& fingerprintType,
+    virtual void asyncSetRemoteDtlsFingerprint(const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool dtlsClientSide) = 0;
-    virtual void disableDtls() = 0;
+    virtual void asyncDisableSrtp() = 0;
     virtual SocketAddress getLocalRtpPort() const = 0;
     virtual void setSctp(uint16_t localPort, uint16_t remotePort) = 0;
     virtual void connectSctp() = 0;
@@ -77,7 +78,6 @@ public:
     virtual void setAbsSendTimeExtensionId(uint8_t extensionId) = 0;
 
     virtual bool isIceEnabled() const = 0;
-    virtual bool isDtlsEnabled() const = 0;
 
     virtual uint32_t getSenderLossCount() const = 0;
     virtual uint32_t getUplinkEstimateKbps() const = 0;
@@ -109,6 +109,8 @@ public:
     virtual const char* getTag() const = 0;
 
     virtual uint64_t getLastReceivedPacketTimestamp() const = 0;
+    virtual void getSdesKeys(std::vector<srtp::AesKey>& sdesKeys) const = 0;
+    virtual void asyncSetRemoteSdesKey(const srtp::AesKey& key) = 0;
 };
 
 std::shared_ptr<RtcTransport> createTransport(jobmanager::JobManager& jobmanager,

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -119,10 +119,10 @@ public: // Transport
         const ice::IceCandidates& candidates,
         memory::AudioPacketPoolAllocator& allocator) override;
     void addRemoteIceCandidate(const ice::IceCandidate& candidate) override;
-    void setRemoteDtlsFingerprint(const std::string& fingerprintType,
+    void asyncSetRemoteDtlsFingerprint(const std::string& fingerprintType,
         const std::string& fingerprintHash,
         const bool dtlsClientSide) override;
-    void disableDtls() override;
+    void asyncDisableSrtp() override;
     SocketAddress getLocalRtpPort() const override;
     /**
      * Called from engine thread.
@@ -148,7 +148,6 @@ public: // Transport
     bool start() override;
 
     bool isIceEnabled() const override { return !!_rtpIceSession; }
-    bool isDtlsEnabled() const override { return _dtlsEnabled; }
 
     void connect() override;
 
@@ -186,6 +185,9 @@ public: // Transport
     const char* getTag() const override { return _tag; };
 
     uint64_t getLastReceivedPacketTimestamp() const override { return _lastReceivedPacketTimestamp; }
+
+    void getSdesKeys(std::vector<srtp::AesKey>& sdesKeys) const override;
+    void asyncSetRemoteSdesKey(const srtp::AesKey& key) override;
 
 private: // SslWriteBioListener
     // Called from Transport serial thread
@@ -343,7 +345,6 @@ private:
     const config::Config& _config;
 
     std::unique_ptr<SrtpClient> _srtpClient;
-    bool _dtlsEnabled;
     std::unique_ptr<ice::IceSession> _rtpIceSession;
 
     Endpoints _rtpEndpoints;

--- a/transport/dtls/SrtpProfiles.cpp
+++ b/transport/dtls/SrtpProfiles.cpp
@@ -1,0 +1,43 @@
+#include "SrtpProfiles.h"
+
+namespace srtp
+{
+uint32_t AesKey::getKeyLength() const
+{
+    switch (profile)
+    {
+    case srtp::Profile::AES128_CM_SHA1_32:
+    case srtp::Profile::AES128_CM_SHA1_80:
+    case srtp::Profile::AEAD_AES_128_GCM:
+        return 16;
+    case srtp::Profile::AES_192_CM_SHA1_32:
+    case srtp::Profile::AES_192_CM_SHA1_80:
+        return 24;
+    case srtp::Profile::AES_256_CM_SHA1_32:
+    case srtp::Profile::AES_256_CM_SHA1_80:
+    case srtp::Profile::AEAD_AES_256_GCM:
+        return 32;
+    default:
+        return 0;
+    }
+}
+
+uint32_t AesKey::getSaltLength() const
+{
+    switch (profile)
+    {
+    case srtp::Profile::AES128_CM_SHA1_32:
+    case srtp::Profile::AES128_CM_SHA1_80:
+    case srtp::Profile::AES_192_CM_SHA1_32:
+    case srtp::Profile::AES_192_CM_SHA1_80:
+    case srtp::Profile::AES_256_CM_SHA1_32:
+    case srtp::Profile::AES_256_CM_SHA1_80:
+        return 14;
+    case srtp::Profile::AEAD_AES_128_GCM:
+    case srtp::Profile::AEAD_AES_256_GCM:
+        return 12;
+    default:
+        return 0;
+    }
+}
+} // namespace srtp

--- a/transport/dtls/SrtpProfiles.h
+++ b/transport/dtls/SrtpProfiles.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <cstdint>
+
+namespace srtp
+{
+enum Profile // ordered after preference
+{
+    NULL_CIPHER = 0,
+    AES128_CM_SHA1_80,
+    AES128_CM_SHA1_32,
+    AES_256_CM_SHA1_80,
+    AES_256_CM_SHA1_32,
+    AES_192_CM_SHA1_80,
+    AES_192_CM_SHA1_32,
+    AEAD_AES_128_GCM,
+    AEAD_AES_256_GCM,
+    PROFILE_LAST
+};
+
+struct AesKey
+{
+    srtp::Profile profile = srtp::Profile::NULL_CIPHER;
+    unsigned char keySalt[46];
+
+    uint32_t getLength() const { return getKeyLength() + getSaltLength(); };
+    uint32_t getKeyLength() const;
+    uint32_t getSaltLength() const;
+};
+
+enum class Mode
+{
+    UNDEFINED = 0,
+    NULL_CIPHER,
+    DTLS,
+    SDES
+};
+
+} // namespace srtp

--- a/utils/Base64.h
+++ b/utils/Base64.h
@@ -7,10 +7,11 @@ namespace utils
 class Base64
 {
 public:
-    static void encode(const std::string& input, uint8_t* output, uint32_t outputLength);
-    static void decode(const std::string& input, uint8_t* output, uint32_t outputLength);
+    static std::string encode(const uint8_t* input, uint32_t inputLength);
+    static size_t decode(const std::string& input, uint8_t* output, uint32_t outputLength);
 
     static uint32_t encodeLength(const std::string& input);
     static uint32_t decodeLength(const std::string& input);
+    static uint32_t encodeLength(uint32_t inputLength);
 };
 } // namespace utils


### PR DESCRIPTION
This enables SRTP using SDES keys in SMB.
Multiple modes can be requested in alloc request.
When transport is configured the decision is made to use either DTLS, SDES, null-cipher. It cannot be changed after that point.