### PR TITLE
RTC-14144: Transition from GCP Container Registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/docker-existing-dockerfile
 {
 	"name": "Docker from Image",
-	"image": "gcr.io/sym-dev-rtc/buildsmb-el7:latest",
+	"image": "europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-el7:latest",
 	"runArgs": [
 		"--security-opt",
 		"seccomp=unconfined"

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -36,7 +36,7 @@ node('be-integration') {
             env.VERSION=version
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-el7:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-el7:latest').inside {
             stage('Build Centos 7') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"
                 env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
@@ -48,7 +48,7 @@ node('be-integration') {
             }
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-el8:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-el8:latest').inside {
             stage('Build RHEL 8') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"
                 env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
@@ -60,7 +60,7 @@ node('be-integration') {
             }
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-ubuntu-focal:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-ubuntu-focal:latest').inside {
             stage('Build Ubuntu Focal') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"
                 env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
@@ -72,7 +72,7 @@ node('be-integration') {
             }
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-ubuntu-focal-deb:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-ubuntu-focal-deb:latest').inside {
             stage('Build Ubuntu Focal deb release') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"
                 env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
@@ -84,7 +84,7 @@ node('be-integration') {
             }
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-aws-linux:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-aws-linux:latest').inside {
             stage('Build AWS linux2 release') {
                 env.GIT_COMMITTER_NAME = "Jenkins deployment job"
                 env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
@@ -96,7 +96,7 @@ node('be-integration') {
             }
         }
 
-        docker.image('gcr.io/sym-dev-rtc/buildsmb-el7:latest').inside {
+        docker.image('europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-el7:latest').inside {
             stage('Create archive') {
                 sh "zip -r ${baseName}-${version}.zip el7/smb/smb el7/smb/versioninfo.txt el7/smb/libs/ el8/smb/smb el8/smb/versioninfo.txt el8/smb/libs/ ubuntu-focal/smb/smb ubuntu-focal/smb/versioninfo.txt ubuntu-focal/smb/libs/ ubuntu-focal-deb/smb/*.tar.gz ubuntu-focal-deb/smb/*.deb aws-linux/smb/versioninfo.txt aws-linux/smb/libs/ aws-linux/smb/smb"
             }

--- a/Jenkins/PRUnitTestRunner.groovy
+++ b/Jenkins/PRUnitTestRunner.groovy
@@ -6,7 +6,7 @@ void prRunner(String cmakeBuildType, String platform, String dockerTag) {
     }
 
     stage("Build\n[$cmakeBuildType $platform]") {
-        docker.image("gcr.io/sym-dev-rtc/buildsmb-$platform:$dockerTag").inside {
+        docker.image("europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-$platform:$dockerTag").inside {
             env.GIT_COMMITTER_NAME = "Jenkins deployment job"
             env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
             sh "docker/$platform/buildscript.sh $cmakeBuildType"
@@ -19,7 +19,7 @@ void prRunner(String cmakeBuildType, String platform, String dockerTag) {
         archiveArtifacts artifacts: "$platform/$cmakeBuildType/smb, $platform/$cmakeBuildType/smbobj.txt", allowEmptyArchive: true
     }
     stage("Test\n[$cmakeBuildType $platform]") {
-        docker.image("gcr.io/sym-dev-rtc/buildsmb-$platform:$dockerTag").inside {
+        docker.image("europe-west1-docker.pkg.dev/sym-dev-rtc/rtc-jenkins-tools/buildsmb-$platform:$dockerTag").inside {
             env.GIT_COMMITTER_NAME = "Jenkins deployment job"
             env.GIT_COMMITTER_EMAIL = "jenkinsauto@symphony.com"
             sh "docker/$platform/runtests.sh"

--- a/Jenkins/build-push-docker-loadtests.groovy
+++ b/Jenkins/build-push-docker-loadtests.groovy
@@ -14,24 +14,26 @@ node {
     def gcpImageName="${gcpArtifactsRegistry}/${gcpArtifactsProject}/${gcpArtifactsRepo}/${imageName}"
     def gcpImageNameWithVer="${gcpImageName}:${gitHash}"
 
-    try {
-        stage("Build") {
-            sh "./docker/build_loadtest_container.sh"
-        }
-        stage("Push") {
-            sh "docker tag ${imageName}:latest ${gcpImageNameWithVer}"
-            if (params.GCP_KEY_FILE_PATH != null) {
-                sh "gcloud auth activate-service-account --key-file=${params.GCP_KEY_FILE_PATH}"
+    dir("./") {
+        try {
+            stage("Build") {
+                sh "./docker/build_loadtest_container.sh"
             }
-            sh "gcloud auth configure-docker ${gcpArtifactsRegistry} --quiet"
-            sh "docker push ${gcpImageNameWithVer}"
-            sh "gcloud container images add-tag -q ${gcpImageNameWithVer} '${gcpImageName}:latest'"
-            println "${gcpImageNameWithVer} successfully uploaded"
-        }
-    } finally {
-        stage("Cleanup") {
-            sh "docker rmi ${imageName}"
-            cleanWs()
+            stage("Push") {
+                sh "docker tag ${imageName}:latest ${gcpImageNameWithVer}"
+                if (params.GCP_KEY_FILE_PATH != null) {
+                    sh "gcloud auth activate-service-account --key-file=${params.GCP_KEY_FILE_PATH}"
+                }
+                sh "gcloud auth configure-docker ${gcpArtifactsRegistry} --quiet"
+                sh "docker push ${gcpImageNameWithVer}"
+                sh "gcloud container images add-tag -q ${gcpImageNameWithVer} '${gcpImageName}:latest'"
+                println "${gcpImageNameWithVer} successfully uploaded"
+            }
+        } finally {
+            stage("Cleanup") {
+                sh "docker rmi ${imageName}"
+                cleanWs()
+            }
         }
     }
 }

--- a/Jenkins/build-push-docker.groovy
+++ b/Jenkins/build-push-docker.groovy
@@ -5,6 +5,7 @@ node {
     checkout scm
     def scmVars = checkout scm
     def gitHash = scmVars.GIT_COMMIT.substring(0,7)
+    def gitBranch = scmVars.GIT_BRANCH.split('/')[-1]
     // Defaults to https://console.cloud.google.com/artifacts/docker/sym-dev-rtc/europe-west1/rtc-jenkins-tools?project=sym-dev-rtc
     def gcpArtifactsProject = params.GCP_ARTIFACTS_PROJECT ?: "sym-dev-rtc"
     def gcpArtifactsRegistry = params.GCP_ARTIFACTS_REGISTRY ?: "europe-west1-docker.pkg.dev"
@@ -14,7 +15,7 @@ node {
     def gcpImageName="${gcpArtifactsRegistry}/${gcpArtifactsProject}/${gcpArtifactsRepo}/${imageName}"
     def gcpImageNameWithVer="${gcpImageName}:${gitHash}"
 
-    currentBuild.displayName = "${params.OSVERSION}-${env.BRANCH_NAME}"
+    currentBuild.displayName = "${params.OSVERSION}-${gitBranch}"
 
     dir("./docker") {
         try {

--- a/Jenkins/build-push-docker.groovy
+++ b/Jenkins/build-push-docker.groovy
@@ -3,32 +3,37 @@
 node {
     cleanWs()
     checkout scm
-    scmVars = checkout scm
-    git_hash = scmVars.GIT_COMMIT.substring(0,7)
+    def scmVars = checkout scm
+    def gitHash = scmVars.GIT_COMMIT.substring(0,7)
+    // Defaults to https://console.cloud.google.com/artifacts/docker/sym-dev-rtc/europe-west1/rtc-jenkins-tools?project=sym-dev-rtc
+    def gcpArtifactsProject = params.GCP_ARTIFACTS_PROJECT ?: "sym-dev-rtc"
+    def gcpArtifactsRegistry = params.GCP_ARTIFACTS_REGISTRY ?: "europe-west1-docker.pkg.dev"
+    def gcpArtifactsRepo = params.GCP_ARTIFACTS_REPOSITORY ?: "rtc-jenkins-tools"
+
+    def imageName = "buildsmb-${params.OSVERSION}"
+    def gcpImageName="${gcpArtifactsRegistry}/${gcpArtifactsProject}/${gcpArtifactsRepo}/${imageName}"
+    def gcpImageNameWithVer="${gcpImageName}:${gitHash}"
 
     dir("./docker") {
         try {
             lock("jenkins-smb-image-build") {
                 stage("Build") {
-                    sh "./prepdocker.sh $params.OSVERSION"
+                    sh "./prepdocker.sh ${params.OSVERSION}"
                 }
                 stage("Push") {
-                    gcloud_image_name="gcr.io/$params.GCE_PROJECT_ID/buildsmb-$params.OSVERSION"
-                    gcloud_image_name_with_ver="$gcloud_image_name:$git_hash"
-                    sh "docker tag buildsmb-$params.OSVERSION:latest $gcloud_image_name_with_ver"
-                    if (params.GCE_KEY_FILE_PATH != null) {
-                        sh "gcloud auth activate-service-account --key-file=$params.GCE_KEY_FILE_PATH"
+                    sh "docker tag ${imageName}:latest ${gcpImageNameWithVer}"
+                    if (params.GCP_KEY_FILE_PATH != null) {
+                        sh "gcloud auth activate-service-account --key-file=${params.GCP_KEY_FILE_PATH}"
                     }
-                    // TODO: Remove the call for gcloud beta when https://warpdrive-lab.dev.symphony.com/jenkins has up to date gcloud tools
-                    sh "gcloud auth configure-docker || gcloud beta auth configure-docker"
-                    sh "docker push $gcloud_image_name_with_ver"
-                    sh "gcloud container images add-tag -q $gcloud_image_name_with_ver '$gcloud_image_name:latest'"
-                    sh "echo $gcloud_image_name_with_ver successfully uploaded"
+                    sh "gcloud auth configure-docker ${gcpArtifactsRegistry} --quiet"
+                    sh "docker push ${gcpImageNameWithVer}"
+                    sh "gcloud container images add-tag -q ${gcpImageNameWithVer} '${gcpImageName}:latest'"
+                    println "${gcpImageNameWithVer} successfully uploaded"
                 }
             }
         } finally {
             stage("Cleanup") {
-                sh "docker rmi buildsmb-$params.OSVERSION || true"
+                sh "docker rmi ${imageName}"
                 cleanWs()
             }
         }

--- a/Jenkins/build-push-docker.groovy
+++ b/Jenkins/build-push-docker.groovy
@@ -14,6 +14,8 @@ node {
     def gcpImageName="${gcpArtifactsRegistry}/${gcpArtifactsProject}/${gcpArtifactsRepo}/${imageName}"
     def gcpImageNameWithVer="${gcpImageName}:${gitHash}"
 
+    currentBuild.displayName = "${params.OSVERSION}-${env.BRANCH_NAME}"
+
     dir("./docker") {
         try {
             lock("jenkins-smb-image-build") {

--- a/docker/ubuntu-focal-loadtest/Dockerfile
+++ b/docker/ubuntu-focal-loadtest/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update
 
-RUN apt-get -y install llvm git wget cmake libc++-dev libc++abi-dev clang libtool lcov libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev zip curl jq
+RUN apt-get -y install llvm git wget cmake libc++-dev libc++abi-dev clang libtool lcov libssl-dev libsrtp2-dev libmicrohttpd-dev libopus-dev zip curl jq lld
 
 RUN useradd -ms /bin/bash builder
 


### PR DESCRIPTION

Container registry will be deprecated later this year. See https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr . Replacing it with new Artifact Registry as recommended

Changes verified in 
https://jenkins.rtc.dev.symphony.com/job/MediaBridge/job/Build%20SMB%20Load%20Test%20Docker%20-%20RTC-14144/
https://jenkins.rtc.dev.symphony.com/job/MediaBridge/job/Buildsmb%20docker%20-%20RTC-14144/

Resulting images can be seen in https://console.cloud.google.com/artifacts/docker/sym-dev-rtc/europe-west1/rtc-jenkins-tools?project=sym-dev-rtc