### PR TITLE
MEDIA-1620: add 'deleteEmptyConferencesWithBarbells' to config, default value is false.

### DIFF
--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -385,7 +385,8 @@ private:
     memory::AudioPacketPoolAllocator& _audioAllocator;
 
     uint64_t _lastReceiveTime;
-    std::atomic_flag _iceReceived = ATOMIC_FLAG_INIT;
+    std::atomic_flag _iceReceivedOnRegularTransport = ATOMIC_FLAG_INIT;
+    std::atomic_flag _iceReceivedOnBarbellTransport = ATOMIC_FLAG_INIT;
     uint64_t _lastCounterCheck;
 
     std::unique_ptr<EngineStreamDirector> _engineStreamDirector;

--- a/config/Config.h
+++ b/config/Config.h
@@ -16,8 +16,10 @@ public:
     CFG_PROP(std::string, logLevel, "INFO");
     CFG_PROP(bool, enableSrtpNullCipher, false);
 
-    // If mixer does not receive any packets during this timeout, it's considered abandoned and is garbage collected.
+    // If mixer does not receive any packets during this timeout, it's considered abandoned and is garbage collected...
     CFG_PROP(int, mixerInactivityTimeoutMs, 2 * 60 * 1000);
+    // ...unless it has barbell connections, and 'deleteEmptyConferencesWithBarbells' is false.
+    CFG_PROP(bool, deleteEmptyConferencesWithBarbells, false);
     CFG_PROP(int, numWorkerTreads, 0);
     CFG_PROP(std::string, logFile, "/tmp/smb.log");
 


### PR DESCRIPTION
If true, empty conferences with existing barbell connections will be automatically deleted despite ICE-only activity after
config.mixerInactivityTimeoutMs timeout.