### PR TITLE
MEDIA-2669: Fix SMB crash

### DIFF
--- a/bridge/Bridge.cpp
+++ b/bridge/Bridge.cpp
@@ -74,6 +74,11 @@ Bridge::Bridge(const config::Config& config)
 
 Bridge::~Bridge()
 {
+    if (_httpd)
+    {
+        _httpd = nullptr;
+    }
+
     if (_mixerManager)
     {
         _mixerManager->stop();

--- a/test/integration/emulator/FakeTcpEndpoint.cpp
+++ b/test/integration/emulator/FakeTcpEndpoint.cpp
@@ -166,7 +166,7 @@ void FakeTcpEndpoint::stop(Endpoint::IStopEvents* listener)
             _receiveJobs.post([this, listener]() { listener->onEndpointStopped(this); });
         }
     }
-    else if (_state == State::CREATED)
+    else if (_state == State::CREATED || _state == State::STOPPING)
     {
         if (listener)
         {

--- a/test/transport/FakeNetwork.cpp
+++ b/test/transport/FakeNetwork.cpp
@@ -426,6 +426,7 @@ void Firewall::removePortMapping(Protocol protocol, transport::SocketAddress& la
 
 void Firewall::block(const transport::SocketAddress& source, const transport::SocketAddress& destination)
 {
+    std::lock_guard<std::mutex> lock(_nodesMutex);
     if (isBlackListed(source, destination))
     {
         return;
@@ -436,6 +437,7 @@ void Firewall::block(const transport::SocketAddress& source, const transport::So
 
 void Firewall::unblock(const transport::SocketAddress& source, const transport::SocketAddress& destination)
 {
+    std::lock_guard<std::mutex> lock(_nodesMutex);
     auto it = _blackList.find(std::pair<transport::SocketAddress, transport::SocketAddress>(source, destination));
     if (it != _blackList.end())
     {

--- a/transport/TcpEndpointImpl.h
+++ b/transport/TcpEndpointImpl.h
@@ -16,7 +16,7 @@ public:
 
     memory::UniquePacket receive();
 
-    bool isGood() const { return fd != -1 && _streamPrestine && !_remoteDisconnect; }
+    bool isGood() const { return fd != -1 && _streamPristine && !_remoteDisconnect; }
     bool hasRemoteDisconnected() const { return _remoteDisconnect; }
     void close();
 
@@ -27,7 +27,7 @@ private:
     size_t _receivedBytes;
     memory::UniquePacket _incompletePacket;
     memory::PacketPoolAllocator& _allocator;
-    bool _streamPrestine;
+    bool _streamPristine;
     bool _remoteDisconnect;
 };
 

--- a/transport/TransportImpl.h
+++ b/transport/TransportImpl.h
@@ -52,7 +52,8 @@ class TransportImpl : public RtcTransport,
                       public sctp::SctpServerPort::IEvents,
                       public sctp::SctpAssociation::IEvents,
                       public ServerEndpoint::IEvents,
-                      private RtcpReportProducer::RtcpSender
+                      private RtcpReportProducer::RtcpSender,
+                      private Endpoint::IStopEvents
 {
 public:
     TransportImpl(jobmanager::JobManager& jobmanager,
@@ -238,6 +239,8 @@ private: // SslWriteBioListener
         uint64_t timestamp) override;
 
     void onTcpDisconnect(Endpoint& endpoint) override;
+    void onEndpointStopped(Endpoint* endpoint) override;
+    void onTcpEndpointStoppedInternal(Endpoint* endpoint);
 
     void onIceTcpConnect(std::shared_ptr<Endpoint> endpoint,
         const SocketAddress& source,


### PR DESCRIPTION
This PR is on top of #377 to avoid merge conflicts. Will rebase this branch on #377 is merged.

This fixes 2 crashes:
 - After nominate a candidate, all TCP connections that does not belongs to nominated ICE are going to be deleted. The crash happen due to a race between deletion (which the endpoint is removed from `IceSession` before erased on std::vector) with a STUN request that was already enqueued on jobQueue that will re-add the endpoint again on `IceSession`. Although the delete takes some time because it has to terminate the socket, the endpoint pointer on `IceSession` will became dangling sooner or later and it will crash if we try to access it. Ensuring that we will not call the `IceSession` if the endpoint already does not belongs to the TransportImpl does not fix the issue (although it could became much less probable). We need to ensure we don't have any enqueued job for that endpoint so `stop` has to be made by Transport instead of being delegate to the destructor so we can have the state synced.
 
 - The 2nd crash is less problematic as it happens only when we are terminating the SMB. We need to stop httpd first so we ensure we don't have http requests trying to access resources that were already deleted