### PR TITLE
MEDIA-2365: Send user map periodic over barbell

### DIFF
--- a/bridge/engine/EngineMixer.h
+++ b/bridge/engine/EngineMixer.h
@@ -386,8 +386,12 @@ private:
     memory::PacketPoolAllocator& _sendAllocator;
     memory::AudioPacketPoolAllocator& _audioAllocator;
 
+    // Useful to avoid get time when a precise time is not needed and we can rely on last/current iteration start time
+    uint64_t _lastStartedIterationTimestamp;
+
     uint64_t _lastReceiveTimeOnRegularTransports;
     uint64_t _lastReceiveTimeOnBarbellTransports;
+    uint64_t _lastSendTimeOfUserMediaMapMessageOverBarbells;
     std::atomic_flag _iceReceivedOnRegularTransport = ATOMIC_FLAG_INIT;
     std::atomic_flag _iceReceivedOnBarbellTransport = ATOMIC_FLAG_INIT;
     uint64_t _lastCounterCheck;
@@ -465,6 +469,7 @@ private:
     void sendUserMediaMapMessage(const size_t endpointIdHash);
     void sendUserMediaMapMessageToAll();
     void sendUserMediaMapMessageOverBarbells();
+    void sendPeriodicUserMediaMapMessageOverBarbells(const uint64_t engineIterationStartTimestamp);
     void sendDominantSpeakerToRecordingStream(EngineRecordingStream& recordingStream,
         const size_t dominantSpeaker,
         const std::string& dominantSpeakerEndpoint);

--- a/config/Config.h
+++ b/config/Config.h
@@ -118,7 +118,7 @@ public:
     CFG_GROUP_END(capabilities)
 
     CFG_GROUP()
-    CFG_PROP(int64_t, userMapPeriodicSendingInterval, 30); // in seconds. Disabled by default
+    CFG_PROP(int64_t, userMapPeriodicSendingInterval, -1); // in seconds. Disabled by default
     CFG_GROUP_END(barbell)
 
     CFG_GROUP()

--- a/config/Config.h
+++ b/config/Config.h
@@ -36,8 +36,8 @@ public:
 
     CFG_GROUP()
     // Value between 0 and 127, where 127 is the lowest audio level and 0 the highest.
-    // Default is 126 to make possible simiulate silence with 127.
-    // If procecessing of silent packet is still desired - set it to 127.
+    // Default is 126 to make possible simulate silence with 127.
+    // If processing of silent packet is still desired - set it to 127.
     CFG_PROP(uint8_t, silenceThresholdLevel, 126);
     CFG_PROP(uint32_t, lastN, 3);
     CFG_PROP(uint32_t, lastNextra, 2);
@@ -116,6 +116,10 @@ public:
     CFG_GROUP()
     CFG_PROP(bool, barbelling, false);
     CFG_GROUP_END(capabilities)
+
+    CFG_GROUP()
+    CFG_PROP(int64_t, userMapPeriodicSendingInterval, 30); // in seconds. Disabled by default
+    CFG_GROUP_END(barbell)
 
     CFG_GROUP()
     CFG_PROP(uint32_t, mtu, 1440);


### PR DESCRIPTION
On C9 we have scenario of recovering where sfumanager can lose track of a barbell and a new barbell will be set up. For this to happen, there is 1 leg that is going to be removed but in 1 region there will be a barbell leaked until the end of the conference.

On this side where the barbell leg leaked, the barbell is o going to be deactivated by timeout and all ssrc inbound context will be decommissioned, when that time we have already a new barbell to replace this broken one, the decommission process can remove the participant endpoint id from the user map. To mitigate this issue, this commit allow us to configure an interval where the user mapping is going to be send over barbells periodically to recovery the problem caused by decommission the old ssrc context.

This is just a safety mechanism as in C9 setting up barbell is super complex with split ownership on the 2 regions involved, for the Symphony use case this setting shouldn't be necessary 