### PR TITLE
Dockerupgrade

### DIFF
--- a/docker/aws-linux/Dockerfile
+++ b/docker/aws-linux/Dockerfile
@@ -2,15 +2,15 @@ FROM amazonlinux:2
 
 RUN yum -y update && yum -y upgrade
 RUN yum -y groupinstall "Development Tools"
-RUN yum -y install git wget which
+RUN yum -y install git wget which perl-IPC-Cmd
 RUN amazon-linux-extras enable python3.8 && yum -y install python3.8
 
-# Build openssl-1.1.1s
-RUN cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz && tar xvfz openssl-1.1.1s.tar.gz && rm openssl-1.1.1s.tar.gz
-RUN cd /tmp/openssl-1.1.1s && ./config && make -j5 && make install_sw
+# Build openssl-3.4.0
+RUN cd /tmp && wget https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz && tar xvfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz
+RUN cd /tmp/openssl-3.4.0 && ./config && make -j5 && make install_sw
 
-RUN cd /tmp && wget https://cmake.org/files/v3.18/cmake-3.18.0.tar.gz && tar -xvzf cmake-3.18.0.tar.gz \
-    && cd cmake-3.18.0 && ./bootstrap && make -j5 && make install
+RUN cd /tmp && wget https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar -xvzf cmake-3.30.0.tar.gz \
+    && cd cmake-3.30.0 && ./bootstrap && make -j5 && make install
 
 RUN cd /tmp \
     && wget -O clang+llvm-12.0.1-x86_64-linux.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
@@ -21,12 +21,11 @@ RUN cd /tmp \
     && ln -s /usr/local/bin/lld /usr/local/bin/ld \
     && rm clang+llvm-12.0.1-x86_64-linux.tar.xz
 
-
-# Build libsrtp 2.4.2
+# Build libsrtp 2.6.0
 RUN cd /tmp \
     && git clone https://github.com/cisco/libsrtp \
     && cd /tmp/libsrtp \
-    && git checkout v2.4.2 \
+    && git checkout v2.6.0 \
     && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl \
     && make -j5 \
     && make install

--- a/docker/aws-linux/buildscript.sh
+++ b/docker/aws-linux/buildscript.sh
@@ -43,8 +43,8 @@ fi
 cp /usr/lib64/libatomic.so.1 libs
 cp /usr/local/lib/libc++.so.1 libs
 cp /usr/local/lib/libc++abi.so.1 libs
-cp /usr/local/lib64/libssl.so.1.1 libs
-cp /usr/local/lib64/libcrypto.so.1.1 libs
+cp /usr/local/lib64/libssl.so.3 libs
+cp /usr/local/lib64/libcrypto.so.3 libs
 cp /usr/local/lib/libmicrohttpd.so.12 libs
 cp /usr/local/lib/libopus.so.0 libs
 

--- a/docker/aws-linux/buildscript.sh
+++ b/docker/aws-linux/buildscript.sh
@@ -43,6 +43,8 @@ fi
 cp /usr/lib64/libatomic.so.1 libs
 cp /usr/local/lib/libc++.so.1 libs
 cp /usr/local/lib/libc++abi.so.1 libs
+cp /usr/local/lib64/libssl.so.1.1 libs
+cp /usr/local/lib64/libcrypto.so.1.1 libs
 cp /usr/local/lib64/libssl.so.3 libs
 cp /usr/local/lib64/libcrypto.so.3 libs
 cp /usr/local/lib/libmicrohttpd.so.12 libs

--- a/docker/el8/Dockerfile
+++ b/docker/el8/Dockerfile
@@ -3,7 +3,7 @@ FROM redhat/ubi8:latest
 RUN yum -y update && yum -y upgrade
 
 # Install build dependenices
-RUN yum -y install git llvm-toolset cmake libtool wget lsof python3 perl-IO-Compress perl-JSON-PP make perl-Pod-Html xz
+RUN yum -y install git cmake llvm-toolset libtool wget lsof python3 perl-IO-Compress perl-JSON-PP perl-IPC-Cmd make perl-Pod-Html xz
 
 # Build lcov 1.15
 RUN cd /tmp && git clone https://github.com/linux-test-project/lcov.git
@@ -15,13 +15,21 @@ RUN cd /tmp/llvm-project/ && mkdir build
 RUN cd /tmp/llvm-project/build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi' ../llvm/
 RUN cd /tmp/llvm-project/build && make -j5 cxx && make install-cxx install-cxxabi
 
-# Build openssl-1.1.1s
-RUN cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz && tar xvfz openssl-1.1.1s.tar.gz && rm openssl-1.1.1s.tar.gz
-RUN cd /tmp/openssl-1.1.1s && ./config && make -j5 && make install_sw
+# Build openssl-3.4.0
+RUN cd /tmp && wget https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz && tar xvfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz
+RUN cd /tmp/openssl-3.4.0 && ./config && make -j5 && make install_sw
 
-# Build libsrtp 2.4.2
-RUN cd /tmp && git clone https://github.com/cisco/libsrtp
-RUN cd /tmp/libsrtp && git checkout v2.4.2 && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl && make -j5 && make install
+RUN yum -y remove cmake && cd /tmp && wget https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar -xvzf cmake-3.30.0.tar.gz \
+    && cd cmake-3.30.0 && ./bootstrap && make -j5 && make install
+
+# Build libsrtp 2.6.0
+RUN cd /tmp \
+    && git clone https://github.com/cisco/libsrtp \
+    && cd /tmp/libsrtp \
+    && git checkout v2.6.0 \
+    && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl \
+    && make -j5 \
+    && make install
 
 # Build libmicrohttpd 0.9.73
 RUN cd /tmp && wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.73.tar.gz && tar xvfz libmicrohttpd-0.9.73.tar.gz

--- a/docker/el8/buildscript.sh
+++ b/docker/el8/buildscript.sh
@@ -41,8 +41,8 @@ fi
 
 cp /usr/local/lib/libc++.so.1 libs
 cp /usr/local/lib/libc++abi.so.1 libs
-cp /usr/local/lib64/libssl.so.1.1 libs
-cp /usr/local/lib64/libcrypto.so.1.1 libs
+cp /usr/local/lib64/libssl.so.3 libs
+cp /usr/local/lib64/libcrypto.so.3 libs
 cp /usr/local/lib/libmicrohttpd.so.12 libs
 cp /usr/local/lib/libopus.so.0 libs
 

--- a/docker/ubuntu-focal/Dockerfile
+++ b/docker/ubuntu-focal/Dockerfile
@@ -7,13 +7,21 @@ RUN apt-get -y update --fix-missing && apt-get -y upgrade
 # Install build dependenices
 RUN apt-get -y install git wget cmake xz-utils libz-dev build-essential
 
-# Build openssl-1.1.1s
-RUN cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz && tar xvfz openssl-1.1.1s.tar.gz && rm openssl-1.1.1s.tar.gz
-RUN cd /tmp/openssl-1.1.1s && ./config && make -j5 && make install_sw
+# Build openssl-3.4.0
+RUN cd /tmp && wget https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz && tar xvfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz
+RUN cd /tmp/openssl-3.4.0 && ./config && make -j5 && make install_sw
 
-# Build libsrtp 2.4.2
-RUN cd /tmp && git clone https://github.com/cisco/libsrtp
-RUN cd /tmp/libsrtp && git checkout v2.4.2 && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-openssl && make -j5 && make install
+RUN apt-get -y remove cmake && cd /tmp && wget https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar -xvzf cmake-3.30.0.tar.gz \
+    && cd cmake-3.30.0 && ./bootstrap && make -j5 && make install
+
+# Build libsrtp 2.6.0
+RUN cd /tmp \
+    && git clone https://github.com/cisco/libsrtp \
+    && cd /tmp/libsrtp \
+    && git checkout v2.6.0 \
+    && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl \
+    && make -j5 \
+    && make install
 
 RUN cd /tmp \
     && wget -O clang+llvm-12.0.1-x86_64-linux.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz \

--- a/docker/ubuntu-focal/Dockerfile
+++ b/docker/ubuntu-focal/Dockerfile
@@ -5,14 +5,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update --fix-missing && apt-get -y upgrade
 
 # Install build dependenices
-RUN apt-get -y install git wget cmake xz-utils libz-dev build-essential
+RUN apt-get -y install git wget xz-utils libz-dev build-essential
+
+RUN mkdir -p /usr/local/cmake-3.30 
+RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-Linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local/cmake-3.30 
+ENV PATH="/usr/local/cmake-3.30/bin:${PATH}"
 
 # Build openssl-3.4.0
 RUN cd /tmp && wget https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz && tar xvfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz
 RUN cd /tmp/openssl-3.4.0 && ./config && make -j5 && make install_sw
-
-RUN apt-get -y remove cmake && cd /tmp && wget https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar -xvzf cmake-3.30.0.tar.gz \
-    && cd cmake-3.30.0 && ./bootstrap && make -j5 && make install
 
 # Build libsrtp 2.6.0
 RUN cd /tmp \

--- a/docker/ubuntu-focal/buildscript.sh
+++ b/docker/ubuntu-focal/buildscript.sh
@@ -41,8 +41,8 @@ fi
 cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 libs
 cp /usr/local/lib/libc++.so.1 libs
 cp /usr/local/lib/libc++abi.so.1 libs
-cp /usr/local/lib/libssl.so.1.1 libs
-cp /usr/local/lib/libcrypto.so.1.1 libs
+cp /usr/local/lib64/libssl.so.3 libs
+cp /usr/local/lib64/libcrypto.so.3 libs
 cp /usr/local/lib/libmicrohttpd.so.12 libs
 cp /usr/local/lib/libopus.so.0 libs
 

--- a/docker/ubuntu-jammy/Dockerfile
+++ b/docker/ubuntu-jammy/Dockerfile
@@ -7,13 +7,21 @@ RUN apt-get -y update --fix-missing && apt-get -y upgrade
 # Install build dependenices
 RUN apt-get -y install git wget cmake xz-utils libz-dev build-essential
 
-# Build openssl-1.1.1s
-RUN cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz && tar xvfz openssl-1.1.1s.tar.gz && rm openssl-1.1.1s.tar.gz
-RUN cd /tmp/openssl-1.1.1s && ./config && make -j5 && make install_sw
+# Build openssl-3.4.0
+RUN cd /tmp && wget https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz && tar xvfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz
+RUN cd /tmp/openssl-3.4.0 && ./config && make -j5 && make install_sw
 
-# Build libsrtp 2.4.2
-RUN cd /tmp && git clone https://github.com/cisco/libsrtp
-RUN cd /tmp/libsrtp && git checkout v2.4.2 && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-openssl && make -j5 && make install
+RUN apt-get -y remove cmake && cd /tmp && wget https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar -xvzf cmake-3.30.0.tar.gz \
+    && cd cmake-3.30.0 && ./bootstrap && make -j5 && make install
+
+# Build libsrtp 2.6.0
+RUN cd /tmp \
+    && git clone https://github.com/cisco/libsrtp \
+    && cd /tmp/libsrtp \
+    && git checkout v2.6.0 \
+    && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl \
+    && make -j5 \
+    && make install
 
 RUN cd /tmp \
     && wget -O clang+llvm-12.0.1-x86_64-linux.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz \

--- a/docker/ubuntu-jammy/buildscript.sh
+++ b/docker/ubuntu-jammy/buildscript.sh
@@ -41,8 +41,8 @@ fi
 cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 libs
 cp /usr/local/lib/libc++.so.1 libs
 cp /usr/local/lib/libc++abi.so.1 libs
-cp /usr/local/lib/libssl.so.1.1 libs
-cp /usr/local/lib/libcrypto.so.1.1 libs
+cp /usr/local/lib64/libssl.so.3 libs
+cp /usr/local/lib64/libcrypto.so.3 libs
 cp /usr/local/lib/libmicrohttpd.so.12 libs
 cp /usr/local/lib/libopus.so.0 libs
 


### PR DESCRIPTION
This is an update of Dockerfiles to use 
openssl 3.4.0
cmake
libsrtp 2.6.0
building and pushing new docker images is needed for this to have any effect on the builds.
Building a much older version of smb may not be possible on the new docker images.
