### PR TITLE
project rtp timestamp after mute or ssrc switch

### DIFF
--- a/bridge/engine/AudioForwarderRewriteAndSendJob.cpp
+++ b/bridge/engine/AudioForwarderRewriteAndSendJob.cpp
@@ -57,13 +57,15 @@ AudioForwarderRewriteAndSendJob::AudioForwarderRewriteAndSendJob(SsrcOutboundCon
     SsrcInboundContext& senderInboundContext,
     memory::UniquePacket packet,
     const uint32_t extendedSequenceNumber,
-    transport::Transport& transport)
+    transport::Transport& transport,
+    uint64_t timestamp)
     : jobmanager::CountedJob(transport.getJobCounter()),
       _outboundContext(outboundContext),
       _senderInboundContext(senderInboundContext),
       _packet(std::move(packet)),
       _extendedSequenceNumber(extendedSequenceNumber),
-      _transport(transport)
+      _transport(transport),
+      _timestamp(timestamp)
 {
     assert(_packet);
     assert(_packet->getLength() > 0);
@@ -90,7 +92,7 @@ void AudioForwarderRewriteAndSendJob::run()
         return;
     }
 
-    bridge::AudioRewriter::rewrite(_outboundContext, _extendedSequenceNumber, *header);
+    bridge::AudioRewriter::rewrite(_outboundContext, _extendedSequenceNumber, *header, _timestamp);
 
     rewriteHeaderExtensions(*header, _senderInboundContext, _outboundContext);
     _transport.protectAndSend(std::move(_packet));

--- a/bridge/engine/AudioForwarderRewriteAndSendJob.h
+++ b/bridge/engine/AudioForwarderRewriteAndSendJob.h
@@ -22,7 +22,8 @@ public:
         SsrcInboundContext& senderInboundContext,
         memory::UniquePacket packet,
         const uint32_t extendedSequenceNumber,
-        transport::Transport& transport);
+        transport::Transport& transport,
+        uint64_t timestamp);
 
     void run() override;
 
@@ -30,8 +31,9 @@ private:
     SsrcOutboundContext& _outboundContext;
     SsrcInboundContext& _senderInboundContext;
     memory::UniquePacket _packet;
-    uint32_t _extendedSequenceNumber;
+    const uint32_t _extendedSequenceNumber;
     transport::Transport& _transport;
+    const uint64_t _timestamp;
 };
 
 } // namespace bridge

--- a/bridge/engine/EngineMixerAudio.cpp
+++ b/bridge/engine/EngineMixerAudio.cpp
@@ -315,7 +315,8 @@ void EngineMixer::forwardAudioRtpPacket(IncomingPacketInfo& packetInfo, uint64_t
                 *(packetInfo.inboundContext()),
                 std::move(packet),
                 packetInfo.extendedSequenceNumber(),
-                audioStream->transport);
+                audioStream->transport,
+                timestamp);
         }
         else
         {

--- a/bridge/engine/EngineMixerBarbell.cpp
+++ b/bridge/engine/EngineMixerBarbell.cpp
@@ -706,7 +706,8 @@ void EngineMixer::forwardAudioRtpPacketOverBarbell(IncomingPacketInfo& packetInf
                 *(packetInfo.inboundContext()),
                 std::move(packet),
                 packetInfo.extendedSequenceNumber(),
-                barbell.transport);
+                barbell.transport,
+                timestamp);
         }
         else
         {
@@ -767,7 +768,8 @@ void EngineMixer::forwardVideoRtpPacketOverBarbell(IncomingPacketInfo& packetInf
                 packetInfo.extendedSequenceNumber(),
                 _messageListener,
                 barbell.idHash,
-                *this);
+                *this,
+                timestamp);
         }
         else
         {

--- a/bridge/engine/EngineMixerRecording.cpp
+++ b/bridge/engine/EngineMixerRecording.cpp
@@ -419,7 +419,8 @@ void EngineMixer::forwardAudioRtpPacketRecording(IncomingPacketInfo& packetInfo,
                     packetInfo.extendedSequenceNumber(),
                     _messageListener,
                     transportEntry.first,
-                    *this);
+                    *this,
+                    timestamp);
             }
             else
             {
@@ -470,7 +471,8 @@ void EngineMixer::forwardVideoRtpPacketRecording(IncomingPacketInfo& packetInfo,
                     packetInfo.extendedSequenceNumber(),
                     _messageListener,
                     transportEntry.first,
-                    *this);
+                    *this,
+                    timestamp);
             }
             else
             {

--- a/bridge/engine/EngineMixerVideo.cpp
+++ b/bridge/engine/EngineMixerVideo.cpp
@@ -656,7 +656,8 @@ void EngineMixer::forwardVideoRtpPacket(IncomingPacketInfo& packetInfo, const ui
                 packetInfo.extendedSequenceNumber(),
                 _messageListener,
                 videoStream->endpointIdHash,
-                *this);
+                *this,
+                timestamp);
         }
         else
         {

--- a/bridge/engine/RecordingAudioForwarderSendJob.cpp
+++ b/bridge/engine/RecordingAudioForwarderSendJob.cpp
@@ -15,7 +15,8 @@ RecordingAudioForwarderSendJob::RecordingAudioForwarderSendJob(SsrcOutboundConte
     const uint32_t extendedSequenceNumber,
     MixerManagerAsync& mixerManager,
     size_t endpointIdHash,
-    EngineMixer& mixer)
+    EngineMixer& mixer,
+    uint64_t timestamp)
     : jobmanager::CountedJob(transport.getJobCounter()),
       _outboundContext(outboundContext),
       _packet(std::move(packet)),
@@ -23,7 +24,8 @@ RecordingAudioForwarderSendJob::RecordingAudioForwarderSendJob(SsrcOutboundConte
       _extendedSequenceNumber(extendedSequenceNumber),
       _mixerManager(mixerManager),
       _endpointIdHash(endpointIdHash),
-      _mixer(mixer)
+      _mixer(mixer),
+      _timestamp(timestamp)
 {
     assert(_packet);
     assert(_packet->getLength() > 0);
@@ -52,7 +54,7 @@ void RecordingAudioForwarderSendJob::run()
         return;
     }
 
-    bridge::AudioRewriter::rewrite(_outboundContext, _extendedSequenceNumber, *rtpHeader);
+    bridge::AudioRewriter::rewrite(_outboundContext, _extendedSequenceNumber, *rtpHeader, _timestamp);
 
     if (_outboundContext.packetCache.isSet())
     {

--- a/bridge/engine/RecordingAudioForwarderSendJob.h
+++ b/bridge/engine/RecordingAudioForwarderSendJob.h
@@ -30,7 +30,8 @@ public:
         const uint32_t extendedSequenceNumber,
         MixerManagerAsync& mixerManager,
         size_t endpointIdHash,
-        EngineMixer& mixer);
+        EngineMixer& mixer,
+        uint64_t timestamp);
 
     void run() override;
 
@@ -38,10 +39,11 @@ private:
     SsrcOutboundContext& _outboundContext;
     memory::UniquePacket _packet;
     transport::RecordingTransport& _transport;
-    uint32_t _extendedSequenceNumber;
+    const uint32_t _extendedSequenceNumber;
     MixerManagerAsync& _mixerManager;
-    size_t _endpointIdHash;
+    const size_t _endpointIdHash;
     EngineMixer& _mixer;
+    const uint64_t _timestamp;
 };
 
 } // namespace bridge

--- a/bridge/engine/RecordingVideoForwarderSendJob.cpp
+++ b/bridge/engine/RecordingVideoForwarderSendJob.cpp
@@ -17,7 +17,8 @@ RecordingVideoForwarderSendJob::RecordingVideoForwarderSendJob(SsrcOutboundConte
     const uint32_t extendedSequenceNumber,
     MixerManagerAsync& mixerManager,
     size_t endpointIdHash,
-    EngineMixer& mixer)
+    EngineMixer& mixer,
+    uint64_t timestamp)
     : jobmanager::CountedJob(transport.getJobCounter()),
       _outboundContext(outboundContext),
       _senderInboundContext(senderInboundContext),
@@ -26,7 +27,8 @@ RecordingVideoForwarderSendJob::RecordingVideoForwarderSendJob(SsrcOutboundConte
       _extendedSequenceNumber(extendedSequenceNumber),
       _mixerManager(mixerManager),
       _endpointIdHash(endpointIdHash),
-      _mixer(mixer)
+      _mixer(mixer),
+      _timestamp(timestamp)
 {
     assert(_packet);
     assert(_packet->getLength() > 0);
@@ -106,6 +108,7 @@ void RecordingVideoForwarderSendJob::run()
             _extendedSequenceNumber,
             _transport.getLoggableId().c_str(),
             rewrittenExtendedSequenceNumber,
+            _timestamp,
             isKeyFrame))
     {
         return;

--- a/bridge/engine/RecordingVideoForwarderSendJob.h
+++ b/bridge/engine/RecordingVideoForwarderSendJob.h
@@ -25,7 +25,8 @@ public:
         const uint32_t extendedSequenceNumber,
         MixerManagerAsync& mixerManager,
         size_t endpointIdHash,
-        EngineMixer& mixer);
+        EngineMixer& mixer,
+        uint64_t timestamp);
 
     void run() override;
 
@@ -38,6 +39,7 @@ private:
     MixerManagerAsync& _mixerManager;
     size_t _endpointIdHash;
     EngineMixer& _mixer;
+    const uint64_t _timestamp;
 };
 
 } // namespace bridge

--- a/bridge/engine/SsrcOutboundContext.h
+++ b/bridge/engine/SsrcOutboundContext.h
@@ -60,14 +60,15 @@ public:
             bool empty() const
             {
                 return ssrc == ~0u && sequenceNumber == ~0u && 0xFFFFu == picId && 0xFFFFu == tl0PicIdx &&
-                    ~0u == timestamp;
+                    ~0u == timestamp && wallClock == ~0u;
             }
 
-            uint32_t ssrc = ~0;
-            uint32_t sequenceNumber = ~0;
-            uint32_t timestamp = ~0;
-            uint16_t picId = ~0;
-            uint16_t tl0PicIdx = ~0;
+            uint32_t ssrc = ~0u;
+            uint32_t sequenceNumber = ~0u;
+            uint32_t timestamp = ~0u;
+            uint16_t picId = -1;
+            uint16_t tl0PicIdx = -1;
+            uint64_t wallClock = ~0u;
         } lastSent;
 
         struct Offset

--- a/bridge/engine/VideoForwarderRewriteAndSendJob.cpp
+++ b/bridge/engine/VideoForwarderRewriteAndSendJob.cpp
@@ -19,7 +19,8 @@ VideoForwarderRewriteAndSendJob::VideoForwarderRewriteAndSendJob(SsrcOutboundCon
     const uint32_t extendedSequenceNumber,
     MixerManagerAsync& mixerManager,
     size_t endpointIdHash,
-    EngineMixer& mixer)
+    EngineMixer& mixer,
+    uint64_t timestamp)
     : jobmanager::CountedJob(transport.getJobCounter()),
       _outboundContext(outboundContext),
       _senderInboundContext(senderInboundContext),
@@ -28,7 +29,8 @@ VideoForwarderRewriteAndSendJob::VideoForwarderRewriteAndSendJob(SsrcOutboundCon
       _extendedSequenceNumber(extendedSequenceNumber),
       _mixerManager(mixerManager),
       _endpointIdHash(endpointIdHash),
-      _mixer(mixer)
+      _mixer(mixer),
+      _timestamp(timestamp)
 {
     assert(_packet);
     assert(_packet->getLength() > 0);
@@ -136,6 +138,7 @@ void VideoForwarderRewriteAndSendJob::run()
                 _extendedSequenceNumber,
                 _transport.getLoggableId().c_str(),
                 rewrittenExtendedSequenceNumber,
+                _timestamp,
                 isKeyFrame))
         {
             return;

--- a/bridge/engine/VideoForwarderRewriteAndSendJob.h
+++ b/bridge/engine/VideoForwarderRewriteAndSendJob.h
@@ -25,7 +25,8 @@ public:
         const uint32_t extendedSequenceNumber,
         MixerManagerAsync& mixerManager,
         size_t endpointIdHash,
-        EngineMixer& mixer);
+        EngineMixer& mixer,
+        uint64_t timestamp);
 
     void run() override;
 
@@ -38,6 +39,7 @@ private:
     MixerManagerAsync& _mixerManager;
     size_t _endpointIdHash;
     EngineMixer& _mixer;
+    const uint64_t _timestamp;
 };
 
 } // namespace bridge

--- a/test/bridge/RtpAudioRewriterTest.cpp
+++ b/test/bridge/RtpAudioRewriterTest.cpp
@@ -31,12 +31,15 @@ class RtpAudioRewriterTest : public ::testing::Test
         _ssrcOutboundContext = std::make_unique<bridge::SsrcOutboundContext>(outboundSsrc,
             *_allocator,
             bridge::RtpMap(bridge::RtpMap::Format::OPUS));
+
+        _wallClock = 4000;
     }
     void TearDown() override { _ssrcOutboundContext.reset(); }
 
 protected:
     std::unique_ptr<memory::PacketPoolAllocator> _allocator;
     std::unique_ptr<bridge::SsrcOutboundContext> _ssrcOutboundContext;
+    uint64_t _wallClock;
 };
 
 TEST_F(RtpAudioRewriterTest, rewrite)
@@ -49,17 +52,14 @@ TEST_F(RtpAudioRewriterTest, rewrite)
     rtpHeader->sequenceNumber = 12;
     rtpHeader->timestamp = 5000;
 
-    const auto seqCount = _ssrcOutboundContext->rewrite.lastSent.sequenceNumber;
-    const auto curTimestamp = _ssrcOutboundContext->rewrite.lastSent.timestamp;
-
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, 12, 5000));
 
     rtpHeader->ssrc = 1001;
     rtpHeader->sequenceNumber = 13;
     rtpHeader->timestamp = 5000 + 960;
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 13, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 2, curTimestamp + 960 * 2));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 13, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, 13, 5000 + 960));
 }
 
 TEST_F(RtpAudioRewriterTest, advTimestamp)
@@ -72,17 +72,17 @@ TEST_F(RtpAudioRewriterTest, advTimestamp)
     rtpHeader->sequenceNumber = 12;
     rtpHeader->timestamp = 5000;
 
-    const auto seqCount = _ssrcOutboundContext->rewrite.lastSent.sequenceNumber;
-    const auto curTimestamp = _ssrcOutboundContext->rewrite.lastSent.timestamp;
+    const auto seqCount = 12;
+    const auto curTimestamp = 5000;
 
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount, curTimestamp));
 
     rtpHeader->ssrc = 1001;
     rtpHeader->sequenceNumber = 13;
-    rtpHeader->timestamp = 5000 + 2 * 960;
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 13, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 2, curTimestamp + 960 * 3));
+    rtpHeader->timestamp = 5000 + 5 * 960;
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 13, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960 * 5));
 }
 
 TEST_F(RtpAudioRewriterTest, prevSequenceNumber)
@@ -96,18 +96,17 @@ TEST_F(RtpAudioRewriterTest, prevSequenceNumber)
     rtpHeader->sequenceNumber = extSeqNo;
     rtpHeader->timestamp = 5000;
 
-    const auto seqCount = _ssrcOutboundContext->rewrite.lastSent.sequenceNumber;
-    const auto curTimestamp = _ssrcOutboundContext->rewrite.lastSent.timestamp;
+    const auto curTimestamp = 5000;
 
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, extSeqNo, curTimestamp));
 
     extSeqNo = 3;
     rtpHeader->ssrc = 1001;
     rtpHeader->sequenceNumber = extSeqNo;
     rtpHeader->timestamp = 5000 - 2 * 960;
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount - 8, curTimestamp - 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, 3, curTimestamp - 2 * 960));
 }
 
 TEST_F(RtpAudioRewriterTest, smallGap)
@@ -121,18 +120,18 @@ TEST_F(RtpAudioRewriterTest, smallGap)
     rtpHeader->sequenceNumber = extSeqNo;
     rtpHeader->timestamp = 5000;
 
-    const auto seqCount = _ssrcOutboundContext->rewrite.lastSent.sequenceNumber;
-    const auto curTimestamp = _ssrcOutboundContext->rewrite.lastSent.timestamp;
+    const auto seqCount = extSeqNo;
+    const auto curTimestamp = 5000;
 
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount, curTimestamp));
 
     extSeqNo = 201;
     rtpHeader->ssrc = 1001;
     rtpHeader->sequenceNumber = extSeqNo;
-    rtpHeader->timestamp = 5000 + 190 * 960;
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 190, curTimestamp + 191 * 960));
+    rtpHeader->timestamp = 5000 + 189 * 960;
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 189, curTimestamp + 189 * 960));
 }
 
 TEST_F(RtpAudioRewriterTest, largeGap)
@@ -146,16 +145,43 @@ TEST_F(RtpAudioRewriterTest, largeGap)
     rtpHeader->sequenceNumber = extSeqNo;
     rtpHeader->timestamp = 5000;
 
-    const auto seqCount = _ssrcOutboundContext->rewrite.lastSent.sequenceNumber;
-    const auto curTimestamp = _ssrcOutboundContext->rewrite.lastSent.timestamp;
+    const auto seqCount = 12;
+    const auto curTimestamp = 5000;
 
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 960));
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, extSeqNo, curTimestamp));
 
-    extSeqNo = 301;
+    _wallClock += 6 * utils::Time::sec;
+    extSeqNo = 312;
     rtpHeader->ssrc = 1001;
     rtpHeader->sequenceNumber = extSeqNo;
-    rtpHeader->timestamp = 5000 + 190 * 960;
-    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader);
-    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 2, curTimestamp + 191 * 960));
+    rtpHeader->timestamp = 5000 + 300 * 960;
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, _ssrcOutboundContext->ssrc, seqCount + 1, curTimestamp + 300 * 960));
+}
+
+TEST_F(RtpAudioRewriterTest, ssrcSwitchAfterMute)
+{
+    memory::Packet packet;
+    packet.setLength(210);
+
+    const auto curTimestamp = 5000;
+
+    uint32_t extSeqNo = 12;
+    auto rtpHeader = rtp::RtpHeader::create(packet);
+    rtpHeader->ssrc = 1001;
+    rtpHeader->sequenceNumber = extSeqNo;
+    rtpHeader->timestamp = curTimestamp;
+
+    const uint32_t outSsrc = _ssrcOutboundContext->ssrc;
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, 12, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, outSsrc, extSeqNo, curTimestamp));
+
+    _wallClock += 6 * utils::Time::sec;
+    extSeqNo = 0x123A890;
+    rtpHeader->ssrc = 1002;
+    rtpHeader->sequenceNumber = 0xA890;
+    rtpHeader->timestamp = 1235000;
+    bridge::AudioRewriter::rewrite(*_ssrcOutboundContext, extSeqNo, *rtpHeader, _wallClock);
+    ASSERT_TRUE(verifyRtp(*rtpHeader, outSsrc, 13, curTimestamp + 300 * 960));
 }


### PR DESCRIPTION
Previously we have ignored analysis of rtp timestamp when it comes to rewrite.
We decide an offset and stick with it until end of meeting. This works fine if the original ssrc is consistently mapped throughout meeting, which is often the case in smaller meetings.
When source ssrc changes, there will be a  huge gap or reverse of the rtp timestamp. This confuses jitter buffers and jitter trackers at the receiver. Potentially, the replay may be affected with pause or cuts.

It can also be a long gap in forwarding because of mute. That causes a seqno offset reset, and now also a rtp timestamp offset.

By projecting the rtp timestamp in the output stream from the last sent rtp timestamp and wall clock, we can reset the offest to a reasonable value after a switch.