### PR TITLE
fix for early DTLS

### DIFF
--- a/doc/ICE/ICEDTLSrace.md
+++ b/doc/ICE/ICEDTLSrace.md
@@ -1,0 +1,18 @@
+```mermaid
+sequenceDiagram
+autonumber
+
+participant A
+participant SMB
+
+
+A->>SMB: ICE BindRequest user SMB:A
+SMB->>A: BindResponse A:SMB
+note over A,SMB: SMB is not in CONNECTING yet as it lacks offer w candidates. It cannot reply to DTLS
+A-->>SMB: DTLS client Hello
+note over A,SMB: SMB has no preliminary rtpEndpoint to send DTLS reply over
+SMB->>A: BindRequest A:SMB, nominate X
+A->>SMB: BindResponse
+note over A,SMB: SMB is waiting for DTLS client Hello
+A->>SMB: DTLS client Hello 1s re-transmit
+```

--- a/test/integration/IntegrationCallTypes.cpp
+++ b/test/integration/IntegrationCallTypes.cpp
@@ -181,7 +181,7 @@ TEST_P(IntegrationCallTypesTest, party3AllModes)
 
                     EXPECT_NEAR(std::max_element(data.amplitudeProfile.begin(), data.amplitudeProfile.end())->second,
                         3600,
-                        500);
+                        550);
                     EXPECT_NEAR(data.rampupAbove(3100), 48000 * 1.22, 48000);
                 }
 

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -187,6 +187,11 @@ public:
                 continue;
             }
 
+            if (dumpPcmData)
+            {
+                item.second->dumpPcmData();
+            }
+
             result.audioSsrcCount++;
 
             std::vector<double> freqVector;
@@ -232,10 +237,6 @@ public:
             result.amplitudeProfile.insert(result.amplitudeProfile.begin(),
                 amplitudeProfile.begin(),
                 amplitudeProfile.end());
-            if (dumpPcmData)
-            {
-                item.second->dumpPcmData();
-            }
         }
 
         std::sort(result.dominantFrequencies.begin(), result.dominantFrequencies.end());

--- a/test/integration/emulator/ColibriChannel.h
+++ b/test/integration/emulator/ColibriChannel.h
@@ -24,6 +24,7 @@ public:
         uint32_t* videoSsrcs) override
     {
         assert(false);
+        return true;
     }
 
     void configureTransport(transport::RtcTransport& transport, memory::AudioPacketPoolAllocator& allocator) override;

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1962,7 +1962,7 @@ void TransportImpl::onIceCandidateChanged(ice::IceSession* session,
     ice::IceEndpoint* endpoint,
     const SocketAddress& sourcePort)
 {
-    if (_selectedRtp == nullptr && session->getState() > ice::IceSession::State::READY)
+    if (_selectedRtp == nullptr && session->getState() >= ice::IceSession::State::READY)
     {
         _selectedRtp = static_cast<transport::Endpoint*>(endpoint); // temporary selection
         _selectedRtcp = _selectedRtp;


### PR DESCRIPTION
This saves time in call setup in case ICE is preliminary for client and he sends Client Hello.

It is also a reason CallTypes tests failed sporadically. Sometimes the call setup was 1s for a client and that caused 1s extended audio rampup for mixed user, which failed the verification.