### PR TITLE
Remove configure docker stage in jenkins files

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -36,10 +36,6 @@ node('be-integration') {
             env.VERSION=version
         }
 
-        stage('Configure Docker') {
-            sh "gcloud auth configure-docker gcr.io --quiet"
-        }
-
         docker.image('gcr.io/sym-dev-rtc/buildsmb-el7:latest').inside {
             stage('Build Centos 7') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"

--- a/Jenkins/PRUnitTestRunner.groovy
+++ b/Jenkins/PRUnitTestRunner.groovy
@@ -5,10 +5,6 @@ void prRunner(String cmakeBuildType, String platform, String dockerTag) {
         checkout scm
     }
 
-    stage('Configure Docker') {
-        sh "gcloud auth configure-docker gcr.io --quiet"
-    }
-
     stage("Build\n[$cmakeBuildType $platform]") {
         docker.image("gcr.io/sym-dev-rtc/buildsmb-$platform:$dockerTag").inside {
             env.GIT_COMMITTER_NAME = "Jenkins deployment job"
@@ -32,33 +28,33 @@ void prRunner(String cmakeBuildType, String platform, String dockerTag) {
 }
 
 abortPreviousRunningBuilds()
-
+// TODO: "Change back to be-integration before merge"
 parallel "Release el7": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("Release", "el7", "1f7ef85")
     }
 }, "Release AWS-linux": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("Release", "aws-linux", "latest")
     }
 }, "Release el8": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("Release", "el8", "latest")
     }
 }, "LCheck": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("LCheck", "el8", "latest")
     }
 }, "TCheck": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("TCheck", "el8", "latest")
     }
 }, "DCheck": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("DCheck", "el8", "latest")
     }
 }, "LCov": {
-    node('be-integration') {
+    node('rtc-14160-test')
         try {
             prRunner("LCov", "el8", "latest")
         } finally {
@@ -78,7 +74,7 @@ parallel "Release el7": {
         }
     }
 }, "Release Ubuntu public": {
-    node('be-integration') {
+    node('rtc-14160-test')
         prRunner("Release", "ubuntu-focal-deb", "latest")
     }
 }

--- a/Jenkins/PRUnitTestRunner.groovy
+++ b/Jenkins/PRUnitTestRunner.groovy
@@ -28,33 +28,32 @@ void prRunner(String cmakeBuildType, String platform, String dockerTag) {
 }
 
 abortPreviousRunningBuilds()
-// TODO: "Change back to be-integration before merge"
 parallel "Release el7": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("Release", "el7", "1f7ef85")
     }
 }, "Release AWS-linux": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("Release", "aws-linux", "latest")
     }
 }, "Release el8": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("Release", "el8", "latest")
     }
 }, "LCheck": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("LCheck", "el8", "latest")
     }
 }, "TCheck": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("TCheck", "el8", "latest")
     }
 }, "DCheck": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("DCheck", "el8", "latest")
     }
 }, "LCov": {
-    node('rtc-14160-test')
+    node('be-integration') {
         try {
             prRunner("LCov", "el8", "latest")
         } finally {
@@ -74,7 +73,7 @@ parallel "Release el7": {
         }
     }
 }, "Release Ubuntu public": {
-    node('rtc-14160-test')
+    node('be-integration') {
         prRunner("Release", "ubuntu-focal-deb", "latest")
     }
 }


### PR DESCRIPTION
The json which the command generates has been put in jenkins vm image and hence no longer needed to execute in pipeline code

```
$ cat ~/.docker/config.json 
{
  "credHelpers": {
    "gcr.io": "gcloud"
  }
}
```
