### PR TITLE
Add production Docker image and compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Keep the build context small and reproducible.
+# NOTE: .git is intentionally NOT ignored — version/CheckGit.cmake needs it
+# to stamp git_version.h during the build.
+
+# In-source CMake artifacts (README documents running `cmake .` in-tree)
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+build/
+out/
+*.o
+*.a
+*.so
+*.so.*
+
+# Prebuilt binaries / test executables
+smb
+UnitTest
+UnitTest2
+LoadTest
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store
+*.log
+_bwelogs/
+
+# CI/agent state
+.omc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,136 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage production build for the Symphony Media Bridge (SMB).
+#
+#   Stage 1 (builder): reproduces the docker/ubuntu-jammy build recipe
+#                      (clang/llvm 12 + libc++, openssl 3.4, libsrtp 2.6,
+#                      libmicrohttpd, opus) and compiles a Release `smb` binary.
+#   Stage 2 (runtime): a slim ubuntu:jammy image carrying only the `smb`
+#                      binary and the shared libraries it needs at run time.
+#
+# Build:   docker build -t smb:latest .
+# Run:     see docker-compose.yml or docker/CONTAINER.md
+#
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# ---------------------------------------------------------------------------
+FROM ubuntu:jammy AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update --fix-missing && apt-get -y upgrade \
+    && apt-get -y install git wget cmake xz-utils libz-dev build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# openssl 3.4.0 (installed to /usr/local/lib64)
+RUN cd /tmp && wget -q https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz \
+    && tar xfz openssl-3.4.0.tar.gz && rm openssl-3.4.0.tar.gz \
+    && cd openssl-3.4.0 && ./config && make -j"$(nproc)" && make install_sw \
+    && rm -rf /tmp/openssl-3.4.0
+
+# cmake 3.30 (jammy's apt cmake is too old for the build)
+RUN apt-get -y remove cmake || true \
+    && cd /tmp && wget -q https://cmake.org/files/v3.30/cmake-3.30.0.tar.gz && tar xfz cmake-3.30.0.tar.gz \
+    && cd cmake-3.30.0 && ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install \
+    && rm -rf /tmp/cmake-3.30.0 /tmp/cmake-3.30.0.tar.gz
+
+# libsrtp 2.6.0 (statically linked into smb; no runtime .so needed)
+RUN cd /tmp && git clone --depth 1 --branch v2.6.0 https://github.com/cisco/libsrtp \
+    && cd libsrtp \
+    && PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig ./configure --enable-openssl \
+    && make -j"$(nproc)" && make install \
+    && rm -rf /tmp/libsrtp
+
+# clang/llvm 12 + libc++ (SMB only compiles with clang + libc++)
+RUN cd /tmp \
+    && wget -q -O clang.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
+    && tar xf clang.tar.xz \
+    && cd clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-* \
+    && cp -rn * /usr/local \
+    && ln -sf /usr/local/bin/lld /usr/local/bin/ld \
+    && cd /tmp && rm -rf clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-* clang.tar.xz
+
+# libmicrohttpd 0.9.73
+RUN cd /tmp && wget -q https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.73.tar.gz \
+    && tar xfz libmicrohttpd-0.9.73.tar.gz && rm libmicrohttpd-0.9.73.tar.gz \
+    && cd libmicrohttpd-0.9.73 && ./configure --disable-https && make -j"$(nproc)" && make install \
+    && rm -rf /tmp/libmicrohttpd-0.9.73
+
+# opus 1.3.1
+RUN cd /tmp && wget -q https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz \
+    && tar xfz opus-1.3.1.tar.gz && rm opus-1.3.1.tar.gz \
+    && cd opus-1.3.1 && ./configure && make -j"$(nproc)" && make install \
+    && rm -rf /tmp/opus-1.3.1
+
+RUN ldconfig
+
+# --- compile SMB (out-of-source Release build) ---
+WORKDIR /src
+COPY . /src
+# .git is required for version/CheckGit.cmake to stamp git_version.h
+RUN git config --global --add safe.directory /src
+
+RUN cmake -S /src -B /src/build \
+        -DENABLE_LEGACY_API=ON \
+        -DENABLE_LIBATOMIC=ON \
+        -D_CMAKE_TOOLCHAIN_PREFIX=llvm- \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=/usr/local/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++ \
+        -G "Unix Makefiles" \
+    && cmake --build /src/build --target smb -j"$(nproc)"
+
+# Gather the exact runtime shared libraries (mirrors docker/ubuntu-jammy/buildscript.sh)
+RUN mkdir -p /out/libs \
+    && cp /src/build/smb /out/smb \
+    && cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 /out/libs/ \
+    && cp /usr/local/lib/libc++.so.1            /out/libs/ \
+    && cp /usr/local/lib/libc++abi.so.1         /out/libs/ \
+    && cp /usr/local/lib64/libssl.so.3          /out/libs/ \
+    && cp /usr/local/lib64/libcrypto.so.3       /out/libs/ \
+    && cp /usr/local/lib/libmicrohttpd.so.12    /out/libs/ \
+    && cp /usr/local/lib/libopus.so.0           /out/libs/
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+FROM ubuntu:jammy AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# curl: HEALTHCHECK probe. ca-certificates: handy if the deployment fetches
+# anything. Kept minimal.
+RUN apt-get -y update --fix-missing \
+    && apt-get -y install --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Runtime shared libraries
+COPY --from=builder /out/libs/ /usr/local/lib/
+RUN ldconfig
+
+# Application binary + default config
+COPY --from=builder /out/smb /opt/smb/smb
+COPY docker/runtime-config.json /etc/smb/config.json
+
+# Real-time thread scheduling (SCHED_FIFO): SMB requests it at startup. To
+# enable it, start the container with `--cap-add=SYS_NICE` (see CONTAINER.md).
+# The capability is NOT baked onto the binary with setcap on purpose — a file
+# whose permitted caps fall outside the container's bounding set fails to exec
+# at all, so that would make the image refuse to start without the cap. Without
+# SYS_NICE, SMB logs a warning and runs at normal priority.
+
+# Non-root runtime user
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin smb
+USER smb
+
+# HTTP API. Media/ICE ports are UDP and depend on the config; see CONTAINER.md.
+EXPOSE 8080/tcp
+EXPOSE 10000/udp
+EXPOSE 10500/udp
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:8080/stats"]
+
+# exec form so SIGINT/SIGTERM reach smb directly (it shuts down cleanly on SIGINT)
+ENTRYPOINT ["/opt/smb/smb"]
+CMD ["/etc/smb/config.json"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# Symphony Media Bridge — container orchestration.
+#
+# SMB is a WebRTC SFU: it advertises its own reachable IP in ICE candidates and
+# carries media over UDP. Host networking is the recommended, best-performing
+# topology for a media server. See docker/CONTAINER.md for the bridged
+# (published-ports) alternative and for setting the public IP.
+
+services:
+  smb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: smb:latest
+    container_name: smb
+
+    # Recommended: host networking. The container shares the host network
+    # stack, so all API/ICE/media ports are reachable with no port mapping and
+    # ICE candidates carry the host's real addresses.
+    network_mode: host
+
+    # Real-time thread scheduling (SCHED_FIFO). SMB runs fine without it (logs a
+    # warning, uses normal priority). NOTE: the default non-root user cannot use
+    # this capability from cap_add alone — to actually get real-time priority,
+    # also run as root by uncommenting `user: "0:0"` below. See CONTAINER.md.
+    cap_add:
+      - SYS_NICE
+    # user: "0:0"
+
+    # Mount your own config to override the baked-in default. At minimum set
+    # "ice.publicIpv4" to the IP remote clients use to reach this host.
+    volumes:
+      - ./docker/runtime-config.json:/etc/smb/config.json:ro
+
+    restart: unless-stopped
+
+    # ---------------------------------------------------------------------
+    # Bridged alternative (comment out `network_mode: host` above to use it).
+    # Media is collapsed onto the single ICE port thanks to ice.sharedPorts=1,
+    # so only a few ports need publishing. You MUST set "ice.publicIpv4" in the
+    # config to the host's public IP for ICE to work through the NAT.
+    # ---------------------------------------------------------------------
+    # ports:
+    #   - "8080:8080/tcp"      # HTTP API
+    #   - "10000:10000/udp"    # ICE / media (shared single port)
+    #   - "10500:10500/udp"    # recording

--- a/docker/CONTAINER.md
+++ b/docker/CONTAINER.md
@@ -1,0 +1,105 @@
+# Running Symphony Media Bridge in a container
+
+This directory's per-distro folders (`ubuntu-jammy`, `el8`, …) are **build/CI**
+images. For a deployable **runtime** image use the multi-stage `Dockerfile` in
+the repository root, which compiles a Release `smb` and ships only the binary
+plus the shared libraries it needs.
+
+## Build
+
+```bash
+docker build -t smb:latest .
+```
+
+The build reproduces the `docker/ubuntu-jammy` toolchain (clang/llvm 12 +
+libc++, OpenSSL 3.4, libsrtp 2.6, libmicrohttpd, opus). It is a from-source
+build and takes a while on first run. `.git` is part of the build context
+because `version/CheckGit.cmake` stamps the git hash into the binary.
+
+## Run
+
+### Recommended: host networking
+
+SMB is a WebRTC **SFU**. It advertises its own reachable IP in ICE candidates
+and moves media over UDP. Host networking avoids Docker NAT entirely and gives
+the best media performance:
+
+```bash
+docker run -d --name smb \
+  --network host \
+  --cap-add SYS_NICE \
+  -v "$PWD/docker/runtime-config.json:/etc/smb/config.json:ro" \
+  smb:latest
+```
+
+or simply:
+
+```bash
+docker compose up -d --build
+```
+
+### Bridged (published ports)
+
+If you cannot use host networking, the default config sets
+`ice.sharedPorts = 1`, so all media is collapsed onto the single ICE UDP port
+and only a handful of ports need publishing:
+
+```bash
+docker run -d --name smb \
+  --cap-add SYS_NICE \
+  -p 8080:8080/tcp \
+  -p 10000:10000/udp \
+  -p 10500:10500/udp \
+  -v "$PWD/docker/runtime-config.json:/etc/smb/config.json:ro" \
+  smb:latest
+```
+
+In this mode you **must** set `ice.publicIpv4` (see below) — behind the Docker
+bridge SMB otherwise advertises an unreachable container-internal address.
+
+## Configuration
+
+The image bakes in `docker/runtime-config.json` at `/etc/smb/config.json`.
+Override it by mounting your own file at that path.
+
+| Key | Purpose |
+| --- | --- |
+| `address` | HTTP API **bind** address. Must be `0.0.0.0` in a container — the code default is `127.0.0.1`, which is loopback-only and unreachable through a port map. |
+| `port` | HTTP API port (TCP, default 8080) |
+| `ice.singlePort` | Shared ICE/media UDP port (default 10000) |
+| `ice.sharedPorts` | `1` = all media on the single port (keeps the port surface small) |
+| `ice.publicIpv4` | **Set this** to the IP clients use to reach the host, unless on AWS with `ice.useAwsInfo` |
+| `recording.singlePort` | Recording UDP port (default 10500) |
+| `logStdOut` | `true` so logs go to the container's stdout |
+
+On AWS EC2 you can instead set `"ice.useAwsInfo": true` to auto-discover the
+public IP from instance metadata.
+
+## Notes
+
+- **CAP_SYS_NICE (real-time priority)** — SMB requests `SCHED_FIFO` thread
+  priority at startup. Without permission it logs
+  `Failed to set thread priority to real-time ... Not permitted` and runs fine
+  at normal priority; it is a performance optimization, not a requirement.
+  To grant it you need **all** of:
+    1. a **rootful** container runtime (Docker, or rootful podman) — under
+       *rootless* podman the host kernel denies `SCHED_FIFO` regardless of
+       caps, because container-root is an unprivileged user in a user
+       namespace (verify with `docker info | grep rootless`);
+    2. `--cap-add=SYS_NICE` (bypasses the `RLIMIT_RTPRIO` limit, which defaults
+       to 0 in containers); on some setups also pass `--ulimit rtprio=99`;
+    3. the process running as root in the container (`--user 0`), since a
+       non-root process does not get the capability into its effective set
+       without ambient caps.
+  The capability is intentionally **not** baked onto the binary with `setcap`:
+  a file whose permitted caps fall outside the container's bounding set fails to
+  `exec` at all, which would make the image refuse to start unless the cap were
+  always present.
+- **Non-root by default** — the process runs as the unprivileged `smb` user
+  (uid 999). This is the secure default; enabling real-time priority (above)
+  means giving that up.
+- **Signals** — `smb` is PID 1 via the exec-form entrypoint and shuts down
+  cleanly on `SIGINT`/`SIGTERM` (`docker stop`).
+- **Health** — `HEALTHCHECK` polls `GET /stats` on the API port. Note: podman
+  builds an OCI image by default and prints a warning that it ignores
+  `HEALTHCHECK`; it works under Docker, or build with `--format docker`.

--- a/docker/runtime-config.json
+++ b/docker/runtime-config.json
@@ -1,0 +1,12 @@
+{
+  "logStdOut": true,
+  "logStdErr": true,
+  "logLevel": "INFO",
+  "address": "0.0.0.0",
+  "port": 8080,
+  "ice.singlePort": 10000,
+  "ice.sharedPorts": 1,
+  "recording.singlePort": 10500,
+  "ice.publicIpv4": "",
+  "ice.enableIpv6": false
+}


### PR DESCRIPTION
Multi-stage Dockerfile that reproduces the docker/ubuntu-jammy toolchain (clang/llvm 12 + libc++, OpenSSL 3.4, libsrtp 2.6, libmicrohttpd, opus) in a builder stage and ships a slim ubuntu:jammy runtime carrying only the Release `smb` binary and its runtime shared libraries.

The per-distro folders under docker/ are build/CI images; this adds a deployable runtime image alongside them.

- docker-compose.yml defaults to host networking (SFU advertises its own reachable IP in ICE candidates and carries media over UDP), with a bridged published-ports alternative documented inline.
- docker/runtime-config.json binds the HTTP API to 0.0.0.0 and collapses media onto a single shared ICE port to keep the port surface small.
- Runs non-root by default; CAP_SYS_NICE for SCHED_FIFO is opt-in and deliberately not baked on with setcap, since permitted caps outside the container bounding set make the binary fail to exec at all.
- docker/CONTAINER.md documents build, both network topologies, the config keys, and the real-time priority requirements.