### PR TITLE
UT stabilization

### DIFF
--- a/httpd/Request.h
+++ b/httpd/Request.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
-#include <string>
+#include <cstring>
 #include <unordered_map>
 
 namespace httpd
@@ -33,27 +33,27 @@ namespace
 {
 Method methodFromString(const char* method)
 {
-    if (strncmp(method, "GET", 3) == 0)
+    if (std::strncmp(method, "GET", 3) == 0)
     {
         return Method::GET;
     }
-    else if (strncmp(method, "POST", 4) == 0)
+    else if (std::strncmp(method, "POST", 4) == 0)
     {
         return Method::POST;
     }
-    else if (strncmp(method, "DELETE", 6) == 0)
+    else if (std::strncmp(method, "DELETE", 6) == 0)
     {
         return Method::DELETE;
     }
-    else if (strncmp(method, "PATCH", 5) == 0)
+    else if (std::strncmp(method, "PATCH", 5) == 0)
     {
         return Method::PATCH;
     }
-    else if (strncmp(method, "OPTIONS", 7) == 0)
+    else if (std::strncmp(method, "OPTIONS", 7) == 0)
     {
         return Method::OPTIONS;
     }
-    else if (strncmp(method, "PUT", 3) == 0)
+    else if (std::strncmp(method, "PUT", 3) == 0)
     {
         return Method::PUT;
     }

--- a/test/integration/emulator/FakeUdpEndpoint.cpp
+++ b/test/integration/emulator/FakeUdpEndpoint.cpp
@@ -257,6 +257,7 @@ bool FakeUdpEndpoint::openPort(uint16_t port)
     }
 
     _localPort.setPort(port);
+    logger::info("adding %s to network", "FakeUdpEndpoint", _localPort.toString().c_str());
     _network->addLocal(this);
     _state = Endpoint::State::CREATED;
     return true;
@@ -341,10 +342,6 @@ void FakeUdpEndpoint::onReceive(fakenet::Protocol protocol,
 
 bool FakeUdpEndpoint::hasIp(const transport::SocketAddress& target)
 {
-    if (_state != State::CONNECTED)
-    {
-        return false;
-    }
     return target == _localPort;
 }
 

--- a/test/transport/JitterTest.cpp
+++ b/test/transport/JitterTest.cpp
@@ -168,8 +168,8 @@ TEST(Welford, normal)
                 sqrt(w2.getVariance()));
         }
     }
-    EXPECT_NEAR(w2.getMean(), 500.0, 20.0);
-    EXPECT_NEAR(w2.getVariance(), 100.0 * 100, 2500.0);
+    EXPECT_NEAR(w2.getMean(), 500.0, 25.0);
+    EXPECT_NEAR(w2.getVariance(), 100.0 * 100, 2900.0);
 }
 
 class JitterBufferTest : public ::testing::Test

--- a/utils/Span.h
+++ b/utils/Span.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <iterator>
 #include <type_traits>
 namespace utils


### PR DESCRIPTION
Stabilization of two falky unit tests.
* Adjustment of expectation in welford test as it sometimes has wider standard deviation.
* Fix in FakeUdpEndpoint to allow packets to queue up on socket port as they also would on a real socket. This fixes problem with random 1s delay in DTLS connection due to loss of first DTLS client hello.