### PR TITLE
Add missing size multiplier when zeroing mixedData

### DIFF
--- a/bridge/engine/EngineMixer.cpp
+++ b/bridge/engine/EngineMixer.cpp
@@ -84,7 +84,7 @@ EngineMixer::EngineMixer(const std::string& id,
     assert(audioSsrcs.size() <= SsrcRewrite::ssrcArraySize);
     assert(videoSsrcs.size() <= SsrcRewrite::ssrcArraySize);
 
-    std::memset(_mixedData, 0, samplesPerFrame20ms * channelsPerFrame);
+    std::memset(_mixedData, 0, samplesPerFrame20ms * channelsPerFrame * sizeof(int16_t));
     _iceReceivedOnRegularTransport.test_and_set();
     _iceReceivedOnBarbellTransport.test_and_set();
 }


### PR DESCRIPTION
Working on gcc compiler support and I got a warning here. Seems like a bug.