### PR TITLE
MEDIA-2661: ICE reconnects during meeting and fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,7 @@ set(TEST_FILES
     test/utils/StringTokenizerTest.cpp
     test/utils/TrackerTest.cpp
     test/utils/StdExtensionsTest.cpp
+    test/utils/SocketAddressTest.cpp
     test/memory/ListTest.cpp
     test/memory/ArrayTest.cpp
     test/jobmanager/JobManagerTest.cpp

--- a/test/include/mocks/IceSessionEventListenerMock.h
+++ b/test/include/mocks/IceSessionEventListenerMock.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "transport/ice/IceSession.h"
+#include <gmock/gmock.h>
+#include <memory>
+
+namespace test
+{
+
+struct IceSessionEventListenerMock : public ::ice::IceSession::IEvents
+{
+    MOCK_METHOD(void, onIceStateChanged, (::ice::IceSession * session, ::ice::IceSession::State state), (override));
+
+    MOCK_METHOD(void, onIceCompleted, (::ice::IceSession * session), (override));
+
+    MOCK_METHOD(void,
+        onIceCandidateChanged,
+        (::ice::IceSession * session, ::ice::IceEndpoint* localEndpoint, const ::transport::SocketAddress& remotePort),
+        (override));
+
+    MOCK_METHOD(void,
+        onIceCandidateAccepted,
+        (::ice::IceSession * session, ::ice::IceEndpoint* localEndpoint, const ::ice::IceCandidate& remoteCandidate),
+        (override));
+
+    MOCK_METHOD(void,
+        onIceDiscardCandidate,
+        (::ice::IceSession * session, ::ice::IceEndpoint* localEndpoint, const ::transport::SocketAddress& remotePort),
+        (override));
+};
+
+} // namespace test

--- a/test/integration/ConfIntegrationTest.cpp
+++ b/test/integration/ConfIntegrationTest.cpp
@@ -523,10 +523,13 @@ TEST_F(IntegrationTest, probing)
         // non-zero RTT indicates that there was a successful candidates pair, hence probing was performed
         ASSERT_GT(transport->getRtt(), 0);
         transport->stop();
+        start = utils::Time::getAbsoluteTime();
         while (transport->hasPendingJobs() && utils::Time::getAbsoluteTime() - start < timeout)
         {
             utils::Time::nanoSleep(utils::Time::ms * 100);
         }
+
+        ASSERT_EQ(false, transport->hasPendingJobs());
         finalizeSimulation();
     });
 }
@@ -1015,7 +1018,7 @@ TEST_F(IntegrationTest, endpointMessage)
                 ++endpointMessageCount;
             }
         });
-        // Dom speaker + UserMap + endpont message
+        // Dom speaker + UserMap + endpoint message
         EXPECT_CALL(listenerMock, onWebRtcDataString(_, _)).Times(AtLeast(3));
         group.run(utils::Time::sec * 2);
 

--- a/test/transport/IceTest.cpp
+++ b/test/transport/IceTest.cpp
@@ -4,15 +4,19 @@
 #include "logger/Logger.h"
 #include "memory/AudioPacketPoolAllocator.h"
 #include "memory/Packet.h"
+#include "mocks/IceSessionEventListenerMock.h"
 #include "test/integration/emulator/TimeTurner.h"
 #include "transport/RtcSocket.h"
 #include "transport/RtcePoll.h"
 #include "transport/ice/IceSerialize.h"
 #include "transport/ice/IceSession.h"
 #include "transport/ice/Stun.h"
+#include "utils/ContainerAlgorithms.h"
 #include <atomic>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+using namespace ::testing;
 
 namespace
 {
@@ -1497,7 +1501,7 @@ TEST_F(IceRobustness, earlyProbes)
         }
     }
 
-    EXPECT_EQ(sessions[0]->getRemoteCandidates().size(), 2);
+    EXPECT_EQ(sessions[0]->getRemoteCandidates().size(), 3);
     EXPECT_GE(sessions[0]->getState(), ice::IceSession::State::CONNECTING);
     EXPECT_LE(sessions[0]->getState(), ice::IceSession::State::CONNECTED);
 
@@ -1527,9 +1531,176 @@ TEST_F(IceRobustness, earlyProbes)
     EXPECT_TRUE(selectedPair0.second.address.equalsIp(firewall2.getPublicIp()));
 
     auto remoteCandidates1 = sessions[0]->getRemoteCandidates();
-    EXPECT_EQ(remoteCandidates1.size(), 2);
+    EXPECT_EQ(remoteCandidates1.size(), 3);
     auto selectedPair1 = sessions[1]->getSelectedPair();
     EXPECT_TRUE(selectedPair1.second.address.equalsIp(firewall1.getPublicIp()));
+}
+
+TEST_F(IceRobustness, removeUnviableCandidates)
+{
+    fakenet::Internet internet;
+
+    FakeStunServer stunServer(transport::SocketAddress::parse("64.233.165.127", 19302), internet);
+    fakenet::Firewall firewall1(transport::SocketAddress::parse("216.93.246.10", 0), internet);
+    fakenet::Firewall firewall2(transport::SocketAddress::parse("216.93.24.11", 0), internet);
+
+    FakeEndpoint endpoint1(transport::SocketAddress::parse("172.16.0.10", 2000), firewall1);
+    FakeEndpoint endpoint2(transport::SocketAddress::parse("172.16.0.20", 3000), firewall2);
+
+    FakeEndpoint otherNonAccessibleEndpoint(transport::SocketAddress::parse("192.168.1.10", 25000));
+
+    NiceMock<test::IceSessionEventListenerMock> session0EventListenerMock;
+
+    EXPECT_CALL(session0EventListenerMock, onIceCandidateAccepted(_, _, Truly([](const auto& candidate) {
+        return transport::SocketAddress::parse("216.93.24.11", 0).equalsIp(candidate.address);
+    }))).Times(1);
+
+    EXPECT_CALL(session0EventListenerMock, onIceCandidateAccepted(_, _, Truly([](const auto& candidate) {
+        return transport::SocketAddress::parse("64.233.165.127", 0).equalsIp(candidate.address);
+    }))).Times(1);
+
+    // Unviable must be discarded
+    EXPECT_CALL(session0EventListenerMock, onIceDiscardCandidate(_, _, Truly([](const auto& remotePort) {
+        return transport::SocketAddress::parse("192.168.1.10", 0).equalsIp(remotePort);
+    }))).Times(1);
+
+    EXPECT_CALL(session0EventListenerMock, onIceDiscardCandidate(_, _, Truly([](const auto& remotePort) {
+        return transport::SocketAddress::parse("172.16.0.20", 0).equalsIp(remotePort);
+    }))).Times(1);
+
+    ice::IceConfig config;
+    IceSessions sessions;
+    sessions.emplace_back(std::make_unique<ice::IceSession>(1,
+        config,
+        ice::IceComponent::RTP,
+        ice::IceRole::CONTROLLING,
+        &session0EventListenerMock));
+
+    sessions.emplace_back(
+        std::make_unique<ice::IceSession>(2, config, ice::IceComponent::RTP, ice::IceRole::CONTROLLED, nullptr));
+
+    endpoint1.attach(sessions[0]);
+    endpoint2.attach(sessions[1]);
+    otherNonAccessibleEndpoint.attach(sessions[1]);
+
+    std::vector<transport::SocketAddress> stunServers;
+    stunServers.push_back(stunServer.getIp());
+
+    gatherCandidates(internet, stunServers, sessions, timeSource);
+    // provide one side with candidates and credentials
+    logger::info("GATHER PHASE COMPLETE", "");
+    setRemoteCandidates(*sessions[1], *sessions[0]);
+    sessions[1]->setRemoteCredentials(sessions[0]->getLocalCredentials());
+
+    int si = 0;
+    for (auto& session : sessions)
+    {
+        logger::info("session %d local candidates", "", si);
+        log(session->getLocalCandidates());
+        logger::info("remote candidates", "");
+        log(session->getRemoteCandidates());
+    }
+
+    EXPECT_EQ(sessions[0]->getRemoteCandidates().size(), 0);
+
+    logger::info("probing from session %u", "", 0);
+    sessions[1]->probeRemoteCandidates(ice::IceRole::CONTROLLING, timeSource.getAbsoluteTime());
+
+    const auto startTimeNoCredentials = timeSource.getAbsoluteTime();
+    bool running = true;
+    while (running && timeSource.getAbsoluteTime() - startTimeNoCredentials < utils::Time::sec * 5)
+    {
+        internet.process(timeSource.getAbsoluteTime());
+        int64_t timeout = std::numeric_limits<int64_t>::max();
+        running = false;
+        for (auto& session : sessions)
+        {
+            auto sessionTimeout = session->processTimeout(timeSource.getAbsoluteTime());
+            internet.process(timeSource.getAbsoluteTime());
+            if (session->getState() == ice::IceSession::State::CONNECTING)
+            {
+                running = true;
+            }
+            if (sessionTimeout >= 0)
+            {
+                timeout = std::min(timeout, sessionTimeout);
+            }
+        }
+        if (running && timeout > 0)
+        {
+            timeSource.advance(timeout + 2);
+        }
+    }
+
+    ASSERT_EQ(sessions[0]->getRemoteCandidates().size(), 1);
+    EXPECT_EQ(sessions[0]->getState(), ice::IceSession::State::READY);
+
+    const auto session0Remotes = sessions[0]->getRemoteCandidates();
+    EXPECT_EQ(session0Remotes[0].type, ice::IceCandidate::Type::PRFLX);
+    EXPECT_TRUE(session0Remotes[0].address.equalsIp(firewall2.getPublicIp()));
+    // session 1 has a candidate, but session 0 cannot send request back on the probe
+
+    sessions[0]->setRemoteCredentials(sessions[1]->getLocalCredentials());
+    setRemoteCandidates(*sessions[0], *sessions[1]);
+    sessions[0]->probeRemoteCandidates(sessions[1]->getRole(), timeSource.getAbsoluteTime());
+    for (bool running = true; running;)
+    {
+        internet.process(timeSource.getAbsoluteTime());
+        int64_t timeout = std::numeric_limits<int64_t>::max();
+        running = false;
+        for (auto& session : sessions)
+        {
+            auto sessionTimeout = session->processTimeout(timeSource.getAbsoluteTime());
+            internet.process(timeSource.getAbsoluteTime());
+            if (session->getState() == ice::IceSession::State::CONNECTING)
+            {
+                running = true;
+            }
+            if (sessionTimeout >= 0)
+            {
+                timeout = std::min(timeout, sessionTimeout);
+            }
+        }
+        if (running && timeout > 0)
+        {
+            timeSource.advance(timeout + 2);
+        }
+    }
+
+    EXPECT_EQ(sessions[0]->getRemoteCandidates().size(), 4);
+    EXPECT_EQ(sessions[0]->getState(), ice::IceSession::State::CONNECTED);
+
+    // Continue until univable are discarded
+    const auto connectedTime = timeSource.getAbsoluteTime();
+    running = true;
+    while (running && timeSource.getAbsoluteTime() - connectedTime < utils::Time::sec * 6)
+    {
+        internet.process(timeSource.getAbsoluteTime());
+        int64_t timeout = std::numeric_limits<int64_t>::max();
+        running = false;
+        for (auto& session : sessions)
+        {
+            auto sessionTimeout = session->processTimeout(timeSource.getAbsoluteTime());
+            internet.process(timeSource.getAbsoluteTime());
+
+            if (sessionTimeout >= 0)
+            {
+                timeout = std::min(timeout, sessionTimeout);
+            }
+        }
+
+        if (sessions[0]->getRemoteCandidates().size() > 2)
+        {
+            running = true;
+        }
+
+        if (running && timeout > 0)
+        {
+            timeSource.advance(timeout + 2);
+        }
+    }
+
+    EXPECT_EQ(sessions[0]->getRemoteCandidates().size(), 2);
 }
 
 TEST_F(IceRobustness, roleConflict)

--- a/test/transport/IceTest.cpp
+++ b/test/transport/IceTest.cpp
@@ -1673,7 +1673,7 @@ TEST_F(IceRobustness, removeUnviableCandidates)
     // Continue until univable are discarded
     const auto connectedTime = timeSource.getAbsoluteTime();
     running = true;
-    while (running && timeSource.getAbsoluteTime() - connectedTime < utils::Time::sec * 6)
+    while (running && timeSource.getAbsoluteTime() - connectedTime < utils::Time::sec * 10)
     {
         internet.process(timeSource.getAbsoluteTime());
         int64_t timeout = std::numeric_limits<int64_t>::max();

--- a/test/transport/IceTest.cpp
+++ b/test/transport/IceTest.cpp
@@ -1606,13 +1606,13 @@ TEST_F(IceTest, udpTcpTimeout)
     endpoint2b.attach(sessions[1]);
 
     exchangeInfo(*sessions[0], *sessions[1]);
-    sessions[0]->addRemoteCandidate(ice::IceCandidate("werwe",
-                                        ice::IceComponent::RTP,
-                                        ice::TransportType::TCP,
-                                        12312,
-                                        endpoint2b._address,
-                                        ice::IceCandidate::Type::HOST,
-                                        ice::TcpType::PASSIVE),
+    sessions[0]->addRemoteTcpPassiveCandidate(ice::IceCandidate("werwe",
+                                                  ice::IceComponent::RTP,
+                                                  ice::TransportType::TCP,
+                                                  12312,
+                                                  endpoint2b._address,
+                                                  ice::IceCandidate::Type::HOST,
+                                                  ice::TcpType::PASSIVE),
         &endpoint1b);
     sessions[1]->addLocalTcpCandidate(ice::IceCandidate::Type::HOST,
         0,

--- a/test/utils/SocketAddressTest.cpp
+++ b/test/utils/SocketAddressTest.cpp
@@ -1,0 +1,83 @@
+#include "utils/SocketAddress.h"
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace transport;
+
+namespace
+{
+struct LogLevelSetAndRestore
+{
+    LogLevelSetAndRestore(logger::Level level) : _levelToRestore(logger::_logLevel) { logger::_logLevel = level; }
+    ~LogLevelSetAndRestore() { logger::_logLevel = _levelToRestore; }
+
+private:
+    logger::Level _levelToRestore;
+};
+
+} // namespace
+
+TEST(SocketAddressTest, toFixedStringIpv4)
+{
+    const auto socketAddress = SocketAddress::parse("127.0.0.1", 1096);
+    auto fixedStringSocket = socketAddress.toFixedString();
+
+    ASSERT_STREQ("127.0.0.1:1096", fixedStringSocket.c_str());
+    ASSERT_EQ(std::strlen("127.0.0.1:1096"), fixedStringSocket.size());
+}
+
+TEST(SocketAddressTest, toFixedStringIpv6)
+{
+    const auto socketAddress0 = SocketAddress::parse("2001:0000:130F:0000:0000:09C0:876A:130B", 65093);
+    auto fixedStringSocket0 = socketAddress0.toFixedString();
+    ASSERT_STREQ("2001:0:130f::9c0:876a:130b:65093", fixedStringSocket0.c_str());
+    ASSERT_EQ(std::strlen("2001:0:130f::9c0:876a:130b:65093"), fixedStringSocket0.size());
+
+    const auto socketAddress1 = SocketAddress::parse("0:0:0:0:0:0:0:1", 9);
+    auto fixedStringSocket1 = socketAddress1.toFixedString();
+    ASSERT_STREQ("::1:9", fixedStringSocket1.c_str());
+    ASSERT_EQ(std::strlen("::1:9"), fixedStringSocket1.size());
+}
+
+TEST(SocketAddressTest, maybeMaskShouldNotMaskWhenLogLevelIsDebug)
+{
+    LogLevelSetAndRestore l(logger::Level::DBG);
+
+    const auto ipv6Address = SocketAddress::parse("2001:0:130f::9c0:876a:130b", 1000);
+    const auto ipv4Address = SocketAddress::parse("64.63.123.98", 2665);
+
+    auto maybeMaskedIpv6 = maybeMasked(ipv6Address);
+    auto maybeMaskedIpv4 = maybeMasked(ipv4Address);
+
+    ASSERT_STREQ("2001:0:130f::9c0:876a:130b:1000", maybeMaskedIpv6.c_str());
+    ASSERT_EQ(std::strlen("2001:0:130f::9c0:876a:130b:1000"), maybeMaskedIpv6.size());
+
+    ASSERT_STREQ("64.63.123.98:2665", maybeMaskedIpv4.c_str());
+    ASSERT_EQ(std::strlen("64.63.123.98:2665"), maybeMaskedIpv4.size());
+}
+
+TEST(SocketAddressTest, maybeMaskShouldMaskWhenLogLevelIsNotDebug)
+{
+    std::array<logger::Level, 3> notDebugLevels = {
+        logger::Level::ERROR,
+        logger::Level::INFO,
+        logger::Level::WARN,
+    };
+
+    const auto ipv6Address = SocketAddress::parse("2001:0:130f::9c0:876a:130b", 1000);
+    const auto ipv4Address = SocketAddress::parse("64.63.123.98", 2665);
+
+    for (const auto level : notDebugLevels)
+    {
+        LogLevelSetAndRestore l(level);
+
+        auto maybeMaskedIpv6 = maybeMasked(ipv6Address);
+        auto maybeMaskedIpv4 = maybeMasked(ipv4Address);
+
+        ASSERT_STREQ("hash(6134717025100730244):1000", maybeMaskedIpv6.c_str());
+        ASSERT_EQ(std::strlen("hash(6134717025100730244):1000"), maybeMaskedIpv6.size());
+
+        ASSERT_STREQ("hash(14244227746646367573):2665", maybeMaskedIpv4.c_str());
+        ASSERT_EQ(std::strlen("hash(14244227746646367573):2665"), maybeMaskedIpv4.size());
+    }
+}

--- a/test/utils/SocketAddressTest.cpp
+++ b/test/utils/SocketAddressTest.cpp
@@ -74,10 +74,13 @@ TEST(SocketAddressTest, maybeMaskShouldMaskWhenLogLevelIsNotDebug)
         auto maybeMaskedIpv6 = maybeMasked(ipv6Address);
         auto maybeMaskedIpv4 = maybeMasked(ipv4Address);
 
-        ASSERT_STREQ("hash(6134717025100730244):1000", maybeMaskedIpv6.c_str());
-        ASSERT_EQ(std::strlen("hash(6134717025100730244):1000"), maybeMaskedIpv6.size());
+        const char* a = maybeMaskedIpv6.c_str();
+        (void)a;
 
-        ASSERT_STREQ("hash(14244227746646367573):2665", maybeMaskedIpv4.c_str());
-        ASSERT_EQ(std::strlen("hash(14244227746646367573):2665"), maybeMaskedIpv4.size());
+        ASSERT_STREQ("ipv6-6134717025100730244:1000", maybeMaskedIpv6.c_str());
+        ASSERT_EQ(std::strlen("ipv6-6134717025100730244:1000"), maybeMaskedIpv6.size());
+
+        ASSERT_STREQ("ipv4-14244227746646367573:2665", maybeMaskedIpv4.c_str());
+        ASSERT_EQ(std::strlen("ipv4-14244227746646367573:2665"), maybeMaskedIpv4.size());
     }
 }

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -2436,9 +2436,7 @@ void TransportImpl::onIceCandidateAccepted(ice::IceSession* session,
 
     for (auto& udpEndpoint : _rtpEndpoints)
     {
-        // static upper cast is a safer option to compare raw points as an
-        // offset might be added in case of multiple inheritance
-        // and ice::IceEndpoint* is not the first (although it not currently the case).
+        // static cast for type safe raw pointer comparison
         if (endpoint == static_cast<ice::IceEndpoint*>(udpEndpoint.get()))
         {
             udpEndpoint->registerListener(remoteCandidate.address, this);
@@ -2479,9 +2477,7 @@ void TransportImpl::onIceDiscardCandidate(ice::IceSession* session,
 
     for (auto& udpEndpoint : _rtpEndpoints)
     {
-        // static upper cast is a safer option to compare raw points as an
-        // offset might be added in case of multiple inheritance
-        // and ice::IceEndpoint* is not the first (although it not currently the case).
+        // static cast for type safe raw pointer comparison
         if (endpoint == static_cast<ice::IceEndpoint*>(udpEndpoint.get()))
         {
             udpEndpoint->unregisterListener(sourcePort, this);

--- a/transport/TransportImpl.cpp
+++ b/transport/TransportImpl.cpp
@@ -1968,8 +1968,8 @@ void TransportImpl::onIceCandidateChanged(ice::IceSession* session,
             _loggableId.c_str(),
             endpoint->getLocalPort().getFamilyString().c_str(),
             ice::toString(endpoint->getTransportType()).c_str(),
-            endpoint->getLocalPort().toString().c_str(),
-            sourcePort.toString().c_str());
+            endpoint->getLocalPort().toFixedString().c_str(),
+            maybeMasked(sourcePort).c_str());
 
         if (_srtpClient->getState() == SrtpClient::State::READY)
         {
@@ -1990,8 +1990,8 @@ void TransportImpl::onIceCandidateChanged(ice::IceSession* session,
             _loggableId.c_str(),
             endpoint->getLocalPort().getFamilyString().c_str(),
             ice::toString(endpoint->getTransportType()).c_str(),
-            endpoint->getLocalPort().toString().c_str(),
-            sourcePort.toString().c_str());
+            endpoint->getLocalPort().toFixedString().c_str(),
+            maybeMasked(sourcePort).c_str());
     }
 }
 
@@ -2019,8 +2019,8 @@ void TransportImpl::onIceStateChanged(ice::IceSession* session, const ice::IceSe
 
         logger::info("Pair selected: %s - %s  rtt:%" PRIu64 "us",
             _loggableId.c_str(),
-            candidatePair.first.address.toString().c_str(),
-            candidatePair.second.address.toString().c_str(),
+            candidatePair.first.address.toFixedString().c_str(),
+            maybeMasked(candidatePair.second.address).c_str(),
             rtt / utils::Time::us);
 
         if (_selectedRtp)
@@ -2431,8 +2431,8 @@ void TransportImpl::onIceCandidateAccepted(ice::IceSession* session,
         _loggableId.c_str(),
         endpoint->getLocalPort().getFamilyString().c_str(),
         ice::toString(endpoint->getTransportType()).c_str(),
-        endpoint->getLocalPort().toString().c_str(),
-        remoteCandidate.address.toString().c_str());
+        endpoint->getLocalPort().toFixedString().c_str(),
+        maybeMasked(remoteCandidate.address).c_str());
 
     for (auto& udpEndpoint : _rtpEndpoints)
     {
@@ -2471,8 +2471,8 @@ void TransportImpl::onIceDiscardCandidate(ice::IceSession* session,
             _loggableId.c_str(),
             endpoint->getLocalPort().getFamilyString().c_str(),
             ice::toString(endpoint->getTransportType()).c_str(),
-            endpoint->getLocalPort().toString().c_str(),
-            sourcePort.toString().c_str());
+            endpoint->getLocalPort().toFixedString().c_str(),
+            maybeMasked(sourcePort).c_str());
     }
 
     for (auto& udpEndpoint : _rtpEndpoints)

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -202,6 +202,9 @@ private: // SslWriteBioListener
     void onIceCandidateChanged(ice::IceSession* session,
         ice::IceEndpoint* endpoint,
         const SocketAddress& sourcePort) override;
+    void onIceCandidateAccepted(ice::IceSession* session,
+        ice::IceEndpoint* localEndpoint,
+        const ice::IceCandidate& remoteCandidate) override;
     void onIceDiscardCandidate(ice::IceSession* session,
         ice::IceEndpoint* endpoint,
         const transport::SocketAddress& sourcePort) override;

--- a/transport/ice/IceSession.cpp
+++ b/transport/ice/IceSession.cpp
@@ -303,8 +303,8 @@ IceSession::CandidatePair* IceSession::addProbeForRemoteCandidate(const Endpoint
 
     logger::info("added candidate pair %s-%s HOST-%s %s",
         _logId.c_str(),
-        endpointAddress.toString().c_str(),
-        remoteCandidate.address.toString().c_str(),
+        endpointAddress.toFixedString().c_str(),
+        maybeMasked(remoteCandidate.address).c_str(),
         ice::toString(remoteCandidate.type).c_str(),
         ice::toString(remoteCandidate.transportType).c_str());
 
@@ -616,7 +616,7 @@ bool IceSession::processValidStunUdpRequest(IceEndpoint* localEndpoint,
         logger::info("too many PRFLX candidates %u, %s",
             _logId.c_str(),
             _config.maxCandidateCount,
-            remotePort.toString().c_str());
+            maybeMasked(remotePort).c_str());
 
         // Although we are not able to accept this candidate (at least not now)
         // we should send probe response anyway as this candidate will not be
@@ -1359,8 +1359,8 @@ void IceSession::removeUnviableRemoteCandidates(uint64_t now)
             _logId.c_str(),
             toString(candidatePair->localEndpoint.endpoint->getTransportType()).c_str(),
             toString(candidatePair->remoteCandidate.type).c_str(),
-            candidatePair->localCandidate.address.toString().c_str(),
-            candidatePair->remoteCandidate.address.toString().c_str());
+            candidatePair->localCandidate.address.toFixedString().c_str(),
+            maybeMasked(candidatePair->remoteCandidate.address).c_str());
 
         candidatePair->state = ProbeState::Failed;
         std::iter_swap(it, --itEnd);
@@ -1428,8 +1428,8 @@ void IceSession::removeUnviableRemoteCandidates(uint64_t now)
             _logId.c_str(),
             toString(candidatePair->localEndpoint.endpoint->getTransportType()).c_str(),
             toString(candidatePair->remoteCandidate.type).c_str(),
-            candidatePair->localCandidate.address.toString().c_str(),
-            candidatePair->remoteCandidate.address.toString().c_str(),
+            candidatePair->localCandidate.address.toFixedString().c_str(),
+            maybeMasked(candidatePair->remoteCandidate.address).c_str(),
             candidatePair->isViable(now) ? "true" : "false");
 
         onCandidatePairRemoved(candidatePair);

--- a/transport/ice/IceSession.cpp
+++ b/transport/ice/IceSession.cpp
@@ -1271,7 +1271,6 @@ void IceSession::stateCheck(const uint64_t now)
 void IceSession::freezePendingProbes(uint64_t now)
 {
     // We are going to clear all remote candidates without candidatePairs
-    logger::info("-------------------------- STARTING freezePendingProbes -------------------", _logId.c_str());
     _remoteCandidates.clear();
     auto itEnd = _candidatePairs.end();
 
@@ -1317,7 +1316,6 @@ void IceSession::freezePendingProbes(uint64_t now)
     }
 
     _candidatePairs.erase(itEnd, _candidatePairs.end());
-    logger::info("-------------------------- DONE freezePendingProbes -------------------", _logId.c_str());
 }
 
 void IceSession::removeNonReadableRemoteCandidates(uint64_t now)

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -250,7 +250,7 @@ private:
     class CandidatePair
     {
     public:
-        CandidatePair(IceSession* iceSession,
+        CandidatePair(IceSession& iceSession,
             const EndpointInfo& localEndpoint,
             const IceCandidate& local,
             const IceCandidate& remote,
@@ -266,12 +266,12 @@ private:
         void send(uint64_t now);
         uint64_t getPriority(IceRole role) const;
         bool isFinished() const { return state == ProbeState::Succeeded || state == ProbeState::Failed; }
-        bool isReadable(uint64_t now) const
+        bool isViable(uint64_t now) const
         {
             return state != ProbeState::Failed && receptionTimestamp != 0 &&
                 utils::Time::diffLT(receptionTimestamp,
                     now,
-                    _iceSession->_config.notReadableCandidateTimeout * utils::Time::ms);
+                    _iceSession._config.notReadableCandidateTimeout * utils::Time::ms);
         };
 
         bool hasTransaction(const StunMessage& response) const;
@@ -307,7 +307,7 @@ private:
         uint64_t pendingRequestAge(uint64_t now) const;
         size_t pendingTransactionCount() const;
 
-        IceSession* _iceSession;
+        IceSession& _iceSession;
         uint64_t _transmitInterval;
         int _replies;
         IceError _errorCode;
@@ -337,7 +337,7 @@ private:
     bool isIceComplete(uint64_t now);
     void stateCheck(uint64_t now);
     void nominate(uint64_t now);
-    void removeNonReadableRemoteCandidates(uint64_t now);
+    void removeUnviableRemoteCandidates(uint64_t now);
     void freezePendingProbes(uint64_t now);
     void releaseFrozenProbes(uint64_t now);
     bool hasNomination() const;

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -394,6 +394,7 @@ private:
     IEvents* const _eventSink;
     SessionCredentials _credentials;
     uint64_t _sessionStart;
+    uint32_t _connectedCount;
     struct HmacComputers
     {
         crypto::HMAC local;

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -338,8 +338,9 @@ private:
     void stateCheck(uint64_t now);
     void nominate(uint64_t now);
     void removeUnviableRemoteCandidates(uint64_t now);
-    void freezePendingProbes(uint64_t now);
-    void releaseFrozenProbes(uint64_t now);
+    void pruneCandidatesAfterConnected(uint64_t now);
+    void cancelAllAfterFail(uint64_t now);
+    void restartProbes(uint64_t now);
     bool hasNomination() const;
     uint64_t getMaxStunServerCandidateAge(uint64_t now) const;
     IceCandidate::Type inferCandidateType(const transport::SocketAddress& mappedAddress);

--- a/transport/ice/IceSession.h
+++ b/transport/ice/IceSession.h
@@ -5,6 +5,7 @@
 #include "crypto/SslHelper.h"
 #include "memory/Map.h"
 #include "utils/SocketAddress.h"
+#include "utils/Time.h"
 #include <deque>
 
 namespace ice
@@ -24,6 +25,9 @@ struct IceConfig
     uint32_t reflexiveProbeTimeout = 15000; // probing towards reflexive
     uint32_t hostProbeTimeout = 5000; // probing towards host address
     uint32_t additionalCandidateTimeout = 2000; // before nominating TCP
+    uint32_t nominatedInProgressMaxTimeout = 1200; // max timeout to nominated is considered unreachable but not failed
+                                                   // yet. This should start a new candidate nomination
+                                                   //  The real timeout is this or 4x candidate rtt (whichever is lower)
     uint32_t connectTimeout = 30000;
     uint32_t RTO = 50; // initial RTO. RFC8489 says 500ms. This is faster in case of loss.
     uint32_t maxRTO = 1000;
@@ -31,6 +35,8 @@ struct IceConfig
     uint32_t probeConnectionExpirationTimeout = 5000;
     uint32_t transmitIntervalExtend = 10;
     uint32_t maxCandidateCount = 15;
+    uint32_t notReadableCandidateTimeout = 45000; // timeout to an candidate to be considered not readable and then be
+                                                  // removed if space for new candidates is needed
 
     std::string software = "slice"; // keep short please.
     transport::SocketAddress publicIpv4;
@@ -97,6 +103,8 @@ typedef std::vector<IceCandidate> IceCandidates;
 // It is not thread safe
 class IceSession
 {
+    struct EndpointInfo;
+
 public:
     enum class State
     {
@@ -125,6 +133,9 @@ public:
         virtual void onIceCandidateChanged(IceSession* session,
             IceEndpoint* localEndpoint,
             const transport::SocketAddress& remotePort) = 0;
+        virtual void onIceCandidateAccepted(IceSession* session,
+            IceEndpoint* localEndpoint,
+            const IceCandidate& remoteCandidate) = 0;
         virtual void onIceDiscardCandidate(IceSession* session,
             IceEndpoint* localEndpoint,
             const transport::SocketAddress& remotePort) = 0;
@@ -140,6 +151,7 @@ public:
     void attachLocalEndpoint(IceEndpoint* udpEndpoint);
 
     bool isAttached(const IceEndpoint* localEndpoint) const;
+    const EndpointInfo* findEndpointInfo(const IceEndpoint* localEndpoint) const;
     void gatherLocalCandidates(const std::vector<transport::SocketAddress>& stunServers, uint64_t timestamp);
     const std::pair<std::string, std::string>& getLocalCredentials() const;
     void setLocalCredentials(const std::pair<std::string, std::string>& credentials);
@@ -156,7 +168,7 @@ public:
     void removeLocalCandidate(const IceCandidate& localCandidate);
 
     const IceCandidate& addRemoteCandidate(const IceCandidate& udpCandidate);
-    void addRemoteCandidate(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
+    void addRemoteTcpPassiveCandidate(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
     void removeRemoteCandidate(const IceCandidate& remoteCandidate);
 
     void setRemoteCredentials(const std::string& ufrag, const std::string& pwd);
@@ -187,6 +199,7 @@ public:
 
     bool isRequestAuthentic(const void* data, size_t len) const;
     bool isResponseAuthentic(const void* data, size_t len) const;
+    bool isIceAuthentic(const void* data, size_t len) const;
 
     int64_t nextTimeout(uint64_t timestamp) const;
     int64_t processTimeout(uint64_t timestamp);
@@ -204,8 +217,6 @@ public:
     }
 
     void stop();
-
-    bool canAcceptNewRemoteCandidate(uint64_t timestamp, const transport::SocketAddress& address) const;
 
 private:
     class CandidatePair;
@@ -239,14 +250,10 @@ private:
     class CandidatePair
     {
     public:
-        CandidatePair(const IceConfig& config,
+        CandidatePair(IceSession* iceSession,
             const EndpointInfo& localEndpoint,
             const IceCandidate& local,
             const IceCandidate& remote,
-            StunTransactionIdGenerator& idGenerator,
-            const SessionCredentials& credentials,
-            crypto::HMAC& hmacComputerRemote,
-            const std::string& name,
             bool gathering);
 
         CandidatePair& operator=(const CandidatePair&) = delete;
@@ -254,16 +261,25 @@ private:
         int64_t nextTimeout(uint64_t now) const;
         void processTimeout(uint64_t now);
 
-        void restartProbe(const uint64_t now);
+        void restartProbe(const uint64_t now, bool releaseNomination);
+        int64_t nominatedInProgressNextTimedout(const uint64_t now) const;
         void send(uint64_t now);
         uint64_t getPriority(IceRole role) const;
         bool isFinished() const { return state == ProbeState::Succeeded || state == ProbeState::Failed; }
+        bool isReadable(uint64_t now) const
+        {
+            return state != ProbeState::Failed && receptionTimestamp != 0 &&
+                utils::Time::diffLT(receptionTimestamp,
+                    now,
+                    _iceSession->_config.notReadableCandidateTimeout * utils::Time::ms);
+        };
 
         bool hasTransaction(const StunMessage& response) const;
         StunTransaction* findTransaction(const StunMessage& response);
         void onResponse(uint64_t now, const StunMessage& response);
         void onDisconnect();
         void nominate(uint64_t now);
+        void accept();
         void freeze();
         void failCandidate(IceError reason);
 
@@ -279,11 +295,10 @@ private:
         uint64_t startTime;
         uint64_t nextTransmission;
         bool nominated;
+        bool accepted;
 
         uint64_t receptionTimestamp; // RTC+ICE traffic
-
         ProbeState state;
-
         StunMessage original;
 
     private:
@@ -292,28 +307,25 @@ private:
         uint64_t pendingRequestAge(uint64_t now) const;
         size_t pendingTransactionCount() const;
 
+        IceSession* _iceSession;
         uint64_t _transmitInterval;
         int _replies;
         IceError _errorCode;
         uint64_t _minRtt;
-        const std::string& _name;
         std::deque<StunTransaction> _transactions; // TODO replace with inplace circular container
-        StunTransactionIdGenerator& _idGenerator;
-        const IceConfig& _config;
-        const SessionCredentials& _credentials;
-        crypto::HMAC& _hmacComputer;
     };
 
-    CandidatePair* addRemoteTcpCandidate(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
-    CandidatePair* addProbeForRemoteCandidate(EndpointInfo& localEndpoint, const IceCandidate& remoteCandidate);
+    CandidatePair* addProbeForRemoteCandidate(const EndpointInfo& localEndpoint, const IceCandidate& remoteCandidate);
     void sortCheckList();
 
     CandidatePair* findCandidatePair(const IceEndpoint* localEndpoint,
         const StunMessage& response,
         const transport::SocketAddress& remotePort);
     CandidatePair* findCandidatePair(const IceEndpoint* localEndpoint, const transport::SocketAddress& remotePort);
+    CandidatePair* addRemoteTcpCandidateAndCreatePair(const IceCandidate& tcpCandidate, IceEndpoint* tcpEndpoint);
 
-    void removeCandidatePair(const CandidatePair* candidatePair);
+    void onCandidatePairRemoved(CandidatePair* candidatePair);
+    void removeCandidatePair(CandidatePair* candidatePair);
     void sendResponse(IceEndpoint* localEndpoint,
         const transport::SocketAddress& target,
         int code,
@@ -325,11 +337,29 @@ private:
     bool isIceComplete(uint64_t now);
     void stateCheck(uint64_t now);
     void nominate(uint64_t now);
+    void removeNonReadableRemoteCandidates(uint64_t now);
     void freezePendingProbes(uint64_t now);
     void releaseFrozenProbes(uint64_t now);
     bool hasNomination() const;
     uint64_t getMaxStunServerCandidateAge(uint64_t now) const;
     IceCandidate::Type inferCandidateType(const transport::SocketAddress& mappedAddress);
+
+    void processValidStunRequest(IceEndpoint* localEndpoint,
+        const transport::SocketAddress& remotePort,
+        const StunMessage& data,
+        uint64_t now);
+
+    bool processValidStunTcpRequest(IceEndpoint* localEndpoint,
+        const transport::SocketAddress& remotePort,
+        const StunMessage& data,
+        int remoteCandidatePriority,
+        uint64_t now);
+
+    bool processValidStunUdpRequest(IceEndpoint* localEndpoint,
+        const transport::SocketAddress& remotePort,
+        const StunMessage& data,
+        int remoteCandidatePriority,
+        uint64_t now);
 
     void onRequestReceived(IceEndpoint* localEndpoint,
         const transport::SocketAddress& remotePort,

--- a/transport/ice/Stun.h
+++ b/transport/ice/Stun.h
@@ -250,8 +250,9 @@ public:
     enum Code
     {
         BadRequest = 400,
-        Unauthorized,
-        RoleConflict = 487
+        Unauthorized = 401,
+        RoleConflict = 487,
+        ServerError = 500,
     };
     StunError(int code, std::string phrase) : StunAttribute(ERROR_CODE)
     {

--- a/utils/FixString.h
+++ b/utils/FixString.h
@@ -2,6 +2,7 @@
 #include "utils/FowlerNollHash.h"
 #include "utils/StdExtensions.h"
 #include <algorithm>
+#include <cstdarg>
 #include <cstring>
 
 namespace utils

--- a/utils/FixString.h
+++ b/utils/FixString.h
@@ -51,6 +51,24 @@ public:
 
     int compare(const char* s) const { return compare(s, std::strlen(s)); }
 
+    __attribute__((format(printf, 1, 2))) static FixString<SIZE> sprintf(const char* format, ...)
+    {
+        FixString<SIZE> str;
+
+        va_list arglist;
+        va_start(arglist, format);
+        const int written = std::vsnprintf(str._value, sizeof(str._value), format, arglist);
+        va_end(arglist);
+
+        if (written > -1)
+        {
+            str._size = std::min(static_cast<size_t>(written), SIZE);
+        }
+
+        str._value[SIZE] = '\0';
+        return str;
+    }
+
 private:
     size_t _size;
     char _value[SIZE + 1];

--- a/utils/SocketAddress.h
+++ b/utils/SocketAddress.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "logger/Logger.h"
+#include "utils/FixString.h"
 #include "utils/FowlerNollHash.h"
 #include <arpa/inet.h>
 #include <cassert>
@@ -46,6 +48,7 @@ public:
     SocketAddress& setPort(uint16_t port);
     std::string ipToString() const;
     std::string toString() const;
+    utils::FixString<46> toFixedString() const;
 
     uint16_t getPort() const;
 
@@ -119,3 +122,36 @@ private:
 };
 
 } // namespace std
+
+namespace transport
+{
+/**
+ * This function will mask the IP if the log level is not debug
+ */
+inline utils::FixString<46> maybeMasked(const SocketAddress& address)
+{
+
+    if (logger::_logLevel != logger::Level::DBG)
+    {
+        size_t ipHash = 0;
+        if (address.getFamily() == AF_INET6)
+        {
+            const auto sin6 = address.getIpv6()->sin6_addr;
+            ipHash = utils::FowlerNollVoHash(&sin6, sizeof(sin6));
+        }
+        else if (address.getFamily() == AF_INET)
+        {
+            const auto sin = address.getIpv4()->sin_addr;
+            ipHash = utils::FowlerNollVoHash(&sin, sizeof(sin));
+        }
+        else
+        {
+            assert(false);
+        }
+
+        return utils::FixString<46>::sprintf("hash(%zu):%" PRIu16, ipHash, address.getPort());
+    }
+
+    return address.toFixedString();
+}
+} // namespace transport

--- a/utils/SocketAddress.h
+++ b/utils/SocketAddress.h
@@ -133,23 +133,26 @@ inline utils::FixString<46> maybeMasked(const SocketAddress& address)
 
     if (logger::_logLevel != logger::Level::DBG)
     {
+        const char* prefix = "";
         size_t ipHash = 0;
         if (address.getFamily() == AF_INET6)
         {
             const auto sin6 = address.getIpv6()->sin6_addr;
             ipHash = utils::FowlerNollVoHash(&sin6, sizeof(sin6));
+            prefix = "ipv6-";
         }
         else if (address.getFamily() == AF_INET)
         {
             const auto sin = address.getIpv4()->sin_addr;
             ipHash = utils::FowlerNollVoHash(&sin, sizeof(sin));
+            prefix = "ipv4-";
         }
         else
         {
             assert(false);
         }
 
-        return utils::FixString<46>::sprintf("hash(%zu):%" PRIu16, ipHash, address.getPort());
+        return utils::FixString<46>::sprintf("%s%zu:%" PRIu16, prefix, ipHash, address.getPort());
     }
 
     return address.toFixedString();


### PR DESCRIPTION
### Problem
We've had some issues with users complaining that they can't hear anyone, but are heard by others. After analyzing the logs we noticed that there are some problems when SMB tries to nominate a new ICE candidate that sometimes fails and let the ICE state in FAILED on SMB,  while clients have a different ICE state which cause the clients to continue in the meeting without trigger the recover (in Symphony this process creates a completely new session that takes over the older one).

We observed that in one of the cases, client presented 1 IPv6 candidate and 1 IPv4. SMB nominates IPv6 and discard IPv4 PRFLX candidate after CONNECTED state. Then something happened with IPv6 and SMB changed the ICE state to CONNECTING trying to select a new candidate and it failed after 15 seconds. Although it was not nominated a new candidate, client logs shows that WebRTC decided to use IPv4 candidate to send as the IPv6 was not reachable. The problem on IPv6 seems to had been a temporary glitch and clients logs shows that the client continued to receive media from SMB through the IPv6 after this event (but SMB was already on FAILED state), that works for a few minutes until it stops to work (perhaps client firewall close the port due to lack of outbound traffic through the IPv6) and client stops to receive media while it continued to send through the IPv4.

This is caused by this issues:
1. SMB stills to respond to client ICE requests when the state is FAILED. This could mean that clients do not fail the ICE on their side, leaving the SMB and clients with different views of the ICE state.
2. After ICE state goes to CONNECTED, SMB discards good PRFLX candidates that could potential be used as backup if something happens with the nominated.
3. After 15 seconds (`reflexiveProbeTimeout`) of being in CONNECTED state, SMB stops to accept new PRFLX candidates. SMB can accept PRFLX candidates again if it goes to CONNECTING state but it has only 15 seconds to see the PRFLX candidates before fail. WebRTC client seems to be quick on detection of ICE problems and they can start probe all backups candidates again before SMB goes to CONNECTING and spend the next 25 seconds without probing them again, causing SMB to fail before see the PRFLX candidates.

### Solution
With this change we stop to respond to ICE STUN request when the ICE state on SMB is FAILED. SMB does not have any mechanism to report the ICE state to the components that manage the signalling with clients nor it has a way to restart the ICE (which involves a new SDP offer-answer negation with a different ICE username). Then, the best decision SMB can take is stop to respond to ICE STUN request which will cause the ICE state on client to go to FAILED as well and then clients can trigger the recover on their end.

Also we don't discard good PRFLX candidates only because they were not nominated. They will be kept as backup candidates if the nominated becomes unreachable. This relies on the fact that the main WebRTC implementation (Google implementation) keeps probing the backup candidates each 25 seconds, preventing to NAT/firewall to recycle the port while SMB has the candidates pair on frozen state.

We also accept candidates anytime. This is not required as the initial problem was discarding backup candidates. So if we keep the backup candidates, then we could stop accept new candidates after a few seconds as the ICE gathering will complete and no new candidates could be gather according to the standard.
**BUT**, although NOT standardized, Google WebRTC allows to configure a "GATHER_CONTINUALLY" (at least via native lib, I am not sure if it possible via browser), `GATHER_CONTINUALLY` makes the gathering to never finish, this can be very useful for mobile phones where it is relatively easy to start a call on mobile data and to connect to a WiFi network later on, or vice-verse. We are exploring ways to improve mobile user experience in Symphony and I am eager to enable this configuration on mobile.

### Future improvements
With `GATHER_CONTINUALLY` enabled, other non standardized mechanism Google implements is ICE renomination. Unlike `GATHER_CONTINUALLY`, which is a WebRTC peer connection configuration that seems to be accessible only through the native WebRTC, ICE renomination seems to be possible to be negotiated via SDP. There is a draft for the renomination https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination-00 and it seems to be very useful together with `GATHER_CONTINUALLY`.

Other Google STUN attribute to explore is `STUN_ATTR_GOOG_NETWORK_INFO` this give us information about the network and it seems to be possible to infer if candidate is from 2G/3G/4G/5G, WIFI, ETHERNET and even if is using a VPN. Together with `CONTINUALLY_GATHERING` + ICE renomination, this attribute can be used to quick change to a better candidate once it is available
