### PR TITLE
Integrate g711

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-stdlib=libc++ -glldb -O0 -DDEBUG ${ADDITIONAL_CXX_FL
 set(CMAKE_CXX_FLAGS_DCHECK "-stdlib=libc++ -glldb -O0 -DDEBUG ${ADDITIONAL_CXX_FLAGS} -DDCHECK_BUILD -DNOPERF_TEST -fno-rtti -Wall -Wuninitialized -Wsign-compare -Wthread-safety -Wno-missing-braces -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_TCHECK "-stdlib=libc++ -glldb -O1 -DDEBUG ${ADDITIONAL_CXX_FLAGS} -DTCHECK_BUILD -DNOPERF_TEST -fno-rtti -Wall -Wuninitialized -Wsign-compare -Wthread-safety -Wno-missing-braces -fsanitize=thread -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_LCHECK "-stdlib=libc++ -glldb -O1 -g -DDEBUG ${ADDITIONAL_CXX_FLAGS} -DLCHECK_BUILD -DNOPERF_TEST -fno-rtti -Wall -Wuninitialized -Wsign-compare -Wthread-safety -Wno-missing-braces -fsanitize=leak -fno-omit-frame-pointer")
-set(CMAKE_CXX_FLAGS_RELEASE "-stdlib=libc++ -O3 -DNDEBUG ${ADDITIONAL_CXX_FLAGS} -fno-rtti -Wno-missing-braces -Wuninitialized -Wsign-compare")
+set(CMAKE_CXX_FLAGS_RELEASE "-stdlib=libc++ -O3 -DNDEBUG ${ADDITIONAL_CXX_FLAGS} -fno-rtti -Wno-missing-braces -Wuninitialized -Wsign-compare -march=x86-64-v3")
 set(CMAKE_C_FLAGS_DEBUG "-glldb -O0 -DDEBUG -Wall")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SYMRELEASE "-stdlib=libc++ -glldb -O2 -DNDEBUG ${ADDITIONAL_CXX_FLAGS} -fno-rtti -fno-omit-frame-pointer -Wall -Wno-missing-braces -Wuninitialized -Wsign-compare")
@@ -252,6 +252,11 @@ set(FILES
         codec/AudioReceivePipeline.h
         codec/AudioReceivePipeline.cpp
         codec/SpscAudioBuffer.h
+        codec/ResampleFilters.cpp
+        codec/ResampleFilters.h
+        codec/G711.h
+        codec/G711codec.h
+        codec/G711codec.cpp
         concurrency/EventSemaphore.cpp
         concurrency/EventSemaphore.h
         concurrency/LockFreeList.cpp
@@ -580,6 +585,7 @@ set(TEST_FILES
     test/jobmanager/JobManagerTest.cpp
     test/jobmanager/JobTest.cpp
     test/codec/OpusCodecTest.cpp
+    test/codec/G711CodecTest.cpp
     test/concurrency/ProcessIntervalTest.cpp
 
     test/sctp/SctpBasicsTests.cpp

--- a/codec/AudioReceivePipeline.h
+++ b/codec/AudioReceivePipeline.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "G711codec.h"
 #include "codec/NoiseFloor.h"
 #include "codec/OpusDecoder.h"
 #include "codec/SpscAudioBuffer.h"
@@ -82,7 +83,12 @@ private:
     void adjustReductionPower(uint32_t recentReduction);
 
     bool shouldWaitForMissingPacket(uint64_t timestamp) const;
-    bool dtxHandler(int16_t seqAdvance, int64_t timestampAdvance,uint32_t totalJitterBufferSize);
+    bool dtxHandler(int16_t seqAdvance, int64_t timestampAdvance, uint32_t totalJitterBufferSize);
+
+    size_t decodeG711(uint32_t extendedSequenceNumber,
+        const uint64_t timestamp,
+        const memory::Packet& packet,
+        int16_t* audioData);
 
     uint32_t _ssrc;
     const uint32_t _rtpFrequency;
@@ -94,6 +100,8 @@ private:
     const int _audioLevelExtensionId;
     codec::OpusDecoder _decoder;
     codec::NoiseFloor _noiseFloor;
+    codec::PcmaCodec _pcmaDecoder;
+    codec::PcmuCodec _pcmuDecoder;
 
     uint32_t _targetDelay;
     struct SampleElimination

--- a/codec/G711.h
+++ b/codec/G711.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace codec
+{
+
+namespace Pcma
+{
+
+constexpr uint32_t sampleRate = 8000;
+constexpr uint32_t channelsPerFrame = 1;
+constexpr uint32_t bytesPerSample = sizeof(int8_t);
+constexpr uint32_t payloadType = 8;
+constexpr uint32_t packetsPerSecond = 50; // default ptime
+
+} // namespace Pcma
+
+namespace Pcmu
+{
+
+constexpr uint32_t sampleRate = 8000;
+constexpr uint32_t channelsPerFrame = 1;
+constexpr uint32_t bytesPerSample = sizeof(int8_t);
+constexpr uint32_t payloadType = 0;
+constexpr uint32_t packetsPerSecond = 50; // default ptime
+
+} // namespace Pcmu
+
+} // namespace codec

--- a/codec/G711codec.cpp
+++ b/codec/G711codec.cpp
@@ -1,0 +1,160 @@
+#include "G711codec.h"
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <stdio.h>
+
+namespace codec
+{
+int16_t PcmaCodec::_table[256] = {0};
+int8_t PcmaCodec::_encodeTable[2048] = {0};
+
+int16_t PcmuCodec::_table[256] = {0};
+uint8_t PcmuCodec::_encodeTable[128] = {0};
+
+void PcmaCodec::encode(const int16_t* pcm, uint8_t* target, size_t samples)
+{
+    for (size_t n = 0; n < samples; n++)
+    {
+        if (pcm[n] < 0)
+        {
+            target[n] = _encodeTable[(~pcm[n]) >> 4] ^ 0x0055;
+        }
+        else
+        {
+            target[n] = (_encodeTable[pcm[n] >> 4] | 0x80) ^ 0x0055;
+        }
+    }
+}
+
+// works from tail so it can decode in place
+void PcmaCodec::decode(const uint8_t* pcma, int16_t* target, size_t samples)
+{
+    assert(_table[0] != 0);
+    for (size_t i = 1; i <= samples; ++i)
+    {
+        target[samples - i] = _table[pcma[samples - i]];
+    }
+}
+
+void PcmaCodec::initialize()
+{
+    for (int16_t d = 0; d < 256; ++d)
+    {
+        // unmask 0x55 and remove sign bit
+        const int16_t ix = (d ^ 0x0055) & 0x007F;
+        const int16_t exponent = ix >> 4;
+        int16_t mant = ix & 0x000F;
+        if (exponent > 0)
+        {
+            mant = mant + 16; /* add leading '1', if exponent > 0 */
+        }
+
+        mant = (mant << 4) + 8; /* now mantissa left adjusted and */
+        /* 1/2 quantization step added */
+        if (exponent > 1)
+        {
+            mant = mant << (exponent - 1);
+        }
+
+        _table[d] = d > 127 ? mant : -mant;
+    }
+
+    for (int16_t d = 0; d < 2048; ++d)
+    {
+        int16_t x = d;
+        if (x > 32) // exponent=0 for x <= 32
+        {
+            int16_t exponent = 1;
+            while (x > 16 + 15) // find mantissa and exponent
+            {
+                x >>= 1;
+                exponent++;
+            }
+            x -= 16; // second step: remove leading '1'
+            x += exponent << 4; // now compute encoded value
+        }
+
+        _encodeTable[d] = x;
+    }
+}
+
+void PcmuCodec::encode(const int16_t* pcm, uint8_t* target, size_t samples)
+{
+    // Change from 14 bit left adjusted to 14 bit right adjusted
+    // Compute absolute value; adjust for easy processing
+    for (size_t n = 0; n < samples; n++)
+    {
+        // compute 1's complement in case of  neg values. NB: 33 is the difference value
+        int16_t absno = pcm[n] < 0 ? ((~pcm[n]) >> 2) + 33 : (pcm[n] >> 2) + 33;
+
+        if (absno > 0x1FFF) // limit to "absno" < 8192
+        {
+            absno = 0x1FFF;
+        }
+
+        const int16_t segno = _encodeTable[absno >> 6]; // Determination of sample's segment
+
+        // Mounting the high-nibble of the log-PCM sample
+        const int16_t high_nibble = 0x0008 - segno;
+
+        // Mounting the low-nibble of the log PCM sample
+        // right shift of mantissa and masking away leading '1'
+        int16_t low_nibble = (absno >> segno) & 0x000F;
+        low_nibble = 0x000F - low_nibble;
+
+        // Joining the high-nibble and the low-nibble of the log PCM sample
+        target[n] = (high_nibble << 4) | low_nibble;
+
+        // Add sign bit
+        if (pcm[n] >= 0)
+        {
+            target[n] = target[n] | 0x0080;
+        }
+    }
+}
+
+// works from tail so it can decode in place
+void PcmuCodec::decode(const uint8_t* pcmu, int16_t* target, size_t samples)
+{
+    assert(_table[0] != 0);
+    for (size_t i = 1; i <= samples; ++i)
+    {
+        target[samples - i] = _table[pcmu[samples - i]];
+    }
+}
+
+void PcmuCodec::initialize()
+{
+    for (int16_t d = 0; d < 256; ++d)
+    {
+        // sign-bit = 1 for positiv values
+        const int16_t sign = d < 0x0080 ? -1 : 1;
+        int16_t mantissa = ~d; // 1's complement of input value
+        const int16_t exponent = (mantissa >> 4) & 0x0007; // extract exponent
+        const int16_t segment = exponent + 1; // compute segment number
+        mantissa = mantissa & 0x000F; // extract mantissa
+
+        // Compute Quantized Sample (14 bit left adjusted)
+        int16_t step = 4 << segment; // position of the LSB = 1 quantization step)
+        _table[d] = sign *
+            ((0x0080 << exponent) // '1', preceding the mantissa
+                + step * mantissa // left shift of mantissa
+                + step / 2 // 1/2 quantization step
+                - 4 * 33);
+    }
+
+    for (int16_t d = 0; d < 128; ++d)
+    {
+        int16_t i = d;
+        int16_t segno = 1;
+        while (i != 0)
+        {
+            segno++;
+            i >>= 1;
+        }
+        _encodeTable[d] = segno;
+    }
+}
+
+} // namespace codec

--- a/codec/G711codec.h
+++ b/codec/G711codec.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace codec
+{
+
+class PcmaCodec
+{
+public:
+    static void encode(const int16_t* data, uint8_t* target, size_t samples);
+    static void decode(const uint8_t* data, int16_t* target, size_t samples);
+
+    static void initialize();
+
+private:
+    static int16_t _table[256];
+    static int8_t _encodeTable[2048];
+};
+
+class PcmuCodec
+{
+public:
+    static void encode(const int16_t* data, uint8_t* target, size_t samples);
+    static void decode(const uint8_t* data, int16_t* target, size_t samples);
+
+    static void initialize();
+
+private:
+    static int16_t _table[256];
+    static uint8_t _encodeTable[128];
+};
+
+} // namespace codec

--- a/codec/ResampleFilters.cpp
+++ b/codec/ResampleFilters.cpp
@@ -1,0 +1,180 @@
+#include "ResampleFilters.h"
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <immintrin.h>
+#include <memory>
+#include <numeric>
+
+namespace codec
+{
+namespace
+{
+// generated with python scipy.signal.remez package.
+// remex {0, 4000, 7000, 24000} to reduce ringing
+alignas(32) const float coefficients48[] = {-0.0014312130547252334,
+    -0.0006054419098336808,
+    0.0005125525474648318,
+    0.002265637857911059,
+    0.003613691908452525,
+    0.0032400421353444516,
+    0.00042171822556735686,
+    -0.004142286440019049,
+    -0.008161844774923781,
+    -0.008669699057834468,
+    -0.0037526619271314693,
+    0.005721817368260278,
+    0.015574714928136658,
+    0.019701079061089664,
+    0.013157977574650844,
+    -0.0043841116127715345,
+    -0.026731687155170873,
+    -0.04228380449900747,
+    -0.038315549216148145,
+    -0.006862934685613791,
+    0.050462556270647566,
+    0.12127833849315953,
+    0.18591190718004647,
+    0.2244508852158846,
+    0.2244508852158846,
+    0.18591190718004647,
+    0.12127833849315953,
+    0.050462556270647566,
+    -0.006862934685613791,
+    -0.038315549216148145,
+    -0.04228380449900747,
+    -0.026731687155170873,
+    -0.0043841116127715345,
+    0.013157977574650844,
+    0.019701079061089664,
+    0.015574714928136658,
+    0.005721817368260278,
+    -0.0037526619271314693,
+    -0.008669699057834468,
+    -0.008161844774923781,
+    -0.004142286440019049,
+    0.00042171822556735686,
+    0.0032400421353444516,
+    0.003613691908452525,
+    0.002265637857911059,
+    0.0005125525474648318,
+    -0.0006054419098336808,
+    -0.0014312130547252334};
+
+// remez band {0,3400,4600,24000}
+alignas(32) const float dec_coEfficients19[] = {-0.10167076519742091,
+    -0.026316766959229757,
+    -0.015019643734867387,
+    0.0070442586114255286,
+    0.038346323980530325,
+    0.07507317680725231,
+    0.1121844952091097,
+    0.14418018600376672,
+    0.16575542007242253,
+    0.17322498623364782,
+    0.16575542007242253,
+    0.14418018600376672,
+    0.1121844952091097,
+    0.07507317680725231,
+    0.038346323980530325,
+    0.0070442586114255286,
+    -0.015019643734867387,
+    -0.026316766959229757,
+    -0.10167076519742091};
+} // namespace
+
+// Pepares a 6 stage polyphase filter from the 48 taps
+FirUpsample6x::FirUpsample6x() : _tapsPerLine(8)
+{
+    clear();
+    for (auto i = 0u; i < _resampleFactor; ++i)
+    {
+        for (auto j = 0u; j < _tapsPerLine; ++j)
+        {
+            _filterLine[i][j] = coefficients48[i + j * _resampleFactor];
+        }
+    }
+}
+
+void FirUpsample6x::clear()
+{
+    _samples.fill(0.f);
+}
+
+// performs 8 * 48000 = 384000 mul/s to upsample 8kHz->48kHz
+void FirUpsample6x::upsample(int16_t* pcm, int16_t* pcmOut, const size_t sampleCountIn)
+{
+    assert(sampleCountIn + _tapsPerLine < sizeof(_samples));
+
+    for (auto i = 0u; i < sampleCountIn; ++i)
+    {
+        _samples[_tapsPerLine + i] = pcm[i];
+    }
+
+    for (auto fi = 0u; fi < _resampleFactor; ++fi)
+    {
+        size_t outIndex = fi;
+        const float* filterLine = _filterLine[fi];
+
+        for (auto i = 0u; i < sampleCountIn; ++i)
+        {
+            // this layout allows compiler to load filter line into xmm and vfmadd321
+            const auto m = _tapsPerLine + i - 7;
+            float ns = _samples[m] * filterLine[7];
+            ns += _samples[m + 1] * filterLine[6];
+            ns += _samples[m + 2] * filterLine[5];
+            ns += _samples[m + 3] * filterLine[4];
+            ns += _samples[m + 4] * filterLine[3];
+            ns += _samples[m + 5] * filterLine[2];
+            ns += _samples[m + 6] * filterLine[1];
+            ns += _samples[m + 7] * filterLine[0];
+
+            pcmOut[outIndex] = std::roundf(ns * _resampleFactor);
+            outIndex += _resampleFactor;
+        }
+    }
+
+    std::memcpy(_samples.data(), _samples.data() + sampleCountIn, _tapsPerLine * sizeof(float));
+}
+
+FirDownsample6x::FirDownsample6x()
+{
+    clear();
+}
+
+void FirDownsample6x::clear()
+{
+    std::fill(_samples, &_samples[MAX_TAPS], 0);
+}
+
+// Requires 8000 * 19 = 152000 mul/s to do 48k->8k
+void FirDownsample6x::downsample(int16_t* pcm, int16_t* pcmOut, const size_t sampleCountIn)
+{
+    assert(sampleCountIn <= 1440);
+    const size_t TAPS = 19;
+
+    for (auto i = 0u; i < sampleCountIn; ++i)
+    {
+        _samples[TAPS + i] = pcm[i];
+    }
+
+    // compiler recognises that there are 10 unique taps and loads those into xmm registers.
+    // then it performs vfmadd231ss to multiply and accumulate
+    auto* pOut = pcmOut;
+    for (auto i = 0u; i < sampleCountIn; i += _resampleFactor)
+    {
+        float ns = 0;
+        for (auto j = 0u; j < TAPS; ++j)
+        {
+            ns += _samples[TAPS + i - j] * dec_coEfficients19[j];
+        }
+        *pOut = std::roundf(ns);
+        ++pOut;
+    }
+
+    for (auto i = 0u; i < TAPS; ++i)
+    {
+        _samples[i] = pcm[sampleCountIn - TAPS + i];
+    }
+}
+} // namespace codec

--- a/codec/ResampleFilters.h
+++ b/codec/ResampleFilters.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <array>
+#include <cinttypes>
+#include <cstddef>
+
+namespace codec
+{
+
+class FirUpsample6x
+{
+    static constexpr size_t _resampleFactor = 6;
+
+public:
+    FirUpsample6x();
+
+    void clear();
+    void upsample(int16_t* pcm, int16_t* pcmOut, const size_t sampleCountIn);
+
+private:
+    const size_t _tapsPerLine;
+
+    float _filterLine[_resampleFactor][8];
+    std::array<float, 256> _samples;
+};
+
+class FirDownsample6x
+{
+    static constexpr size_t MAX_TAPS = 64;
+    static constexpr size_t _resampleFactor = 6;
+
+public:
+    FirDownsample6x();
+
+    void clear();
+    void downsample(int16_t* pcm, int16_t* pcmOut, const size_t sampleCountIn);
+
+private:
+    alignas(32) float _samples[MAX_TAPS + 1440];
+};
+
+} // namespace codec

--- a/test/codec/AudioProcessingTest.cpp
+++ b/test/codec/AudioProcessingTest.cpp
@@ -1,5 +1,9 @@
+#include "codec/ResampleFilters.h"
+#include "utils/Format.h"
+#include "utils/ScopedFileHandle.h"
 #include <cmath>
 #include <gtest/gtest.h>
+#include <iostream>
 
 namespace codec
 {
@@ -22,4 +26,69 @@ TEST(AudioProcess, audiolevel)
     auto dB = codec::computeAudioLevel(data, samples);
     double dBrms = 20 * std::log10(amplitude / (double(0x8000) * std::sqrt(2)));
     EXPECT_EQ(static_cast<int>(dBrms), -dB);
+}
+
+TEST(AudioProcess, DISABLED_upsample)
+{
+    utils::ScopedFileHandle inFile(::fopen("../tools/testfiles/jpsample.raw", "r"));
+    utils::ScopedFileHandle outFile(::fopen("pcm48k48.raw", "wr"));
+
+    codec::FirUpsample6x resampler;
+    codec::FirDownsample6x downSampler;
+
+    int16_t samples[960];
+    int16_t samples8k[160];
+    int16_t samples48k[960];
+    for (auto i = 0u; i < 500; ++i)
+    {
+        ::fread(samples, sizeof(int16_t), 960, inFile.get());
+        downSampler.downsample(samples, samples8k, 960);
+        resampler.upsample(samples8k, samples48k, 160);
+
+        ::fwrite(samples48k, sizeof(int16_t), 960, outFile.get());
+    }
+}
+
+TEST(AudioProcess, DISABLED_downsample)
+{
+    utils::ScopedFileHandle inFile(::fopen("../tools/testfiles/jpsample.raw", "r"));
+    utils::ScopedFileHandle outFile(::fopen("pcm8k19.raw", "wr"));
+
+    codec::FirDownsample6x downSampler;
+
+    int16_t samples[160];
+    int16_t samples48k[960];
+    for (auto i = 0u; i < 500; ++i)
+    {
+        ::fread(samples48k, sizeof(int16_t), 960, inFile.get());
+        downSampler.downsample(samples48k, samples, 960);
+
+        ::fwrite(samples, sizeof(int16_t), 160, outFile.get());
+    }
+}
+
+TEST(AudioProcess, downsamplePerf)
+{
+    int16_t samples48k[960];
+
+    codec::FirDownsample6x downSampler;
+    int16_t samples8k[160];
+    // 10h of audio to down sample
+    for (auto i = 0u; i < 50 * 60 * 60 * 10; ++i)
+    {
+        downSampler.downsample(samples48k, samples8k, 960);
+    }
+}
+
+TEST(AudioProcess, upsamplePerf)
+{
+    int16_t samples48k[960];
+
+    codec::FirUpsample6x resampler;
+    int16_t samples8k[160];
+    // 10h of audio to down sample
+    for (auto i = 0u; i < 50 * 60 * 60 * 10; ++i)
+    {
+        resampler.upsample(samples8k, samples48k, 160);
+    }
 }

--- a/test/codec/G711CodecTest.cpp
+++ b/test/codec/G711CodecTest.cpp
@@ -1,0 +1,107 @@
+#include "codec/G711codec.h"
+#include "codec/AudioLevel.h"
+#include "codec/ResampleFilters.h"
+#include "logger/Logger.h"
+#include "utils/ScopedFileHandle.h"
+#include "utils/Time.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+namespace codec
+{
+int computeAudioLevel(const int16_t* payload, int samples);
+}
+
+struct G711Test : testing::Test
+{
+    void SetUp() override
+    {
+        for (size_t i = 0; i < samples; ++i)
+        {
+            _pcmData[i] = sin(2 * PI * i * 400 / sampleFrequency) * amplitude;
+        }
+
+        codec::PcmaCodec::initialize();
+        codec::PcmuCodec::initialize();
+    }
+
+    static constexpr double PI = 3.14159;
+    static constexpr double sampleFrequency = 8000;
+    static constexpr size_t samples = sampleFrequency / 50;
+    static constexpr double amplitude = 2000;
+    int16_t _pcmData[samples];
+};
+
+TEST_F(G711Test, alaw)
+{
+    codec::PcmaCodec codec;
+
+    auto dB = codec::computeAudioLevel(_pcmData, samples);
+
+    auto g711 = reinterpret_cast<uint8_t*>(_pcmData);
+    codec.encode(_pcmData, g711, samples);
+
+    codec.decode(g711, _pcmData, samples);
+    auto dB2 = codec::computeAudioLevel(_pcmData, samples);
+
+    EXPECT_EQ(dB, dB2);
+    EXPECT_EQ(static_cast<int>(27), dB);
+}
+
+TEST_F(G711Test, ulaw)
+{
+    codec::PcmuCodec codec;
+
+    auto dB = codec::computeAudioLevel(_pcmData, samples);
+
+    auto g711 = reinterpret_cast<uint8_t*>(_pcmData);
+    codec.encode(_pcmData, g711, samples);
+
+    codec.decode(g711, _pcmData, samples);
+    auto dB2 = codec::computeAudioLevel(_pcmData, samples);
+
+    EXPECT_EQ(dB, dB2);
+    EXPECT_EQ(static_cast<int>(27), dB);
+}
+
+TEST_F(G711Test, DISABLED_alawFrom48k)
+{
+    utils::ScopedFileHandle inFile(::fopen("../tools/testfiles/jpsample.raw", "r"));
+    utils::ScopedFileHandle outFile(::fopen("pcma8kout.raw", "wr"));
+
+    codec::FirDownsample6x downSampler;
+    codec::PcmaCodec codec;
+
+    int16_t samples8k[160];
+    int16_t samples48k[960];
+    for (auto i = 0u; i < 500; ++i)
+    {
+        ::fread(samples48k, sizeof(int16_t), 960, inFile.get());
+        downSampler.downsample(samples48k, samples8k, 960);
+
+        uint8_t pcma[160];
+        codec.encode(samples8k, pcma, 160);
+        ::fwrite(pcma, sizeof(uint8_t), 160, outFile.get());
+    }
+}
+
+TEST_F(G711Test, DISABLED_ulawFrom48k)
+{
+    utils::ScopedFileHandle inFile(::fopen("../tools/testfiles/jpsample.raw", "r"));
+    utils::ScopedFileHandle outFile(::fopen("pcmu8kout.raw", "wr"));
+
+    codec::FirDownsample6x downSampler;
+    codec::PcmuCodec codec;
+
+    int16_t samples8k[160];
+    int16_t samples48k[960];
+    for (auto i = 0u; i < 500; ++i)
+    {
+        ::fread(samples48k, sizeof(int16_t), 960, inFile.get());
+        downSampler.downsample(samples48k, samples8k, 960);
+
+        uint8_t pcma[160];
+        codec.encode(samples8k, pcma, 160);
+        ::fwrite(pcma, sizeof(uint8_t), 160, outFile.get());
+    }
+}


### PR DESCRIPTION
G711 codec support. 
Efficient resampling as compiler produces SIMD implementation.

Remaining for mixed leg: 
- negotiation of g711 only
- encoding to g711 in encodeJob if receiver is limited