### PR TITLE
RTC-14823: Video thumbnails are frozen when someone is screensharing

### DIFF
--- a/bridge/engine/EngineStreamDirector.cpp
+++ b/bridge/engine/EngineStreamDirector.cpp
@@ -1,13 +1,55 @@
 #include "EngineStreamDirector.h"
-
-namespace bridge
+namespace
 {
+constexpr uint32_t calculateMaxBitrate(uint32_t base, uint32_t overhead)
+{
+    // Assuming a _lastN of 9 participants. Perhaps this should be dynamic as EngineStreamDirector knows _lastN
+    return base + 8 * overhead;
+}
+
+} // namespace
+
+using namespace bridge;
+
+// Configuration based on
+// https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/video/config/simulcast.cc
+// Calculation based on following assumptions:
+// - Video at 25fps
+// - RTP header 12 bytes + 8 byte extension header (abs-time extension)
+// - Until 9 bytes for VP8 payload descriptor + VP8 payload header
+// - LOW_QUALITY resolution: 320x180. Target bitrate 150kbits/s, 25 packets/s (~750 bytes per packet + headers)
+// - MID_QUALITY resolution: 640x360. Target bitrate 500kbits/s, 50 packets/s (~1250 bytes per packet + headers)
+// - HIGH_QUALITY resolution: 1280x720. Target bitrate 2500kbits/s, 225 packets/s (~ 1389 bytes per packet + headers)
+// - Round up as the layer selection does not take into account sending audio nor RTCP packets
+constexpr const uint32_t EngineStreamDirector::LOW_QUALITY_BITRATE = 160;
+constexpr const uint32_t EngineStreamDirector::MID_QUALITY_BITRATE = 520;
+constexpr const uint32_t EngineStreamDirector::HIGH_QUALITY_BITRATE = 2600;
+
 constexpr EngineStreamDirector::ConfigRow EngineStreamDirector::configLadder[6] = {
-    // BaseRate = 0, PinnedQuality, UnpinnedQuality, OverheadBitrate, MinBitrateMargin, MaxBitrateMargin
-    {2500 - 500, highQuality, midQuality, 500, 2500, 6500},
-    {500 - 500, midQuality, midQuality, 500, 500, 4500},
-    {500 - 100, midQuality, lowQuality, 100, 500, 1300},
-    {100 - 100, lowQuality, lowQuality, 100, 100, 900},
-    {100, lowQuality, dropQuality, 0, 100, 100},
+    // BaseRate = 0, pinnedQuality, unpinnedQuality, overheadBitrate, minBitrateMargin, maxBitrateMargin
+    {HIGH_QUALITY_BITRATE - MID_QUALITY_BITRATE,
+        highQuality,
+        midQuality,
+        MID_QUALITY_BITRATE,
+        HIGH_QUALITY_BITRATE,
+        calculateMaxBitrate(HIGH_QUALITY_BITRATE, MID_QUALITY_BITRATE)}, // 6760
+    {MID_QUALITY_BITRATE - MID_QUALITY_BITRATE,
+        midQuality,
+        midQuality,
+        MID_QUALITY_BITRATE,
+        MID_QUALITY_BITRATE,
+        calculateMaxBitrate(MID_QUALITY_BITRATE, MID_QUALITY_BITRATE)}, // 4680
+    {MID_QUALITY_BITRATE - LOW_QUALITY_BITRATE,
+        midQuality,
+        lowQuality,
+        LOW_QUALITY_BITRATE,
+        MID_QUALITY_BITRATE,
+        calculateMaxBitrate(MID_QUALITY_BITRATE, LOW_QUALITY_BITRATE)}, // 1800
+    {LOW_QUALITY_BITRATE - LOW_QUALITY_BITRATE,
+        lowQuality,
+        lowQuality,
+        LOW_QUALITY_BITRATE,
+        LOW_QUALITY_BITRATE,
+        calculateMaxBitrate(LOW_QUALITY_BITRATE, LOW_QUALITY_BITRATE)}, // 1440
+    {LOW_QUALITY_BITRATE, lowQuality, dropQuality, 0, LOW_QUALITY_BITRATE, LOW_QUALITY_BITRATE},
     {0, dropQuality, dropQuality, 0, 0, 0}};
-} // namespace bridge

--- a/config/Config.h
+++ b/config/Config.h
@@ -36,8 +36,8 @@ public:
 
     CFG_GROUP()
     // Value between 0 and 127, where 127 is the lowest audio level and 0 the highest.
-    // Default is 126 to make possible simiulate silence with 127.
-    // If procecessing of silent packet is still desired - set it to 127.
+    // Default is 126 to make possible simulate silence with 127.
+    // If processing of silent packet is still desired - set it to 127.
     CFG_PROP(uint8_t, silenceThresholdLevel, 126);
     CFG_PROP(uint32_t, lastN, 3);
     CFG_PROP(uint32_t, lastNextra, 2);
@@ -95,7 +95,10 @@ public:
 
     CFG_GROUP()
     CFG_PROP(uint32_t, minBitrate, 900);
-    CFG_PROP(double, allocFactor, 1.0);
+    // CFG_PROP(uint32_t, maxBitrate, 7500);
+    CFG_PROP(uint32_t,
+        borrowBandwidthThreshold,
+        2500); // value from which we can borrow slides bandwidth for sending video thumbnails
     CFG_GROUP_END(slides)
 
     CFG_GROUP()

--- a/test/bridge/EngineStreamDirectorTest.cpp
+++ b/test/bridge/EngineStreamDirectorTest.cpp
@@ -428,14 +428,14 @@ TEST_F(EngineStreamDirectorTest, setUplinkEstimateKbps)
     _engineStreamDirector->updateBandwidthFloor(5, 2, 2);
     _engineStreamDirector->updateBandwidthFloor(5, 3, 2);
 
-    EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 100, 1 * utils::Time::sec));
+    EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 160, 1 * utils::Time::sec));
     EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 1000, 2 * utils::Time::sec));
     EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 1000, 6 * utils::Time::sec));
-    EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 100, 7 * utils::Time::sec));
+    EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 160, 7 * utils::Time::sec));
     EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 10000, 8 * utils::Time::sec));
     EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 10000, 9 * utils::Time::sec));
     EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 10000, 10 * utils::Time::sec));
-    EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 100, 11 * utils::Time::sec));
+    EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 160, 11 * utils::Time::sec));
     EXPECT_FALSE(_engineStreamDirector->setUplinkEstimateKbps(1, 10000, 14 * utils::Time::sec));
     EXPECT_TRUE(_engineStreamDirector->setUplinkEstimateKbps(1, 10000, 16 * utils::Time::sec));
 }
@@ -462,11 +462,11 @@ TEST_F(EngineStreamDirectorTest, pinnedMidQualityStreamIsIncludedMidBandwidth)
 TEST_F(EngineStreamDirectorTest, pinnedLowQualityStreamIsIncludedLowBandwidth)
 {
     _engineStreamDirector->addParticipant(1, makeSimulcastStream(1, 2, 3, 4, 5, 6));
-    _engineStreamDirector->setUplinkEstimateKbps(1, 100, 5 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(1, 160, 5 * utils::Time::sec);
     _engineStreamDirector->addParticipant(2, makeSimulcastStream(7, 8, 9, 10, 11, 12));
-    _engineStreamDirector->setUplinkEstimateKbps(2, 100, 5 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 160, 5 * utils::Time::sec);
     _engineStreamDirector->addParticipant(3, makeSimulcastStream(13, 14, 15, 16, 17, 18));
-    _engineStreamDirector->setUplinkEstimateKbps(3, 100, 5 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(3, 160, 5 * utils::Time::sec);
 
     _engineStreamDirector->streamActiveStateChanged(3, 13, true);
     _engineStreamDirector->streamActiveStateChanged(3, 15, true);
@@ -574,8 +574,8 @@ TEST_F(EngineStreamDirectorTest, lowEstimateUsesLowQualityLevel)
     _engineStreamDirector->addParticipant(2);
     _engineStreamDirector->pin(2, 1);
 
-    _engineStreamDirector->setUplinkEstimateKbps(2, 101, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(2, 101, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 161, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 161, 61 * utils::Time::sec);
 
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(1, 1, true, true, 0));
 }
@@ -615,8 +615,8 @@ TEST_F(EngineStreamDirectorTest, bandwidthEstimationAllNeededQualityLevelsAreUse
     _engineStreamDirector->setUplinkEstimateKbps(3, 2000, 61 * utils::Time::sec);
 
     // Low estimate
-    _engineStreamDirector->setUplinkEstimateKbps(4, 101, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(4, 101, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 161, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 161, 61 * utils::Time::sec);
 
     // Used by 4
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(1, 1, true, true, 0));
@@ -666,8 +666,8 @@ TEST_F(EngineStreamDirectorTest, lowEstimateForwardsLowQualityLevel)
     _engineStreamDirector->addParticipant(2);
     _engineStreamDirector->pin(2, 1);
 
-    _engineStreamDirector->setUplinkEstimateKbps(2, 100, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(2, 100, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 160, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 160, 61 * utils::Time::sec);
 
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(2, 1));
     EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(2, 3));
@@ -713,12 +713,12 @@ TEST_F(EngineStreamDirectorTest, bandwidthEstimationAllNeededQualityLevelsAreFor
     _engineStreamDirector->setUplinkEstimateKbps(3, 2000, 61 * utils::Time::sec);
 
     // Low estimate
-    _engineStreamDirector->setUplinkEstimateKbps(4, 100, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(4, 100, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 160, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 160, 61 * utils::Time::sec);
 
     // Very low estimate
-    _engineStreamDirector->setUplinkEstimateKbps(5, 99, 60 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(5, 99, 61 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(5, 159, 60 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(5, 159, 61 * utils::Time::sec);
 
     // Used by 5
     EXPECT_FALSE(_engineStreamDirector->shouldForwardSsrc(5, 1));
@@ -835,7 +835,7 @@ TEST_F(EngineStreamDirectorTest,
     _engineStreamDirector->pin(3, 2);
     _engineStreamDirector->pin(4, 2);
 
-    _engineStreamDirector->setUplinkEstimateKbps(1, 400, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(1, 640, 10 * utils::Time::sec);
 
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(13, 3, true, true, 0));
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(15, 3, true, true, 0));
@@ -853,10 +853,10 @@ TEST_F(EngineStreamDirectorTest, midQualitySsrc_InLastN_AndNotPinned_AndAllParti
     _engineStreamDirector->pin(3, 2);
     _engineStreamDirector->pin(4, 2);
 
-    _engineStreamDirector->setUplinkEstimateKbps(1, 400, 10 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(2, 400, 10 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(3, 400, 10 * utils::Time::sec);
-    _engineStreamDirector->setUplinkEstimateKbps(4, 400, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(1, 640, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(2, 640, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(3, 640, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(4, 640, 10 * utils::Time::sec);
 
     EXPECT_TRUE(_engineStreamDirector->isSsrcUsed(13, 3, true, true, 0));
     EXPECT_FALSE(_engineStreamDirector->isSsrcUsed(15, 3, true, true, 0));
@@ -1211,7 +1211,7 @@ TEST_F(EngineStreamDirectorTest, highQualitySsrcAndMidQualitySsrcs_PinTarget_Hig
     addActiveVideoSender(8, 43);
     addActiveVideoSender(9, 49);
 
-    _engineStreamDirector->setUplinkEstimateKbps(1, 6000, 10 * utils::Time::sec);
+    _engineStreamDirector->setUplinkEstimateKbps(1, 6240, 10 * utils::Time::sec);
     _engineStreamDirector->pin(1, 2);
 
     EXPECT_TRUE(_engineStreamDirector->shouldForwardSsrc(1, 11));


### PR DESCRIPTION
We greedy allocate bandwidth to send screensharing which causes to drop camera video frames due to not enough bandwidth. This fixes the problem by trying to "borrow" bandwidth reservation from screensharing to send regular camera limits.

To avoid degradate too much the screensharing in favor of the other camera video, a new setting was added "slides.borrowBandwidthThreshold", where we will borrow the bandwidth only when the bandwidth is higher than the configured threshold (default 2500Kbits/s), that means, we we going to prefer dropping camera video streams when the available bandwidth is below "slides.borrowBandwidthThreshold". When it's higher, we are going to prefer to limit the slides bitrate and used some of the available bandwidth to send the video camera.

Also after calculate how much bandwidth we need to borrow for sending low quality video layer for the video cameras, we add to give some margin to allow some flotation on bandwidth estimation, so we don't disable the video cameras only because we have estimated a slight lower uplink.

**Future improvements**
2500Kbits/s it's seems to be good enough for screensharing FHD with low fps, but perhaps for 4K it would be better have a bit higher threshold.
Other weakness of this algorithm is if we have a sudden a big reduction of uplink estimation, it could cause to drop the camera video screen for a moment until calculate a new value that we can borrow from the screensharing, even if the screensharing is not actually using all the allocated bandwidth.
As SMB does not the resolution nor the fps, we could track the actually bandwidth the sceenshare takes and make the allocation based on that, so we could take better decision about when to drop the other videos
 