### PR TITLE
Fix Flaky MixAudio Unit tests

### DIFF
--- a/logger/LoggerThread.cpp
+++ b/logger/LoggerThread.cpp
@@ -22,8 +22,6 @@ LoggerThread::LoggerThread(const char* logFileName, bool logStdOut, bool logStdE
       _lastMaintenanceTime(0),
       _thread(new std::thread([this] { this->run(); }))
 {
-    _reOpenLog.test_and_set();
-    reopenLogFile();
 }
 
 void LoggerThread::reopenLogFile()
@@ -52,6 +50,9 @@ void LoggerThread::run()
     concurrency::setThreadName("Logger");
     char localTime[timeStringLength];
     bool gotLogItem = false;
+    _reOpenLog.test_and_set();
+    reopenLogFile();
+
     for (;;)
     {
         const auto item = _logQueue.front();
@@ -78,10 +79,12 @@ void LoggerThread::run()
         {
             if (gotLogItem)
             {
-                if (_logStdOut) {
+                if (_logStdOut)
+                {
                     fflush(stdout);
                 }
-                if (_logStdErr) {
+                if (_logStdErr)
+                {
                     fflush(stderr);
                 }
             }
@@ -238,7 +241,7 @@ void LoggerThread::immediate(std::chrono::system_clock::time_point timestamp,
         formatTo(stdout, localTime, logLevel, threadId, message);
         fflush(stdout);
     }
-    if (_logStdErr && !std::strcmp(logLevel, "ERROR")) 
+    if (_logStdErr && !std::strcmp(logLevel, "ERROR"))
     {
         formatTo(stderr, localTime, logLevel, threadId, message);
         fflush(stderr);

--- a/test/integration/FFTanalysis.cpp
+++ b/test/integration/FFTanalysis.cpp
@@ -99,7 +99,7 @@ void analyzeRecording(const std::vector<int16_t>& recording,
         for (size_t i = 0; i < frequencies[threadId].size() && i < 50; ++i)
         {
             if (std::find_if(frequencyPeaks.begin(), frequencyPeaks.end(), [&](double f) {
-                    return std::abs(f - frequencies[threadId][i]) < 90;
+                    return std::abs(f - frequencies[threadId][i]) < f * 0.1;
                 }) == frequencyPeaks.end())
             {
                 logger::debug("added new freq %.3f", logId, frequencies[threadId][i]);


### PR DESCRIPTION
When integration test runs in real time, there can be time compression of audio going into mixed output. This creates sibling frequencies with +5%Hz. This makes tests flaky as more frequencies than expected may appear in the FFT.
This fix prunes such artifacts so tests are more reliable when mixed output is produced.

There was also a data race in LoggerThread constructor vs run. If the flag was not cleared by constructor before run tests it, both threads will re-open log file at the same time. Now the log file is opened in run before log processing loop starts.