### PR TITLE
Fix UT mixed audio analysis

### DIFF
--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -348,3 +348,25 @@ void IntegrationTest::enterRealTime(size_t expectedThreadCount, const uint64_t t
     // release all sleeping threads into real time to finish the test
     _timeSource.shutdown();
 }
+
+// When several audio streams are mixed, they all pass jitter buffers and audio time compression.
+// This means that some frequencies may appear that are 6% above original frequency.
+void IntegrationTest::removeTimeCompressionArtifacts(std::vector<double>& freqVector)
+{
+    std::sort(freqVector.begin(), freqVector.end());
+
+    double prevFreq = -5000;
+    for (auto it = freqVector.begin(); it != freqVector.end();)
+    {
+        if (*it < prevFreq * 1.1 && *it > prevFreq)
+        {
+            logger::debug("eliminating time compressed frequency %.2f", "IntegrationTest", *it);
+            it = freqVector.erase(it);
+        }
+        else
+        {
+            prevFreq = *it;
+            ++it;
+        }
+    }
+}

--- a/test/integration/IntegrationTest.h
+++ b/test/integration/IntegrationTest.h
@@ -206,8 +206,12 @@ public:
                 codec::Opus::sampleRate,
                 mixedAudioSources ? expectedDurationSeconds * utils::Time::ms : 0);
 
+            logger::flushLog();
+            logger::awaitLogDrained(0, 100 * utils::Time::ms);
+
             if (mixedAudioSources)
             {
+                removeTimeCompressionArtifacts(freqVector);
                 EXPECT_EQ(freqVector.size(), mixedAudioSources);
                 EXPECT_GE(rec.size(), expectedDurationSeconds * codec::Opus::sampleRate);
             }
@@ -314,6 +318,8 @@ protected:
     void startSimulation();
 
     void initLocalTransports(config::Config& bridgeConfig);
+
+    static void removeTimeCompressionArtifacts(std::vector<double>& freqVector);
 
 protected:
     emulator::TimeTurner _timeSource;


### PR DESCRIPTION
When integration test runs in real time, there can be time compression of audio going into mixed output. This creates sibling frequencies with +5%Hz. This makes tests flaky as more frequencies than expected may appear in the FFT.
This fix prunes such artifacts so tests are more reliable when mixed output is produced.